### PR TITLE
toNativeString() now returns "." on Windows for relative empty paths whe...

### DIFF
--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -100,7 +100,7 @@ struct Path {
 		if (m_nodes.empty) {
 			version(Windows) {
 				assert(!absolute, "Empty absolute path detected.");
-				return ".\\";
+				return m_endsWithSlash ? ".\\" : ".";
 			} else return absolute ? "/" : "./";
 		}
 


### PR DESCRIPTION
The ".\" path was still generated in VisualD projects, this shall fix https://github.com/rejectedsoftware/dub/issues/195 for good.
