### PR TITLE
Fix ctRegex unstable parser

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -735,8 +735,8 @@ string determineModuleName(BuildSettings settings, Path file, Path base_path)
 string getModuleNameFromContent(string content) {
 	import std.regex;
 
-	auto commentsPattern = ctRegex!(`(/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/)|(//.*)`, "g");
-	auto modulePattern = ctRegex!(`module\s+([\w\.]+)\s*;`, "g");
+	auto commentsPattern = regex(`(/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/)|(//.*)`, "g");
+	auto modulePattern = regex(`module\s+([\w\.]+)\s*;`, "g");
 
 	content = replaceAll(content, commentsPattern, "");
 	string moduleName = matchFirst(content, modulePattern).front;


### PR DESCRIPTION
I got this error using `dub test` on libasync and it traced back to something complex inside `ctRegex`.

https://gist.github.com/etcimon/c659ef8050b698303614
