### PR TITLE
Only use temporary builds shebang invocations.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -100,7 +100,7 @@ int runDubCommandLine(string[] args)
 
 	// special single-file package shebang syntax
 	if (args.length >= 2 && args[1].endsWith(".d")) {
-		args = args[0] ~ ["run", "-q", "--single", args[1], "--"] ~ args[2 ..$];
+		args = args[0] ~ ["run", "-q", "--temp-build", "--single", args[1], "--"] ~ args[2 ..$];
 	}
 
 	// split application arguments from DUB arguments
@@ -749,7 +749,7 @@ class GenerateCommand : PackageBuildCommand {
 		gensettings.runArgs = app_args;
 		gensettings.force = m_force;
 		gensettings.rdmd = m_rdmd;
-		gensettings.tempBuild = m_tempBuild || m_single;
+		gensettings.tempBuild = m_tempBuild;
 		gensettings.parallelBuild = m_parallel;
 
 		logDiagnostic("Generating using %s", m_generator);

--- a/test/issue103-single-file-package-json.d
+++ b/test/issue103-single-file-package-json.d
@@ -1,5 +1,5 @@
 /+ dub.json: {
-   "name": "hello_world"
+   "name": "single-file-test"
 } +/
 module hello;
 

--- a/test/issue103-single-file-package-w-dep.d
+++ b/test/issue103-single-file-package-w-dep.d
@@ -1,5 +1,5 @@
 /+ dub.sdl:
-name "hello_world"
+name "single-file-test"
 dependency "sourcelib-simple" path="1-sourceLib-simple"
 +/
 module hello;

--- a/test/issue103-single-file-package.d
+++ b/test/issue103-single-file-package.d
@@ -1,6 +1,6 @@
 #!../bin/dub
 /+ dub.sdl:
-   name "hello_world"
+   name "single-file-test"
 +/
 module hello;
 

--- a/test/issue103-single-file-package.sh
+++ b/test/issue103-single-file-package.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 cd ${CURR_DIR}
-./issue103-single-file-package.d foo -- bar
+rm -f single-file-test
+
 ${DUB} run --single issue103-single-file-package-json.d --compiler=${DC}
-${DUB} issue103-single-file-package-w-dep.d --compiler=${DC}
+if [ ! -f single-file-test ]; then
+	echo "Normal invocation did not produce a binary in the current directory"
+	exit 1
+fi
+rm single-file-test
+
+./issue103-single-file-package.d foo -- bar
+
+${DUB} issue103-single-file-package-w-dep.d
+
+if [ -f single-file-test ]; then
+	echo "Shebang invocation produced binary in current directory"
+	exit 1
+fi


### PR DESCRIPTION
See issue #887 - now builds single-file packages normally in the package's parent directory unless the `dub file.d` syntax is used.