### PR TITLE
Upgraded to new travis D build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,14 @@
 language: d
+sudo: false
 
-env:
-  # dmd: 2.064 - 2.066
-  - DC_NAME=DMD DC_URL=http://downloads.dlang.org/releases/2013/ DC_ARCHIVE=dmd_2.064.2-0_amd64.deb DC_BIN=dmd
-  - DC_NAME=DMD DC_URL=http://downloads.dlang.org/releases/2014/ DC_ARCHIVE=dmd_2.065.0-0_amd64.deb DC_BIN=dmd
-  - DC_NAME=DMD DC_URL=http://downloads.dlang.org/releases/2014/ DC_ARCHIVE=dmd_2.066.0-0_amd64.deb DC_BIN=dmd
-  # ldc: Latest (0.14.0 / FE 2.065.0 ATM)
-  - DC_NAME=LDC DC_URL=https://github.com/ldc-developers/ldc/releases/download/v0.14.0/ DC_ARCHIVE=ldc2-0.14.0-linux-x86_64.tar.gz DC_BIN=/usr/local/ldc2-0.14.0-linux-x86_64/bin/ldc2
-  # gdc: Latest (4.9.0 / FE 2.065.0 ATM)
-  - DC_NAME=GDC DC_URL=http://gdcproject.org/downloads/binaries/x86_64-linux-gnu/ DC_ARCHIVE=native_2.065_gcc4.9.0_a8ad6a6678_20140615.tar.xz DC_BIN=/usr/local/x86_64-gdcproject-linux-gnu/bin/gdc
-
-install:
-  # Install release version of DUB for bootstrapping
-  - BOOTSTRAP_DUB_VER=0.9.21
-  - BOOTSTRAP_DUB=dub-${BOOTSTRAP_DUB_VER}-linux-x86_64
-  - wget http://code.dlang.org/files/${BOOTSTRAP_DUB}.tar.gz
-  - sudo tar -C /usr/local/bin -zxf ${BOOTSTRAP_DUB}.tar.gz
-
-  # Install compiler
-  - wget ${DC_URL}${DC_ARCHIVE}
-  - if [[ $DC_NAME == "DMD" ]]; then sudo dpkg -i ${DC_ARCHIVE} || true; sudo apt-get -y update; sudo apt-get -fy install; sudo dpkg -i ${DC_ARCHIVE}; fi
-  - if [[ $DC_NAME != "DMD" ]]; then sudo tar xf ${DC_ARCHIVE} -C /usr/local/; fi
+d:
+  - dmd-2.064.2
+  - dmd-2.065.0
+  - dmd-2.066.1
+  - ldc-0.14.0
+  - gdc-4.9.0
 
 script:
-  - dub test --compiler=${DC_BIN} -c library-nonet
-  - dub build --compiler=${DC_BIN}
-  - DUB=`pwd`/bin/dub COMPILER=${DC_BIN} test/run-unittest.sh
+  - dub test --compiler=${DC} -c library-nonet
+  - dub build --compiler=${DC}
+  - DUB=`pwd`/bin/dub COMPILER=${DC} test/run-unittest.sh


### PR DESCRIPTION
This upgrades the Travis build system to use the native D support, instead of installing compilers manually. It removes  fair amount of code, and should make maintenance much easier.

A sample of what the builds look like is available on my fork of dub, [here](https://travis-ci.org/ColdenCullen/dub).
