### PR TITLE
fix Windows ldc-win64-msvc library names problem - close #835

### DIFF
--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -34,7 +34,8 @@ string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
 			else return settings.targetName;
 		case TargetType.library:
 		case TargetType.staticLibrary:
-			if (platform.platform.canFind("windows") && platform.compiler == "dmd")
+			if ((platform.platform.canFind("windows") && platform.compiler == "dmd")
+					||(platform.compilerBinary.canFind("win64-msvc")))
 				return settings.targetName ~ ".lib";
 			else return "lib" ~ settings.targetName ~ ".a";
 		case TargetType.dynamicLibrary:


### PR DESCRIPTION
For Windows builds using LDC with msvc linker, static libraries must have extension .lib instead of .a

How to reproduce:
in any dub project which uses some static library dub dependency, try to build it with ldc2 or ldmd2:
dub build --compiler=C:\Tools\D\ldc2-1.0.0-beta1-win64-msvc\bin\ldmd2.exe
You will get "Error: unrecognized file extension a"

Solution: if "win64-msvc" is found in compiler binary path, use .lib instead of .a for static lib names.
