### PR TITLE
Attempt at fixing #201

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -197,6 +197,9 @@ class Package {
 		// special support for DMD style flags
 		getCompiler("dmd").extractBuildOptions(ret);
 
+        if (platform.architecture == ["x86_64"])
+            ret.addDFlags("-m64");
+
 		return ret;
 	}
 


### PR DESCRIPTION
As I see it the problem is with dub.package_.getBuildSettings() not looking at platform.architecture, this makes the arch. override without effect.
A bit ugly.
