### PR TITLE
fix gdc/ldc build options

### DIFF
--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -67,7 +67,7 @@ class GdcCompiler : Compiler {
 	{
 		enforceBuildRequirements(settings);
 
-		if (!fields & BuildSetting.options) {
+		if (!(fields & BuildSetting.options)) {
 			foreach (t; s_options)
 				if (settings.options & t[0])
 					settings.addDFlags(t[1]);

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -67,7 +67,7 @@ class LdcCompiler : Compiler {
 	{
 		enforceBuildRequirements(settings);
 
-		if (!fields & BuildSetting.options) {
+		if (!(fields & BuildSetting.options)) {
 			foreach (t; s_options)
 				if (settings.options & t[0])
 					settings.addDFlags(t[1]);


### PR DESCRIPTION
With --compiler=gdc or --compiler=ldc2 the build options are not passed to the compiler.  This can be observed when building with the -v option.
