### PR TITLE
Set default compiler to be the same that built dub

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -17,6 +17,7 @@ import dub.internal.vibecompat.inet.url;
 import dub.package_;
 import dub.packagemanager;
 import dub.packagesupplier;
+import dub.platform : determineCompiler;
 import dub.project;
 import dub.internal.utils : getDUBVersion;
 
@@ -322,7 +323,7 @@ abstract class PackageBuildCommand : Command {
 	protected {
 		string m_build_type;
 		string m_build_config;
-		string m_compiler_name = "dmd";
+		string m_compiler_name = .determineCompiler();
 		string m_arch;
 		string[] m_debug_versions;
 		Compiler m_compiler;


### PR DESCRIPTION
Raising this PR as a bug - there are likely other things that need to change too, such as the help message.
`"  dmd (default), gdc, ldc, gdmd, ldmd"`

It would be nice if the default compiler dub used was the same that built the application.  So for me, I don't need to specify --compiler=gdc explicitly every time.
