### PR TITLE
init with empty deps

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -90,6 +90,15 @@ void initPackage(Path root_path, string[string] deps, string type,
 private void initMinimalPackage(Path root_path, ref PackageRecipe p)
 {
 	p.description = "A minimal D application.";
+
+	// we want to create a empty, not-null dictionary,
+	// s. t. the generated recipe contains an empty "dependencies" section
+	// in case of PackageFormat.json
+	auto bar = Dependency("~>0.0.0");
+	p.buildSettings.dependencies["foo"] = bar;
+	p.buildSettings.dependencies.remove("foo");
+	assert(p.buildSettings.dependencies !is null);
+
 	createDirectory(root_path ~ "source");
 	write((root_path ~ "source/app.d").toNativeString(),
 q{import std.stdio;

--- a/test/0-init-simple-json.sh
+++ b/test/0-init-simple-json.sh
@@ -1,16 +1,32 @@
 #!/bin/bash
 
 packname="0-init-simple-pack"
+currentYear=$(date +"%Y")
 
 $DUB init -n $packname -f json
+
+cat > $packname/dub2.json <<- EOL
+{
+	"name": "$packname",
+	"authors": [
+		"$USER"
+	],
+	"dependencies": {},
+	"description": "A minimal D application.",
+	"copyright": "Copyright © $currentYear, $USER",
+	"license": "proprietary"
+}
+EOL
 
 function cleanup {
     rm -rf $packname
 }
 
+diff -w $packname/dub.json $packname/dub2.json
+
 if [ ! -e $packname/dub.json ]; then # it failed
-    cleanup
-    exit 1
+	cleanup
+	exit 1
 fi
 cleanup
 exit 0


### PR DESCRIPTION
This would initialize `dependencies` for the `json` file - it leave `sdl` untouched.
The idea ist that it is a bit easier to copy & paste dependencies once the new code.dlang.org website with the clipboard buttons is released.

Btw quite a silly workaround, but I couldn't come up with something smarter.
