### PR TITLE
Escaping LDC arguments given in a @cmdfile (Issue 834)

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -225,7 +225,6 @@ class LDCCompiler : Compiler {
         auto escapedSettings = (cast(string[])settings.dflags ).map!(a => "\"" ~ a ~ "\"").join("\n");
 
 		std.file.write(res_file.toNativeString(), escapedSettings);
-        logDiagnostic("%s", res_file);
 		logDiagnostic("%s %s", platform.compilerBinary, join(cast(string[])settings.dflags, " "));
 		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback);
 	}


### PR DESCRIPTION
This works on Windows when issue 834 was spotted in the first place, but need to be tested for POSIX first. (Presumably just adding " " wouldn't work there, and there was no problem in the first place in POSIX AFAIK)