### PR TITLE
Add tag & stats badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dub package manager [![Build Status](https://travis-ci.org/dlang/dub.svg?branch=master)](https://travis-ci.org/dlang/dub) [![Coverage Status](https://coveralls.io/repos/dlang/dub/badge.svg)](https://coveralls.io/r/dlang/dub)
+# dub package manager [![GitHub tag](https://img.shields.io/github/tag/dlang/dub.svg?maxAge=86400)](#) [![Build Status](https://travis-ci.org/dlang/dub.svg?branch=master)](https://travis-ci.org/dlang/dub) [![Coverage Status](https://coveralls.io/repos/dlang/dub/badge.svg)](https://coveralls.io/r/dlang/dub) [![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/dub.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/dub)
 
 Package and build manager for [D](http://dlang.org/) applications and libraries.
 


### PR DESCRIPTION
- The tag badge will automatically show the latest git tag
- The issue stats badge shows the time to close a PR and is intended to act as a positive motivation for contributors

Preview:

![image](https://cloud.githubusercontent.com/assets/4370550/18039311/fa809638-6da1-11e6-8c61-150505b55dec.png)

I might also make sense to put them in their own line now:

![image](https://cloud.githubusercontent.com/assets/4370550/18039347/5cd921b0-6da2-11e6-91d0-06764db5f1fe.png)
