### PR TITLE
[0.9.22] fix compilation with dmd master

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -472,7 +472,7 @@ struct PackageInfo {
 
 	@property const(Dependency)[string] dependencies()
 	const {
-		const(Dependency)[string] ret;
+		Dependency[string] ret;
 		foreach (n, d; this.buildSettings.dependencies)
 			ret[n] = d;
 		foreach (ref c; configurations)


### PR DESCRIPTION
Similar to 022102598253dcba8be38bcf74ad3cb7e7d030ee

NB: this is PR against 0.9.22 branch. I need it merged to make stable dub version compatible with dmd git master to not screw my CI system (https://jenkins.dicebot.lv)

Making point release for 0.9.22 with this merged is not strictly necessary as it does not affect any functionality
