### PR TITLE
Prevent searching file system multiple times for package file

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -415,7 +415,7 @@ class Dub {
 	void cleanPackage(Path path)
 	{
 		logInfo("Cleaning package at %s...", path.toNativeString());
-		enforce(Package.isPackageAt(path), "No package found.", path.toNativeString());
+		enforce(!Package.findPackageFile(path).empty, "No package found.", path.toNativeString());
 
 		// TODO: clear target files and copy files
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -47,13 +47,14 @@ class Project {
 	this(PackageManager package_manager, Path project_path)
 	{
 		Package pack;
-		if (!Package.isPackageAt(project_path)) {
+		Path packageFile = Package.findPackageFile(project_path);
+		if (packageFile.empty) {
 			logWarn("There was no package description found for the application in '%s'.", project_path.toNativeString());
 			auto json = Json.emptyObject;
 			json.name = "unknown";
 			pack = new Package(json, project_path);
 		} else {
-			pack = package_manager.getOrLoadPackage(project_path);
+			pack = package_manager.getOrLoadPackage(project_path, packageFile);
 		}
 
 		this(package_manager, pack);


### PR DESCRIPTION
The file system was being queried multiple times to find the Package file, once in the `isPackageAt` function and in the Package `constructor`.  I changed `isPackageAt` to `findPackageFile` which returns the file name using the `Path struct`.  If the file was found the caller can pass the file name to the Package `constructor`.
