### PR TITLE
Minor tweak in SublimeText generation

### DIFF
--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -56,8 +56,8 @@ class SublimeTextGenerator : ProjectGenerator {
 private Json targetFolderJson(in ProjectGenerator.TargetInfo target)
 {
 	return [
-		"name": target.pack.name.Json,
-		"path": target.pack.path.toNativeString.Json,
+		"name": target.pack.basePackage.name.Json,
+		"path": target.pack.basePackage.path.toNativeString.Json,
 		"follow_symlinks": true.Json,
 		"folder_exclude_patterns": [".dub"].map!Json.array.Json,
 	].Json;


### PR DESCRIPTION
In the project explorer, folders were named after the name of the first sub-package, instead of the parent package.

Before this PR:
![before](https://cloud.githubusercontent.com/assets/1067485/18053897/e377edc8-6e01-11e6-88f6-6df0e7b3c5f4.png)

After this PR:
![after](https://cloud.githubusercontent.com/assets/1067485/18053903/e9b95d20-6e01-11e6-9531-826fe8e8c4fb.png)
