### PR TITLE
Remove some duplicated code, implement platform probing for LDC.

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -57,27 +57,16 @@ class LDCCompiler : Compiler {
 
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{
-		// TODO: determine platform by invoking the compiler instead
-		BuildPlatform build_platform;
-		build_platform.platform = .determinePlatform();
-		build_platform.architecture = .determineArchitecture();
-		build_platform.compiler = this.name;
-		build_platform.compilerBinary = compiler_binary;
-
+		string[] arch_flags;
 		switch (arch_override) {
 			default: throw new Exception("Unsupported architecture: "~arch_override);
 			case "": break;
-			case "x86":
-				build_platform.architecture = ["x86"];
-				settings.addDFlags("-march=x86");
-				break;
-			case "x86_64":
-				build_platform.architecture = ["x86_64"];
-				settings.addDFlags("-march=x86-64");
-				break;
+			case "x86": arch_flags = ["-march=x86"]; break;
+			case "x86_64": arch_flags = ["-march=x86-64"]; break;
 		}
+		settings.addDFlags(arch_flags);
 
-		return build_platform;
+		return probePlatform(compiler_binary, arch_flags ~ ["-c", "-o-"], arch_override);
 	}
 
 	void prepareBuildSettings(ref BuildSettings settings, BuildSetting fields = BuildSetting.all) const


### PR DESCRIPTION
The repeated code was moved from gdc and dmd implementations to a protected final method of their base `interface Compiler`. `LDCCompiler.determinePlatform` was implemented using the same method.
I've tested it with dmd and a few different builds of gdc and ldc, but only on linux x86_64 build system (x86, x86_64 and various arm targets).