### PR TITLE
Revert "Remove the build type switch for "dub test". See #385."

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -347,18 +347,15 @@ abstract class PackageBuildCommand : Command {
 		string m_defaultConfig;
 		bool m_nodeps;
 		bool m_forceRemove = false;
-		bool m_disableBuildOption = false;
 	}
 
 	override void prepare(scope CommandArgs args)
 	{
-		if (!m_disableBuildOption) {
-			args.getopt("b|build", &m_buildType, [
-				"Specifies the type of build to perform. Note that setting the DFLAGS environment variable will override the build type with custom flags.",
-				"Possible names:",
-				"  debug (default), plain, release, release-nobounds, unittest, profile, docs, ddox, cov, unittest-cov and custom types"
-			]);
-		}
+		args.getopt("b|build", &m_buildType, [
+			"Specifies the type of build to perform. Note that setting the DFLAGS environment variable will override the build type with custom flags.",
+			"Possible names:",
+			"  debug (default), plain, release, release-nobounds, unittest, profile, docs, ddox, cov, unittest-cov and custom types"
+		]);
 		args.getopt("c|config", &m_buildConfig, [
 			"Builds the specified configuration. Configurations can be defined in dub.json"
 		]);
@@ -661,7 +658,6 @@ class TestCommand : PackageBuildCommand {
 		this.acceptsAppArgs = true;
 
 		m_buildType = "unittest";
-		m_disableBuildOption = true;
 	}
 
 	override void prepare(scope CommandArgs args)


### PR DESCRIPTION
This reverts commit 2bc77802be0c94e6f01788b3474cc8194f2634a8.

Conflicts:
    source/dub/commandline.d
