### PR TITLE
Requested by Nick Sabalausky: App dependencies (partial patch)

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -132,6 +132,7 @@ struct BuildSettings {
 	string[] copyFiles;
 	string[] versions;
 	string[] importPaths;
+	string[] binPaths; // Where to search for executables (for the following commands environment)
 	string[] stringImportPaths;
 	string[] preGenerateCommands;
 	string[] postGenerateCommands;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -22,7 +22,7 @@ import dub.project;
 import std.exception;
 import std.file;
 import std.string;
-
+import std.array;
 
 /**
 	Common interface for project generators/builders.
@@ -143,5 +143,14 @@ void runBuildCommands(string[] commands, in BuildSettings build_settings)
 	env["LIBS"] = join(cast(string[])build_settings.libs," ");
 	env["IMPORT_PATHS"] = join(cast(string[])build_settings.importPaths," ");
 	env["STRING_IMPORT_PATHS"] = join(cast(string[])build_settings.stringImportPaths," ");
+	/// FIXME , this should be dependent on the target
+	version(Posix) string sep=":";
+	else version(Windows) string sep=";";
+	else static assert(0, "Unsupported platform!");
+	if(!env["PATH"].empty && !build_settings.binPaths.empty)
+		env["PATH"] ~= sep;
+	env["PATH"] ~= join(cast(string[])build_settings.binPaths, sep);
+	writeln("binPaths: ", build_settings.binPaths);
+	writeln("Path: ", env["PATH"]);
 	runCommands(commands, env);
 }

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -208,7 +208,8 @@ class Package {
 	const {
 		foreach(ref conf; m_info.configurations){
 			if( !conf.matchesPlatform(platform) ) continue;
-			if( !is_main_package && conf.buildSettings.targetType == TargetType.executable ) continue;
+		// FIXME Is this really necessary? What about application dependencies?
+		//	if( !is_main_package && conf.buildSettings.targetType == TargetType.executable ) continue;
 			return conf.name;
 		}
 		throw new Exception(format("Found no suitable configuration for %s on this platform.", this.name));

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -246,6 +246,9 @@ class Project {
 				dst.targetPath = psettings.targetPath;
 				dst.targetName = psettings.targetName;
 			}
+			else if(psettings.targetType == TargetType.executable) {
+				dst.binPaths ~= (pkg.path~PathEntry(psettings.targetPath)).toNativeString();
+			}
 		}
 
 		// add version identifiers for available packages


### PR DESCRIPTION
Add targetPath of application dependencies to binPaths of current build settings.

With this patch targetPaths of application dependencies will be added to the PATH variable for the hook commands.

Currently dub ignores dependencies with application configuration, I commented that out so this patch works. Are there any reasons for this other than that application dependencies are not implemented yet?
