### PR TITLE
Updated 3 for SDL support

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -844,7 +844,7 @@ class DependencyVersionResolver : DependencyResolver!(Dependency, Dependency) {
 			auto basepack = getPackage(basename, dep);
 			if (auto sp = basepack.getSubPackage(subname, true)) {
 				return sp;
-			} else if (!basepack.exportedPackages.length) {
+			} else if (!basepack.exportedPackageCount) {
 				logDiagnostic("Sub package %s doesn't exist in %s %s.", name, basename, dep.version_);
 				return null;
 			}

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -208,9 +208,10 @@ class PackageManager {
 		{
 			int handlePackage(Package p) {
 				if (auto ret = del(p)) return ret;
-				foreach (sp; p.subPackages)
-					if (auto ret = del(sp))
-						return ret;
+				foreach (sp; p.allSubPackages)
+					if(sp.package_ !is null)
+						if (auto ret = del(sp.package_))
+							return ret;
 				return 0;
 			}
 
@@ -718,8 +719,8 @@ class PackageManager {
 		// Additionally to the internally defined subpackages, whose metadata
 		// is loaded with the main dub.json, load all externally defined
 		// packages after the package is available with all the data.
-		foreach (sub_path; pack.exportedPackages) {
-			auto path = pack.path ~ sub_path;
+		foreach (package_; pack.exportedPackages) {
+			auto path = pack.path ~ package_.referenceName;
 			if (!existsFile(path)) {
 				logError("Package %s declared a sub-package, definition file is missing: %s", pack.name, path.toNativeString());
 				continue;


### PR DESCRIPTION
Moved sub packages to `PackageInfo` and added `subPackagesImported` array in `PackageInfo` to store whether a sub package was "imported" or "inline".  This is used in the `toJson` function to know whether or not a subPackage was imported.
