### PR TITLE
Issue #383 - add an option to override the default compiler and arch in dub.json

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -338,7 +338,7 @@ abstract class PackageBuildCommand : Command {
 		string m_buildType;
 		BuildMode m_buildMode;
 		string m_buildConfig;
-		string m_compilerName = initialCompilerBinary;
+		string m_compilerName;
 		string m_arch;
 		string[] m_debugVersions;
 		Compiler m_compiler;
@@ -388,12 +388,24 @@ abstract class PackageBuildCommand : Command {
 
 	protected void setupPackage(Dub dub, string package_name)
 	{
+		m_defaultConfig = null;
+		enforce (loadSpecificPackage(dub, package_name), "Failed to load package.");
+
+		if (m_compilerName is null) {
+			m_compilerName = dub.projectCompiler;
+		}
+
+		if (m_compilerName is null) {
+			m_compilerName = initialCompilerBinary;
+		}
+
+		if (m_arch is null) {
+			m_arch = dub.projectArch;
+		}
+
 		m_compiler = getCompiler(m_compilerName);
 		m_buildPlatform = m_compiler.determinePlatform(m_buildSettings, m_compilerName, m_arch);
 		m_buildSettings.addDebugVersions(m_debugVersions);
-
-		m_defaultConfig = null;
-		enforce (loadSpecificPackage(dub, package_name), "Failed to load package.");
 
 		if (m_buildConfig.length != 0 && !dub.configurations.canFind(m_buildConfig))
 		{

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -162,6 +162,12 @@ class Dub {
 
 	@property inout(Project) project() inout { return m_project; }
 
+	/// Return (if any) a project-specified compiler
+	@property const(string) projectCompiler() { return m_project.projectCompiler; }
+
+	/// Return (if any) a project-specifed arch
+	@property const(string) projectArch() { return m_project.projectArch; }
+
 	/// Loads the package from the current working directory as the main
 	/// project package.
 	void loadPackageFromCwd()

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -212,6 +212,8 @@ class Package {
 	@property inout(Package) basePackage() inout { return m_parentPackage ? m_parentPackage.basePackage : this; }
 	@property inout(Package) parentPackage() inout { return m_parentPackage; }
 	@property inout(SubPackage)[] subPackages() inout { return m_info.subPackages; }
+	@property const(string) packageCompiler() const { return m_info.packageCompiler; }
+	@property const(string) packageArch() const { return m_info.packageArch; }
 
 	@property string[] configurations()
 	const {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -112,6 +112,18 @@ class Project {
 	/// Package manager instance used by the project.
 	@property inout(PackageManager) packageManager() inout { return m_packageManager; }
 
+	/// A project-specified compiler setting. (Override via --compiler)
+	@property const(string) projectCompiler() const
+	{
+		return m_rootPackage.packageCompiler;
+	}
+
+	/// A project-specified arch setting. (Override via --arch)
+	@property const(string) projectArch() const
+	{
+		return m_rootPackage.packageArch;
+	}
+
 	/** Allows iteration of the dependency tree in topological order
 	*/
 	int delegate(int delegate(ref const Package)) getTopologicalPackageList(bool children_first = false, in Package root_package = null, string[string] configs = null)

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -32,6 +32,8 @@ void parseJson(ref PackageRecipe recipe, Json json, string parent_name)
 			case "description": recipe.description = value.get!string; break;
 			case "homepage": recipe.homepage = value.get!string; break;
 			case "authors": recipe.authors = deserializeJson!(string[])(value); break;
+			case "compiler": recipe.packageCompiler = value.get!string; break;
+			case "arch": recipe.packageArch = value.get!string; break;
 			case "copyright": recipe.copyright = value.get!string; break;
 			case "license": recipe.license = value.get!string; break;
 			case "configurations": break; // handled below, after the global settings have been parsed

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -71,6 +71,8 @@ struct PackageRecipe {
 	string copyright;
 	string license;
 	string[] ddoxFilterArgs;
+	string packageCompiler;
+	string packageArch;
 	BuildSettingsTemplate buildSettings;
 	ConfigurationInfo[] configurations;
 	BuildSettingsTemplate[string] buildTypes;


### PR DESCRIPTION
Add two keys to a project's dub.json file: "compiler" and "arch". These override the system defaults and are overridden by --compiler and --arch respectively.
