### PR TITLE
Fix resolving .lib dependencies on windows.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -126,8 +126,7 @@ void resolveLibs(ref BuildSettings settings)
 	} catch( Exception e ){
 		logDiagnostic("pkg-config failed: %s", e.msg);
 		logDiagnostic("Falling back to direct -lxyz flags.");
-		version(Windows) settings.addSourceFiles(settings.libs.map!(l => l~".lib")().array());
-		else settings.addLFlags(settings.libs.map!(l => "-l"~l)().array());
+		settings.addLFlags(settings.libs.map!(l => "-l"~l)().array());
 	}
 	settings.libs = null;
 }


### PR DESCRIPTION
This fixes building vibe.d dependent projects on windows with dmd 2.063.2
