### PR TITLE
allow specifying version in env variable to aid packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,9 @@ fi
 LIBS=`echo "$LIBS" | sed 's/^-L/-L-L/; s/ -L/ -L-L/g; s/^-l/-L-l/; s/ -l/ -L-l/g'`
 
 echo Generating version file...
-GITVER=$(git describe) || GITVER=unknown
+if  [ "$GITVER" = "" ]; then
+  GITVER=$(git describe) || GITVER=unknown
+fi
 echo "module dub.version_;" > source/dub/version_.d
 echo "enum dubVersion = \"$GITVER\";" >> source/dub/version_.d
 


### PR DESCRIPTION
When a package description downloads the git archive (tar.gz) and runs `builds.sh`, `$GITVER` is set to 'unknown'. This PR allows the variable to be set outside the script.