### PR TITLE
Changes for operation with enviroment variables

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -102,6 +102,7 @@ int runDubCommandLine(string[] args)
 	if (args.length >= 2 && args[1].endsWith(".d")) {
 		args = args[0] ~ ["run", "-q", "--temp-build", "--single", args[1], "--"] ~ args[2 ..$];
 	}
+
 	// split application arguments from DUB arguments
 	string[] app_args;
 	auto app_args_idx = args.countUntil("--");

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -102,7 +102,6 @@ int runDubCommandLine(string[] args)
 	if (args.length >= 2 && args[1].endsWith(".d")) {
 		args = args[0] ~ ["run", "-q", "--temp-build", "--single", args[1], "--"] ~ args[2 ..$];
 	}
-
 	// split application arguments from DUB arguments
 	string[] app_args;
 	auto app_args_idx = args.countUntil("--");

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -42,6 +42,7 @@ struct BuildSettings {
 	string[] postGenerateCommands;
 	string[] preBuildCommands;
 	string[] postBuildCommands;
+	string[] enviromentCommands; // mgw
 	@byName BuildRequirements requirements;
 	@byName BuildOptions options;
 
@@ -62,6 +63,7 @@ struct BuildSettings {
 
 	void add(in BuildSettings bs)
 	{
+import std.stdio: writeln;
 		addDFlags(bs.dflags);
 		addLFlags(bs.lflags);
 		addLibs(bs.libs);
@@ -78,6 +80,7 @@ struct BuildSettings {
 		addPostGenerateCommands(bs.postGenerateCommands);
 		addPreBuildCommands(bs.preBuildCommands);
 		addPostBuildCommands(bs.postBuildCommands);
+		addEnviromentCommands(bs.enviromentCommands);
 	}
 
 	void addDFlags(in string[] value...) { dflags ~= value; }
@@ -101,6 +104,9 @@ struct BuildSettings {
 	void addPostGenerateCommands(in string[] value...) { add(postGenerateCommands, value, false); }
 	void addPreBuildCommands(in string[] value...) { add(preBuildCommands, value, false); }
 	void addPostBuildCommands(in string[] value...) { add(postBuildCommands, value, false); }
+	// mgw
+	void addEnviromentCommands(in string[] value...) { add(enviromentCommands, value, false); }
+	//
 	void addRequirements(in BuildRequirement[] value...) { foreach (v; value) this.requirements |= v; }
 	void addRequirements(in BuildRequirements value) { this.requirements |= value; }
 	void addOptions(in BuildOption[] value...) { foreach (v; value) this.options |= v; }

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -63,7 +63,6 @@ struct BuildSettings {
 
 	void add(in BuildSettings bs)
 	{
-import std.stdio: writeln;
 		addDFlags(bs.dflags);
 		addLFlags(bs.lflags);
 		addLibs(bs.libs);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -499,6 +499,7 @@ class BuildGenerator : ProjectGenerator {
 
 	private void runTarget(Path exe_file_path, in BuildSettings buildsettings, string[] run_args, GeneratorSettings settings)
 	{
+import std.stdio: writeln;			
 		if (buildsettings.targetType == TargetType.executable) {
 			auto cwd = Path(getcwd());
 			auto runcwd = cwd;
@@ -520,11 +521,19 @@ class BuildGenerator : ProjectGenerator {
 					exe_path_string = ".\\" ~ exe_path_string;
 			}
 			logInfo("Running %s %s", exe_path_string, run_args.join(" "));
+			// mgw
+			// create ass.array for spawnProcess with enviroment
+			string[string] menv; 
+			foreach(v; buildsettings.enviromentCommands) {
+				auto m = split(v, "="); 
+				menv[strip(m[0])] = strip(m[1]); 
+			}
+			//
 			if (settings.runCallback) {
 				auto res = execute(exe_path_string ~ run_args);
 				settings.runCallback(res.status, res.output);
 			} else {
-				auto prg_pid = spawnProcess(exe_path_string ~ run_args);
+				auto prg_pid = spawnProcess(exe_path_string ~ run_args, menv);
 				auto result = prg_pid.wait();
 				enforce(result == 0, "Program exited with code "~to!string(result));
 			}

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -499,7 +499,6 @@ class BuildGenerator : ProjectGenerator {
 
 	private void runTarget(Path exe_file_path, in BuildSettings buildsettings, string[] run_args, GeneratorSettings settings)
 	{
-import std.stdio: writeln;			
 		if (buildsettings.targetType == TargetType.executable) {
 			auto cwd = Path(getcwd());
 			auto runcwd = cwd;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1107,6 +1107,9 @@ void processVars(ref BuildSettings dst, in Project project, in Package pack,
 	dst.addPostGenerateCommands(processVars(project, pack, settings.postGenerateCommands));
 	dst.addPreBuildCommands(processVars(project, pack, settings.preBuildCommands));
 	dst.addPostBuildCommands(processVars(project, pack, settings.postBuildCommands));
+	// mgw
+	dst.addEnviromentCommands(processVars(project, pack, settings.enviromentCommands));
+	//
 	dst.addRequirements(settings.requirements);
 	dst.addOptions(settings.options);
 

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -220,6 +220,11 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 			case "postGenerateCommands": bs.postGenerateCommands[suffix] = deserializeJson!(string[])(value); break;
 			case "preBuildCommands": bs.preBuildCommands[suffix] = deserializeJson!(string[])(value); break;
 			case "postBuildCommands": bs.postBuildCommands[suffix] = deserializeJson!(string[])(value); break;
+			// mgw
+			case "enviromentCommands": 
+				bs.enviromentCommands[suffix] = deserializeJson!(string[])(value); 
+				break;
+			//	
 			case "buildRequirements":
 				BuildRequirements reqs;
 				foreach (req; deserializeJson!(string[])(value))

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -157,6 +157,7 @@ struct BuildSettingsTemplate {
 	string[][string] postGenerateCommands;
 	string[][string] preBuildCommands;
 	string[][string] postBuildCommands;
+	string[][string] enviromentCommands; // mgw
 	BuildRequirements[string] buildRequirements;
 	BuildOptions[string] buildOptions;
 
@@ -221,6 +222,9 @@ struct BuildSettingsTemplate {
 		getPlatformSetting!("postGenerateCommands", "addPostGenerateCommands")(dst, platform);
 		getPlatformSetting!("preBuildCommands", "addPreBuildCommands")(dst, platform);
 		getPlatformSetting!("postBuildCommands", "addPostBuildCommands")(dst, platform);
+		// mgw
+		getPlatformSetting!("enviromentCommands", "addEnviromentCommands")(dst, platform);
+		//
 		getPlatformSetting!("buildRequirements", "addRequirements")(dst, platform);
 		getPlatformSetting!("buildOptions", "addOptions")(dst, platform);
 	}

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.0.0";
+enum dubVersion = "v1.1.0-beta.1-3-gc807a61";


### PR DESCRIPTION
I very need a possibility of installation of a envoroment variable for application  directly from dub. I suggest to consider a question of introduction of the following change for a possibility of setting enviroment variables from dub.

```
   . . .
    "configurations": [
        {
            "platforms": [  "linux" ],
            "workingDirectory": "exampleLinux",
            "name": "exampleLinux",
            "targetType": "executable",
            "targetName": "exampleLinux",
            "enviromentCommands": [
                "LD_LIBRARY_PATH=$PACKAGE_DIR/exampleLinux",
                "MY_VARIABLE=String",
            ],
            "targetPath": "exampleLinux",
            "mainSourceFile": "example/example.d"
        }
    ],
   . . .
```

I ask to consider this change. Without it there is no possibility of full application launch from dub.
