### PR TITLE
On-demand Compiler instantiation + fix computeBuildID for --compiler=/my/path

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -372,7 +372,7 @@ abstract class PackageBuildCommand : Command {
 
 	protected void setupPackage(Dub dub, string package_name)
 	{
-		m_compiler = getCompiler(m_compilerName);
+		m_compiler = Compiler.factory(m_compilerName);
 		m_buildPlatform = m_compiler.determinePlatform(m_buildSettings, m_compilerName, m_arch);
 		m_buildSettings.addDebugVersions(m_debugVersions);
 
@@ -671,7 +671,7 @@ class TestCommand : PackageBuildCommand {
 
 		GeneratorSettings settings;
 		settings.platform = m_buildPlatform;
-		settings.compiler = getCompiler(m_buildPlatform.compilerBinary);
+		settings.compiler = Compiler.factory(m_buildPlatform.compilerBinary);
 		settings.buildType = m_buildType;
 		settings.buildMode = m_buildMode;
 		settings.buildSettings = m_buildSettings;

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -48,7 +48,10 @@ class DmdCompiler : Compiler {
 		tuple(BuildOptions.property, ["-property"]),
 	];
 
-	@property string name() const { return "dmd"; }
+	override @property string name() const { return "dmd"; }
+	override protected @property string binary() const { return m_binary; }
+	private immutable string m_binary;
+	this(string bin) { this.m_binary = bin; }
 
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{
@@ -137,8 +140,10 @@ class DmdCompiler : Compiler {
 		assert(fields & BuildSetting.copyFiles);
 	}
 
-	void extractBuildOptions(ref BuildSettings settings) const
-	{
+	void extractBuildOptions(ref BuildSettings settings) const {
+		DmdCompiler.extractBuildOptions_(settings);
+	}
+	static void extractBuildOptions_(ref BuildSettings settings) {
 		Appender!(string[]) newflags;
 		next_flag: foreach (f; settings.dflags) {
 			foreach (t; s_options)

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -49,6 +49,9 @@ class GdcCompiler : Compiler {
 	];
 
 	@property string name() const { return "gdc"; }
+	override protected @property string binary() const { return m_binary; }
+	private immutable string m_binary;
+	this(string bin) { this.m_binary = bin; }
 
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -49,6 +49,9 @@ class LdcCompiler : Compiler {
 	];
 
 	@property string name() const { return "ldc"; }
+	override protected @property string binary() const { return m_binary; }
+	private immutable string m_binary;
+	this(string bin) { this.m_binary = bin; }
 
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -609,7 +609,7 @@ class Dub {
 
 			GeneratorSettings settings;
 			settings.config = "application";
-			settings.compiler = getCompiler(compiler_binary);
+			settings.compiler = Compiler.factory(compiler_binary);
 			settings.platform = settings.compiler.determinePlatform(settings.buildSettings, compiler_binary);
 			settings.buildType = "debug";
 			ddox_dub.generateProject("build", settings);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -297,7 +297,7 @@ class BuildGenerator : ProjectGenerator {
 		return format("%s-%s-%s-%s-%s-%s", config, settings.buildType,
 			settings.platform.platform.join("."),
 			settings.platform.architecture.join("."),
-			settings.platform.compilerBinary, hashstr);
+			settings.platform.compiler, hashstr);
 	}
 
 	private void copyTargetFile(Path build_path, BuildSettings buildsettings, BuildPlatform platform)

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -274,7 +274,7 @@ class Package {
 		if( ret.targetName.empty ) ret.targetName = this.name.replace(":", "_");
 
 		// special support for DMD style flags
-		getCompiler("dmd").extractBuildOptions(ret);
+		dub.compilers.dmd.DmdCompiler.extractBuildOptions_(ret);
 
 		return ret;
 	}
@@ -291,7 +291,7 @@ class Package {
 		if (ret.targetName.empty) ret.targetName = this.name.replace(":", "_");
 
 		// special support for DMD style flags
-		getCompiler("dmd").extractBuildOptions(ret);
+		dub.compilers.dmd.DmdCompiler.extractBuildOptions_(ret);
 
 		return ret;
 	}


### PR DESCRIPTION
Just a small refactoring.
This moves Compiler to a factory, and avoid instantiating the 3 of them when they are not needed.
Also, it fixes a small bug when you used, eg `dub --compiler=/usr/bin/gdc`, the cache directory was `.dub/build/application-debug-linux.posix-x86_64-/usr/bin/gdc-17DEAD7B0A2CF7221FDFDAB7B4508576/`.
This was a potential security threat due to relatives path.
