### PR TITLE
buildTypes disapper from dub.json of a fetched package

### DIFF
--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -101,6 +101,7 @@ Json toJson(in ref PackageRecipe recipe)
 		Json[string] types;
 		foreach (name, settings; recipe.buildTypes)
 			types[name] = settings.toJson();
+		ret.buildTypes = types;
 	}
 	if (!recipe.ddoxFilterArgs.empty) ret["-ddoxFilterArgs"] = recipe.ddoxFilterArgs.serializeToJson();
 	return ret;


### PR DESCRIPTION
This is caused by `toJson` returning no `buildTypes`. Dub overwrites dub.json in fetched packages with one generated by `toJson`, IIUC.
