### PR TITLE
Fix flag apply order for builds.

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -43,9 +43,10 @@ class BuildGenerator : ProjectGenerator {
 	{
 		auto cwd = Path(getcwd());
 
+		// force halt on warning by default - must be before using config to allow overriding
+		buildsettings.addDFlags(["-w"/*, "-property"*/]);
 		auto buildsettings = settings.buildSettings;
 		m_project.addBuildSettings(buildsettings, settings.platform, settings.config);
-		buildsettings.addDFlags(["-w"/*, "-property"*/]);
 		string dflags = environment.get("DFLAGS");
 		if( dflags.length ){
 			settings.buildType = "$DFLAGS";


### PR DESCRIPTION
Apply -w flag to build before flags from properties.json are applied to allow overriding that setting. It's not always possible to fix upstream warnings, so the option to disable is useful.
