### PR TITLE
Various small fixes

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -377,22 +377,18 @@ Path generatePlatformProbeFile()
 	fil.write(q{
 		template toString(int v) { enum toString = v.stringof; }
 
-		void main()
-		{
-			pragma(msg, `{`);
-			pragma(msg,`  "compiler": "`~ determineCompiler() ~ `",`);
-			pragma(msg, `  "frontendVersion": ` ~ toString!__VERSION__ ~ `,`);
-			pragma(msg, `  "compilerVendor": "` ~ __VENDOR__ ~ `",`);
-			pragma(msg, `  "platform": [`);
-			pragma(msg, `    ` ~ determinePlatform());
-			pragma(msg, `  ],`);
-			pragma(msg, `  "architecture": [`);
-			pragma(msg, `    ` ~ determineArchitecture());
-			pragma(msg, `   ],`);
-			pragma(msg, `}`);
-		}
-
-
+		pragma(msg, `{`);
+		pragma(msg,`  "compiler": "`~ determineCompiler() ~ `",`);
+		pragma(msg, `  "frontendVersion": ` ~ toString!__VERSION__ ~ `,`);
+		pragma(msg, `  "compilerVendor": "` ~ __VENDOR__ ~ `",`);
+		pragma(msg, `  "platform": [`);
+		pragma(msg, `    ` ~ determinePlatform());
+		pragma(msg, `  ],`);
+		pragma(msg, `  "architecture": [`);
+		pragma(msg, `    ` ~ determineArchitecture());
+		pragma(msg, `   ],`);
+		pragma(msg, `}`);
+		
 		string determinePlatform()
 		{
 			string ret;

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -67,7 +67,7 @@ class GdcCompiler : Compiler {
 		}
 		settings.addDFlags(arch_flags);
 
-		auto result = executeShell(escapeShellCommand(compiler_binary ~ arch_flags ~ ["-c", fil.toNativeString()]));
+		auto result = executeShell(escapeShellCommand(compiler_binary ~ arch_flags ~ ["-c", "-o", (getTempDir()~"dub_platform_probe").toNativeString(), fil.toNativeString()]));
 		enforce(result.status == 0, format("Failed to invoke the compiler %s to determine the build platform: %s",
 			compiler_binary, result.output));
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -297,7 +297,7 @@ class BuildGenerator : ProjectGenerator {
 		return format("%s-%s-%s-%s-%s-%s", config, settings.buildType,
 			settings.platform.platform.join("."),
 			settings.platform.architecture.join("."),
-			settings.platform.compilerBinary, hashstr);
+			settings.platform.compiler, hashstr);
 	}
 
 	private void copyTargetFile(Path build_path, BuildSettings buildsettings, BuildPlatform platform)

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -81,7 +81,7 @@ string determineCompiler()
 {
 	version(DigitalMars) return "dmd";
 	else version(GNU) return "gdc";
-	else version(LDC) return "ldc";
+	else version(LDC) return "ldc2";
 	else version(SDC) return "sdc";
 	else return null;
 }


### PR DESCRIPTION
- fix computeBuildID for --compiler=/my/path;
- dub compiled with ldc tried to invoke ldc as default binary instead of ldc2;
- dmd: Don't generate anything (as you suggested in #380);
- gdc: Do not link, only generate an object;
