### PR TITLE
No check optional deps

### DIFF
--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -74,13 +74,13 @@ class DependencyResolver(CONFIGS, CONFIG) {
 				auto basepack = basePackage(ch.pack);
 				auto pidx = all_configs.length;
 
-				if (ch.depType != DependencyType.required) maybe_optional_deps[ch.pack] = true;
+				if (optional) maybe_optional_deps[ch.pack] = true;
 
 				CONFIG[] configs;
 				if (auto pi = basepack in package_indices) {
 					pidx = *pi;
 					configs = all_configs[*pi];
-				} else {
+				} else if(ch.depType == DependencyType.required) {
 					if (basepack == root_base_pack) configs = [root.config];
 					else configs = getAllConfigs(basepack);
 					all_configs ~= configs;

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -74,19 +74,23 @@ class DependencyResolver(CONFIGS, CONFIG) {
 				auto basepack = basePackage(ch.pack);
 				auto pidx = all_configs.length;
 
-				if (optional) maybe_optional_deps[ch.pack] = true;
+				if (ch.depType != DependencyType.required) maybe_optional_deps[ch.pack] = true;
 
 				CONFIG[] configs;
 				if (auto pi = basepack in package_indices) {
 					pidx = *pi;
 					configs = all_configs[*pi];
-				} else if(ch.depType == DependencyType.required) {
-					if (basepack == root_base_pack) configs = [root.config];
-					else configs = getAllConfigs(basepack);
-					all_configs ~= configs;
-					package_indices[basepack] = pidx;
-					package_names[pidx] = basepack;
+				} else {
+				  if (basepack == root_base_pack) configs = [root.config];
+				  else if(ch.depType == DependencyType.required)
+					configs = getAllConfigs(basepack);
+				  else
+					configs = [];
+				  package_indices[basepack] = pidx;
+				  package_names[pidx] = basepack;
+				  all_configs ~= configs;
 				}
+
 
 				foreach (c; getSpecificConfigs(basepack, ch))
 					if (!configs.canFind(c))

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,0 @@
-module dub.version_; 
-enum dubVersion = "v0.9.24"; 


### PR DESCRIPTION
Avoid stalling on polling online servers for versions of dependencies that we aren't going to use.

Not sure if I did this right... works for stopping optional deps, but I don't have an optional dependency to actually select, to test if that sets `depType` to `required` early enough.