### PR TITLE
Fix library extensions for LDC when using the MS linker. Fixes #618.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -104,6 +104,9 @@ interface Compiler {
 	/// Removes any dflags that match one of the BuildOptions values and populates the BuildSettings.options field.
 	void extractBuildOptions(ref BuildSettings settings) const;
 
+	/// Computes the full file name of the generated binary.
+	string getTargetFileName(in BuildSettings settings, in BuildPlatform platform) const;
+
 	/// Adds the appropriate flag to set a target path
 	void setTarget(ref BuildSettings settings, in BuildPlatform platform, string targetPath = null) const;
 

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -166,6 +166,33 @@ class DMDCompiler : Compiler {
 		settings.dflags = newflags.data;
 	}
 
+	string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
+	const {
+		assert(settings.targetName.length > 0, "No target name set.");
+		final switch (settings.targetType) {
+			case TargetType.autodetect: assert(false, "Configurations must have a concrete target type.");
+			case TargetType.none: return null;
+			case TargetType.sourceLibrary: return null;
+			case TargetType.executable:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".exe";
+				else return settings.targetName;
+			case TargetType.library:
+			case TargetType.staticLibrary:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".lib";
+				else return "lib" ~ settings.targetName ~ ".a";
+			case TargetType.dynamicLibrary:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".dll";
+				else return "lib" ~ settings.targetName ~ ".so";
+			case TargetType.object:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".obj";
+				else return settings.targetName ~ ".o";
+		}
+	}
+
 	void setTarget(ref BuildSettings settings, in BuildPlatform platform, string tpath = null) const
 	{
 		final switch (settings.targetType) {

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -169,6 +169,31 @@ class GDCCompiler : Compiler {
 		settings.dflags = newflags.data;
 	}
 
+	string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
+	const {
+		assert(settings.targetName.length > 0, "No target name set.");
+		final switch (settings.targetType) {
+			case TargetType.autodetect: assert(false, "Configurations must have a concrete target type.");
+			case TargetType.none: return null;
+			case TargetType.sourceLibrary: return null;
+			case TargetType.executable:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".exe";
+				else return settings.targetName;
+			case TargetType.library:
+			case TargetType.staticLibrary:
+				return "lib" ~ settings.targetName ~ ".a";
+			case TargetType.dynamicLibrary:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".dll";
+				else return "lib" ~ settings.targetName ~ ".so";
+			case TargetType.object:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".obj";
+				else return settings.targetName ~ ".o";
+		}
+	}
+
 	void setTarget(ref BuildSettings settings, in BuildPlatform platform, string tpath = null) const
 	{
 		final switch (settings.targetType) {

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -153,6 +153,33 @@ class LDCCompiler : Compiler {
 		settings.dflags = newflags.data;
 	}
 
+	string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
+	const {
+		assert(settings.targetName.length > 0, "No target name set.");
+		final switch (settings.targetType) {
+			case TargetType.autodetect: assert(false, "Configurations must have a concrete target type.");
+			case TargetType.none: return null;
+			case TargetType.sourceLibrary: return null;
+			case TargetType.executable:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".exe";
+				else return settings.targetName;
+			case TargetType.library:
+			case TargetType.staticLibrary:
+				/*if (m_generatesCOFF)
+					return settings.targetName ~ ".lib";
+				else*/ return "lib" ~ settings.targetName ~ ".a";
+			case TargetType.dynamicLibrary:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".dll";
+				else return "lib" ~ settings.targetName ~ ".so";
+			case TargetType.object:
+				if (platform.platform.canFind("windows"))
+					return settings.targetName ~ ".obj";
+				else return settings.targetName ~ ".o";
+		}
+	}
+
 	void setTarget(ref BuildSettings settings, in BuildPlatform platform, string tpath = null) const
 	{
 		final switch (settings.targetType) {

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -155,7 +155,18 @@ class LDCCompiler : Compiler {
 
 	string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
 	const {
+		import std.string : splitLines, strip;
+		import std.uni : toLower;
+
 		assert(settings.targetName.length > 0, "No target name set.");
+
+		auto result = executeShell(escapeShellCommand([platform.compilerBinary, "-version"]));
+		enforce (result.status == 0, "Failed to determine linker used by LDC. \""
+			~platform.compilerBinary~" -version\" failed with exit code "
+			~result.status.to!string()~".");
+
+		bool generates_coff = result.output.splitLines.find!(l => l.strip.toLower.startsWith("default target:")).front.canFind("-windows-msvc");
+
 		final switch (settings.targetType) {
 			case TargetType.autodetect: assert(false, "Configurations must have a concrete target type.");
 			case TargetType.none: return null;
@@ -166,9 +177,8 @@ class LDCCompiler : Compiler {
 				else return settings.targetName;
 			case TargetType.library:
 			case TargetType.staticLibrary:
-				/*if (m_generatesCOFF)
-					return settings.targetName ~ ".lib";
-				else*/ return "lib" ~ settings.targetName ~ ".a";
+				if (generates_coff) return settings.targetName ~ ".lib";
+				else return "lib" ~ settings.targetName ~ ".a";
 			case TargetType.dynamicLibrary:
 				if (platform.platform.canFind("windows"))
 					return settings.targetName ~ ".dll";

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -15,41 +15,6 @@ import std.algorithm : canFind, endsWith, filter;
 
 
 /**
-	Given a set of build settings and a target platform, determines the target
-	binary file name.
-
-	The returned string contains the file name, as well as the platform
-	specific file extension. The directory is not included.
-*/
-string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
-{
-	assert(settings.targetName.length > 0, "No target name set.");
-	final switch (settings.targetType) {
-		case TargetType.autodetect: assert(false, "Configurations must have a concrete target type.");
-		case TargetType.none: return null;
-		case TargetType.sourceLibrary: return null;
-		case TargetType.executable:
-			if (platform.platform.canFind("windows"))
-				return settings.targetName ~ ".exe";
-			else return settings.targetName;
-		case TargetType.library:
-		case TargetType.staticLibrary:
-			if (platform.platform.canFind("windows") && platform.compiler == "dmd")
-				return settings.targetName ~ ".lib";
-			else return "lib" ~ settings.targetName ~ ".a";
-		case TargetType.dynamicLibrary:
-			if( platform.platform.canFind("windows") )
-				return settings.targetName ~ ".dll";
-			else return "lib" ~ settings.targetName ~ ".so";
-		case TargetType.object:
-			if (platform.platform.canFind("windows"))
-				return settings.targetName ~ ".obj";
-			else return settings.targetName ~ ".o";
-	}
-}
-
-
-/**
 	Alters the build options to comply with the specified build requirements.
 
 	And enabled options that do not comply will get disabled.

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -67,9 +67,9 @@ class BuildGenerator : ProjectGenerator {
 			foreach (ldep; ti.linkDependencies) {
 				auto dbs = targets[ldep].buildSettings;
 				if (bs.targetType != TargetType.staticLibrary) {
-					bs.addSourceFiles((Path(dbs.targetPath) ~ getTargetFileName(dbs, settings.platform)).toNativeString());
+					bs.addSourceFiles(getTargetPath(dbs, settings).toNativeString());
 				} else {
-					additional_dep_files ~= Path(dbs.targetPath) ~ getTargetFileName(dbs, settings.platform);
+					additional_dep_files ~= getTargetPath(dbs, settings);
 				}
 			}
 			if (buildTarget(settings, bs, ti.pack, ti.config, ti.packages, additional_dep_files))
@@ -96,7 +96,7 @@ class BuildGenerator : ProjectGenerator {
 		// run the generated executable
 		auto buildsettings = targets[m_project.rootPackage.name].buildSettings;
 		if (settings.run && !(buildsettings.options & BuildOption.syntaxOnly)) {
-			auto exe_file_path = Path(buildsettings.targetPath) ~ getTargetFileName(buildsettings, settings.platform);
+			auto exe_file_path = getTargetPath(buildsettings, settings);
 			runTarget(exe_file_path, buildsettings, settings.runArgs, settings);
 		}
 	}
@@ -148,10 +148,10 @@ class BuildGenerator : ProjectGenerator {
 		auto cwd = Path(getcwd());
 		auto target_path = pack.path ~ format(".dub/build/%s/", build_id);
 
-		if (!settings.force && isUpToDate(target_path, buildsettings, settings.platform, pack, packages, additional_dep_files)) {
+		if (!settings.force && isUpToDate(target_path, buildsettings, settings, pack, packages, additional_dep_files)) {
 			logInfo("%s %s: target for configuration \"%s\" is up to date.", pack.name, pack.version_, config);
 			logDiagnostic("Using existing build in %s.", target_path.toNativeString());
-			copyTargetFile(target_path, buildsettings, settings.platform);
+			copyTargetFile(target_path, buildsettings, settings);
 			return true;
 		}
 
@@ -177,7 +177,7 @@ class BuildGenerator : ProjectGenerator {
 		cbuildsettings.targetPath = target_path.relativeTo(cwd).toNativeString();
 		buildWithCompiler(settings, cbuildsettings);
 
-		copyTargetFile(target_path, buildsettings, settings.platform);
+		copyTargetFile(target_path, buildsettings, settings);
 
 		return false;
 	}
@@ -217,11 +217,11 @@ class BuildGenerator : ProjectGenerator {
 				m_temporaryFiles ~= tmpdir;
 				tmp_target = true;
 			}
-			exe_file_path = Path(buildsettings.targetPath) ~ getTargetFileName(buildsettings, settings.platform);
+			exe_file_path = getTargetPath(buildsettings, settings);
 			settings.compiler.setTarget(buildsettings, settings.platform);
 		}
 
-		logDiagnostic("Application output name is '%s'", getTargetFileName(buildsettings, settings.platform));
+		logDiagnostic("Application output name is '%s'", settings.compiler.getTargetFileName(buildsettings, settings.platform));
 
 		string[] flags = ["--build-only", "--compiler="~settings.platform.compilerBinary];
 		if (settings.force) flags ~= "--force";
@@ -286,7 +286,7 @@ class BuildGenerator : ProjectGenerator {
 				m_temporaryFiles ~= tmppath;
 				is_temp_target = true;
 			}
-			exe_file_path = Path(buildsettings.targetPath) ~ getTargetFileName(buildsettings, settings.platform);
+			exe_file_path = getTargetPath(buildsettings, settings);
 		}
 
 		if( buildsettings.preBuildCommands.length ){
@@ -333,9 +333,9 @@ class BuildGenerator : ProjectGenerator {
 			settings.platform.compiler, settings.platform.frontendVersion, hashstr);
 	}
 
-	private void copyTargetFile(Path build_path, BuildSettings buildsettings, BuildPlatform platform)
+	private void copyTargetFile(Path build_path, BuildSettings buildsettings, GeneratorSettings settings)
 	{
-		auto filename = getTargetFileName(buildsettings, platform);
+		auto filename = settings.compiler.getTargetFileName(buildsettings, settings.platform);
 		auto src = build_path ~ filename;
 		logDiagnostic("Copying target from %s to %s", src.toNativeString(), buildsettings.targetPath);
 		if (!existsFile(Path(buildsettings.targetPath)))
@@ -343,11 +343,11 @@ class BuildGenerator : ProjectGenerator {
 		hardLinkFile(src, Path(buildsettings.targetPath) ~ filename, true);
 	}
 
-	private bool isUpToDate(Path target_path, BuildSettings buildsettings, BuildPlatform platform, in Package main_pack, in Package[] packages, in Path[] additional_dep_files)
+	private bool isUpToDate(Path target_path, BuildSettings buildsettings, GeneratorSettings settings, in Package main_pack, in Package[] packages, in Path[] additional_dep_files)
 	{
 		import std.datetime;
 
-		auto targetfile = target_path ~ getTargetFileName(buildsettings, platform);
+		auto targetfile = target_path ~ settings.compiler.getTargetFileName(buildsettings, settings.platform);
 		if (!existsFile(targetfile)) {
 			logDiagnostic("Target '%s' doesn't exist, need rebuild.", targetfile.toNativeString());
 			return false;
@@ -413,7 +413,7 @@ class BuildGenerator : ProjectGenerator {
 		Path target_file;
 		scope (failure) {
 			logDiagnostic("FAIL %s %s %s" , buildsettings.targetPath, buildsettings.targetName, buildsettings.targetType);
-			auto tpath = Path(buildsettings.targetPath) ~ getTargetFileName(buildsettings, settings.platform);
+			auto tpath = getTargetPath(buildsettings, settings);
 			if (generate_binary && existsFile(tpath))
 				removeFile(tpath);
 		}
@@ -537,4 +537,9 @@ private Path getMainSourceFile(in Package prj)
 		if (existsFile(prj.path ~ f))
 			return prj.path ~ f;
 	return prj.path ~ "source/app.d";
+}
+
+private Path getTargetPath(in ref BuildSettings bs, in ref GeneratorSettings settings)
+{
+	return Path(bs.targetPath) ~ settings.compiler.getTargetFileName(bs, settings.platform);
 }

--- a/source/dub/generators/targetdescription.d
+++ b/source/dub/generators/targetdescription.d
@@ -9,7 +9,6 @@ module dub.generators.targetdescription;
 
 import dub.compilers.buildsettings;
 import dub.compilers.compiler;
-import dub.compilers.utils : getTargetFileName;
 import dub.description;
 import dub.generators.generator;
 import dub.internal.vibecompat.inet.path;
@@ -53,7 +52,7 @@ class TargetDescriptionGenerator : ProjectGenerator {
 			foreach (ld; ti.linkDependencies) {
 				auto ltarget = targets[ld];
 				auto ltbs = ltarget.buildSettings;
-				auto targetfil = (Path(ltbs.targetPath) ~ getTargetFileName(ltbs, settings.platform)).toNativeString();
+				auto targetfil = (Path(ltbs.targetPath) ~ settings.compiler.getTargetFileName(ltbs, settings.platform)).toNativeString();
 				d.buildSettings.addLinkerFiles(targetfil);
 			}
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -601,8 +601,11 @@ class Package {
 	*/
 	PackageDescription describe(BuildPlatform platform, string config)
 	const {
-		import dub.compilers.utils : getTargetFileName;
-
+		return describe(platform, getCompiler(platform.compilerBinary), config);
+	}
+	/// ditto
+	PackageDescription describe(BuildPlatform platform, Compiler compiler, string config)
+	const {
 		PackageDescription ret;
 		ret.configuration = config;
 		ret.path = m_path.toNativeString();
@@ -622,8 +625,8 @@ class Package {
 		ret.targetType = bs.targetType;
 		ret.targetPath = bs.targetPath;
 		ret.targetName = bs.targetName;
-		if (ret.targetType != TargetType.none)
-			ret.targetFileName = getTargetFileName(bs, platform);
+		if (ret.targetType != TargetType.none && compiler)
+			ret.targetFileName = compiler.getTargetFileName(bs, platform);
 		ret.workingDirectory = bs.workingDirectory;
 		ret.mainSourceFile = bs.mainSourceFile;
 		ret.dflags = bs.dflags;


### PR DESCRIPTION
Fixes the output binary extensions for the MSVC version of LDC. This requires runtime detection of the type of compiler invoked and thus requires moving the target filename handling code to the compiler class.