### PR TITLE
fix issue with missing dub.selections.json

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -551,8 +551,9 @@ class Project {
 		if (m_selections.hasSelectedVersion(m_rootPackage.basePackage.name))
 			m_selections.deselectVersion(m_rootPackage.basePackage.name);
 
-		if (m_selections.dirty)
-			m_selections.save(m_rootPackage.path ~ SelectedVersions.defaultFile);
+		auto path = m_rootPackage.path ~ SelectedVersions.defaultFile;
+		if (m_selections.dirty || !existsFile(path))
+			m_selections.save(path);
 	}
 
 	private bool needsUpToDateCheck(Package pack) {


### PR DESCRIPTION
- the dub.selections.json file was no longer generated
  for packages without dependencies
- this lead to an error when checking for the timestamp
  of the selections file later on
- an alternative fix would be to ignore the timestamp
  when no selections file exists
