### PR TITLE
add custom type for dub init

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -627,7 +627,7 @@ class Dub {
 		m_packageManager.removeSearchPath(makeAbsolute(path), system ? LocalPackageType.system : LocalPackageType.user);
 	}
 
-	void createEmptyPackage(Path path, string[] deps, string type)
+	void createEmptyPackage(Path path, string[] deps, InitType type)
 	{
 		if (!path.absolute) path = m_rootPath ~ path;
 		path.normalize();

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -652,7 +652,7 @@ class Dub {
 			throw new Exception(format("Couldn't find package: %-(%s, %).", notFound));
 		}
 
-		initPackage(path, depVers, type);
+		initPackage(path, m_userDubPath, depVers, type);
 
 		//Act smug to the user.
 		logInfo("Successfully created an empty project in '%s'.", path.toNativeString());

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -17,9 +17,52 @@ import std.file;
 import std.format;
 import std.process;
 import std.string;
+import std.algorithm : map;
+import std.traits : EnumMembers;
 
+enum InitType
+{
+	minimal,
+	vibe_d,
+	deimos
+}
 
-void initPackage(Path root_path, string[string] deps, string type)
+auto fullInitTypeDescriptions(string fmt="%7s - %s")
+{
+	return map!(a=>fullInitTypeDescription(a,fmt))( [EnumMembers!InitType] );
+}
+
+auto initTypeNames()
+{
+	return map!(a=>initTypeName(a))( [EnumMembers!InitType] );
+}
+
+string fullInitTypeDescription(InitType type, string fmt="%7s - %s")
+{
+	return format( fmt, initTypeName(type), initTypeDescription(type) );
+}
+
+string initTypeName(InitType type)
+{
+	final switch(type)
+	{
+		case InitType.minimal: return "minimal";
+		case InitType.vibe_d:  return "vibe.d";
+		case InitType.deimos:  return "deimos";
+	}
+}
+
+string initTypeDescription(InitType type)
+{
+	final switch(type)
+	{
+		case InitType.minimal: return "simple \"hello world\" project (default)";
+		case InitType.vibe_d:  return "minimal HTTP server based on vibe.d";
+		case InitType.deimos:  return "skeleton for C header bindings";
+	}
+}
+
+void initPackage(Path root_path, string[string] deps, InitType type)
 {
 	void enforceDoesNotExist(string filename) {
 		enforce(!existsFile(root_path ~ filename), "The target directory already contains a '"~filename~"' file. Aborting.");
@@ -39,11 +82,10 @@ void initPackage(Path root_path, string[string] deps, string type)
 	foreach (fil; files)
 		enforceDoesNotExist(fil);
 
-	switch (type) {
-		default: throw new Exception("Unknown package init type: "~type);
-		case "minimal": initMinimalPackage(root_path, deps); break;
-		case "vibe.d": initVibeDPackage(root_path, deps); break;
-		case "deimos": initDeimosPackage(root_path, deps); break;
+	final switch (type) {
+		case InitType.minimal: initMinimalPackage(root_path, deps); break;
+		case InitType.vibe_d:  initVibeDPackage(root_path, deps); break;
+		case InitType.deimos:  initDeimosPackage(root_path, deps); break;
 	}
 	writeGitignore(root_path);
 }

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -202,6 +202,10 @@ class Package {
 		auto filename = path ~ defaultPackageFilename;
 		auto dstFile = openFile(filename.toNativeString(), FileMode.CreateTrunc);
 		scope(exit) dstFile.close();
+
+		//TODO: write SDL if origin is SDL
+		//TODO: save order of PackageRecipe fields
+		//TODO: not write defaul values
 		dstFile.writePrettyJsonString(m_info.toJson());
 	}
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -29,14 +29,14 @@ import std.range;
 import std.string;
 import std.typecons : Nullable;
 
-
-
 enum PackageFormat { json, sdl }
+
 struct FilenameAndFormat
 {
 	string filename;
 	PackageFormat format;
 }
+
 struct PathAndFormat
 {
 	Path path;

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,3 +1,3 @@
 module dub.version_;
-enum dubVersion = "v0.9.24-beta.1-10-gdf70c6a";
+enum dubVersion = "v0.9.24-beta.1-11-g37b42ef";
 enum initialCompilerBinary = "dmd";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,3 +1,3 @@
-module dub.version_; 
-enum dubVersion = "v0.9.23"; 
-enum initialCompilerBinary = "dmd"; 
+module dub.version_;
+enum dubVersion = "v0.9.24-beta.1-9-g4f9afd8";
+enum initialCompilerBinary = "dmd";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,3 +1,3 @@
 module dub.version_;
-enum dubVersion = "v0.9.24-beta.1-11-g37b42ef";
+enum dubVersion = "v0.9.24-beta.1-12-gab8ec9a";
 enum initialCompilerBinary = "dmd";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,3 +1,3 @@
 module dub.version_;
-enum dubVersion = "v0.9.24-beta.1-9-g4f9afd8";
+enum dubVersion = "v0.9.24-beta.1-10-gdf70c6a";
 enum initialCompilerBinary = "dmd";


### PR DESCRIPTION
- rework init types (now enum)
- add custom type (issue #557)

Example usage:
`dub init MyApp gtk-d deslog -tcustom` copies files from `.dub/custom_init_package/` and replace in them some vars:
- $name -> myapp
- $Name -> MyApp
- $deps_json -> "gtk-d": "3.1.3", "deslog": "0.2.0"
