### PR TITLE
Fixing redundant package.json in visuald-combined generated projects when using sub-packages

### DIFF
--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -212,7 +212,7 @@ EndGlobal");
 					string[] prjFiles;
 
 					// Avoid multiples package.json when using sub-packages.
-					// Only add the package info file if no mother module/sub-module from the same base package
+					// Only add the package info file if no other package/sub-package from the same base package
 					// has been seen yet.
 					{
 						const(Package) base = prj.basePackage();


### PR DESCRIPTION
Let's say I have a package.json which define two sub-packages:

mypackage:foo and mypackage:bar

As the two packages have the same package.json, it will be included twice in visuald-combined generated projects.

This pull request checks that when adding package files in topological order that package.json is only added at the first time we see a base package.
