### PR TITLE
Use std.stdio instead of the deprecated std.stream.

### DIFF
--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -38,11 +38,11 @@ struct RangeFile {
 		enforce(sz <= size_t.max, "File is too big to read to memory.");
 		file.seek(0, SEEK_SET);
 		auto ret = new ubyte[cast(size_t)sz];
-		file.rawRead(ret);
+		rawRead(ret);
 		return ret;
 	}
 
-	void rawRead(ubyte[] dst) { file.rawRead(dst); }
+	void rawRead(ubyte[] dst) { enforce(file.rawRead(dst).length == dst.length, "Failed to readall bytes from file."); }
 	void write(string str) { put(str); }
 	void close() { file.close(); }
 	void flush() { file.flush(); }

--- a/test/issue130-unicode-СНАЯАСТЕЯЅ/dub.sdl
+++ b/test/issue130-unicode-СНАЯАСТЕЯЅ/dub.sdl
@@ -1,0 +1,1 @@
+name "tests"

--- a/test/issue130-unicode-СНАЯАСТЕЯЅ/source/app.d
+++ b/test/issue130-unicode-СНАЯАСТЕЯЅ/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Success.");
+}


### PR DESCRIPTION
Since opening non-ASCII file names on Windows is fixed for the latest DMD version, it now only has to be made sure to use a recent compiler to build DUB.