### PR TITLE
Fix auto-generated main not importing tested when using tested for running tests.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -286,6 +286,7 @@ class Dub {
 						shared static this() {
 							version (Have_tested) {
 								import core.runtime;
+								import tested;
 								Runtime.moduleUnitTester = () => true;
 								//runUnitTests!app(new JsonTestResultWriter("results.json"));
 								assert(runUnitTests!test_main(new ConsoleTestResultWriter), "Unit tests failed.");


### PR DESCRIPTION
Currently including tested as a dependency causes test_main to try and use tested for running tests, but that fails to compile as it does not import tested, unless a different module publicly imports tested.
