### PR TITLE
Choose default compiler using path based priority.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1052,10 +1052,11 @@ class Dub {
 		version (Posix) enum sep = ":", exe = "";
 
 		auto compilers = ["dmd", "gdc", "gdmd", "ldc2", "ldmd2"];
+		typeof(compilers[0]) found;
 
 		auto paths = environment.get("PATH", "").splitter(sep).map!Path;
-		auto res = compilers.find!(bin => paths.canFind!(p => existsFile(p ~ (bin~exe))));
-		m_defaultCompiler = res.empty ? compilers[0] : res.front;
+		auto res = paths.find!(path => compilers.canFind!((compiler){found = compiler; return existsFile(path ~ (compiler~exe));}));
+		m_defaultCompiler = res.empty ? compilers[0] : found;
 	}
 
 	private Path makeAbsolute(Path p) const { return p.absolute ? p : m_rootPath ~ p; }


### PR DESCRIPTION
Old Code: Do a compiler first scan, stopping when one is found, which results in dmd always being the default compiler.

New Code: Do a path scan first, stopping when a compiler is found, and use that compiler instead.

Result: The default compiler selected by dub will depend on how your path is setup, so that the first one found is selected, as oposed to always choosing compilers in a pre determined order.
