### PR TITLE
block on ddox child process

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -532,8 +532,9 @@ class Dub {
 		runCommands(commands);
 
 		if (run) {
-			spawnProcess([dub_path~"ddox", "serve-html", "--navigation-type=ModuleTree", "docs.json", "--web-file-dir="~dub_path~"public"]);
+			auto proc = spawnProcess([dub_path~"ddox", "serve-html", "--navigation-type=ModuleTree", "docs.json", "--web-file-dir="~dub_path~"public"]);
 			browse("http://127.0.0.1:8080/");
+			wait(proc);
 		}
 	}
 


### PR DESCRIPTION
- fixes SIGINT (ctrl+c) for 'dub -b ddox'
