### PR TITLE
Fix isUpToDate for sub-packages

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -322,7 +322,8 @@ class BuildGenerator : ProjectGenerator {
 		allfiles ~= buildsettings.importFiles;
 		allfiles ~= buildsettings.stringImportFiles;
 		// TODO: add library files
-		foreach (p; packages) allfiles ~= p.packageInfoFile.toNativeString();
+		foreach (p; packages)
+			allfiles ~= (p.packageInfoFile != Path.init ? p : p.basePackage).packageInfoFile.toNativeString();
 		foreach (f; additional_dep_files) allfiles ~= f.toNativeString();
 		if (main_pack is m_project.rootPackage)
 			allfiles ~= (main_pack.path ~ SelectedVersions.defaultFile).toNativeString();


### PR DESCRIPTION
`packageInfoFile` of sub-packages are not used(it contains just `Path.init`), but `BuildGenerator.isUpToDate` checks it.
I changed `BuildGenerator.isUpToDate` to look at basePackage's one.

This PR fixes problem like this:

```
...
File '.' modified, need rebuild.
Building gtk-d:gtkd ~Gtk2 configuration "library", build type debug.
...
```

For sub-packages, everytime this message was printed and made unnecessary builds.
It occured because `Path.init` means '.'
