### PR TITLE
Invoke the binary for linking, not the name

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -189,7 +189,7 @@ class DmdCompiler : Compiler {
 	{
 		import std.string;
 		auto tpath = Path(settings.targetPath) ~ getTargetFileName(settings, platform);
-		auto args = [platform.compiler, "-of"~tpath.toNativeString()];
+		auto args = [platform.compilerBinary, "-of"~tpath.toNativeString()];
 		args ~= objects;
 		args ~= settings.sourceFiles;
 		version(linux) args ~= "-L--no-as-needed"; // avoids linker errors due to libraries being speficied in the wrong order by DMD

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -197,7 +197,7 @@ class GdcCompiler : Compiler {
 			assert(tpath !is null, "setTarget should be called before invoke");
 			args = [ "ar", "rcs", tpath ] ~ objects;
 		} else {
-			args = platform.compiler ~ objects ~ settings.sourceFiles ~ settings.lflags ~ settings.dflags.filter!(f => isLinkageFlag(f)).array;
+			args = platform.compilerBinary ~ objects ~ settings.sourceFiles ~ settings.lflags ~ settings.dflags.filter!(f => isLinkageFlag(f)).array;
 			version(linux) args ~= "-L--no-as-needed"; // avoids linker errors due to libraries being speficied in the wrong order by DMD
 		}
 		logDiagnostic("%s", args.join(" "));


### PR DESCRIPTION
/// See_Also: #372 to prevent this kind of mistakes.
