### PR TITLE
Expand '~' in paths.

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -28,6 +28,7 @@ import std.conv;
 import std.datetime;
 import std.exception;
 import std.file;
+import std.path;
 import std.process;
 import std.string;
 import std.typecons;
@@ -1346,7 +1347,7 @@ final class SelectedVersions {
 		if (j.type == Json.Type.string)
 			return Dependency(Version(j.get!string));
 		else if (j.type == Json.Type.object)
-			return Dependency(Path(j["path"].get!string));
+			return Dependency(Path(j["path"].get!string.expandTilde));
 		else throw new Exception(format("Unexpected type for dependency: %s", j.type));
 	}
 


### PR DESCRIPTION
Resolves #771: Fails to expand ~ in path.
For example, a ~ in a path dependency path in dub.json will now be
expanded.
