### PR TITLE
Fix assertion errors when the HOME variable is a relative path.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -73,6 +73,8 @@ class Dub {
 		} else version(Posix){
 			m_systemDubPath = Path("/var/lib/dub/");
 			m_userDubPath = Path(environment.get("HOME")) ~ ".dub/";
+			if(!m_userDubPath.absolute)
+				m_userDubPath = Path(getcwd()) ~ m_userDubPath;
 			m_tempPath = Path("/tmp");
 		}
 		


### PR DESCRIPTION
This pull makes it so if HOME is relative, it's made absolute relative to the working directory.

This is useful because often things like CI servers (in this case, Bamboo) will pass the HOME variable as being the build folder so builds don't leak to where other projects would if they use HOME for determining paths (such as one of the locations dub stores local packages).

Fixes issue #189.
