### PR TITLE
Search for dub configuration in ../etc/dub/. Fixes #895.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -176,6 +176,7 @@ class Dub {
 
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), null);
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
+		m_config = new DubConfig(jsonFromFile(Path(thisExePath) ~ "../etc/dub/settings.json", true), m_config);
 
 		determineDefaultCompiler();
 	}

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -174,8 +174,8 @@ class Dub {
 
 		m_dirs.temp = Path(tempDir);
 
-		m_config = new DubConfig(jsonFromFile(Path(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
+		m_config = new DubConfig(jsonFromFile(Path(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		determineDefaultCompiler();

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -174,8 +174,8 @@ class Dub {
 
 		m_dirs.temp = Path(tempDir);
 
-		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), null);
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
+		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), null);
 		m_config = new DubConfig(jsonFromFile(Path(thisExePath) ~ "../etc/dub/settings.json", true), m_config);
 
 		determineDefaultCompiler();

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -174,9 +174,9 @@ class Dub {
 
 		m_dirs.temp = Path(tempDir);
 
+		m_config = new DubConfig(jsonFromFile(Path(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
-		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), null);
-		m_config = new DubConfig(jsonFromFile(Path(thisExePath) ~ "../etc/dub/settings.json", true), m_config);
+		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		determineDefaultCompiler();
 	}

--- a/test/issue895-local-configuration.sh
+++ b/test/issue895-local-configuration.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+cd ${CURR_DIR}
+mkdir ../etc
+mkdir ../etc/dub
+echo "{\"defaultCompiler\": \"foo\"}" > ../etc/dub/settings.json
+
+if [ -e /var/lib/dub/settings.json ]; then
+	echo "Found existing system wide DUB configuration. Aborting."
+	exit 1
+fi
+
+if [ -e ~/.dub/settings.json ]; then
+	echo "Found existing user wide DUB configuration. Aborting."
+	exit 1
+fi
+
+if ! ${DUB} describe --single issue103-single-file-package.d 2>&1 | grep -e "Unknown compiler: foo" -c > /dev/null; then
+	rm -r ../etc
+	echo "DUB didn't find the local configuration"
+	exit 1
+fi
+
+rm -r ../etc


### PR DESCRIPTION
The search happens relative to the executable file. This also contains two small refactorings to prepare for a separation of configuration files and cache files, which currently reside in the same folder.

#895