### PR TITLE
add dynamic library build target

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -31,6 +31,14 @@
 				"vibe-d": {"version": "~>0.7.19-rc.4", "optional": true}
 			},
 			"excludedSourceFiles": ["source/app.d"]
-		}
+		},
+      {
+         "name": "dynamic-library-nonet",
+         "targetType": "dynamicLibrary",
+         "dependencies": {
+            "vibe-d": {"version": "~>0.7.19-rc.4", "optional": true}
+         },
+         "excludedSourceFiles": ["source/app.d"]
+      }
 	]
 }


### PR DESCRIPTION
I want to add d / dub support to qt-creator and want to use dub as a library. The problem with the static library is that it will not get compiled with -fPIC support which is needed to be linked against the c++ qtcreator plugin api. I figured that compiling dub as a shared library solves this problems, hence the additional configuration.