### PR TITLE
Added quoting of import paths

### DIFF
--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -311,7 +311,7 @@ EndGlobal");
 			{
 				auto settings = getSettings!setting();
 				auto ret = new string[settings.length];
-				foreach (i; 0 .. settings.length) ret[i] = (Path(settings[i]).relativeTo(project_file_dir)).toNativeString();
+				foreach (i; 0 .. settings.length) ret[i] = '"' ~ (Path(settings[i]).relativeTo(project_file_dir)).toNativeString() ~ '"';
 				return ret;
 			}
 			


### PR DESCRIPTION
This fixes generation of import paths, otherwise VisualD's build will not work when paths contain spaces.

Example, before:

``` xml
<imppath>C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\vibe-d-0.7.18\source C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\libevent-master C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\openssl-master</imppath>
```

after:

``` xml
<imppath>"C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\vibe-d-0.7.18\source" "C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\libevent-master" "C:\Documents and Settings\Piotr\Dane aplikacji\dub\packages\openssl-master"</imppath>
```
