### PR TITLE
Fix collecting path based sub package + base package dependencies. Fixes #959.

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -224,7 +224,7 @@ class PackageManager {
 		foreach (p; getPackageIterator(base_package.name~":"~sub_name))
 			if (p.parentPackage is base_package)
 				return p;
-		enforce(silent_fail, "Sub package "~base_package.name~":"~sub_name~" doesn't exist.");
+		enforce(silent_fail, "Sub package \""~base_package.name~":"~sub_name~"\" doesn't exist.");
 		return null;
 	}
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -314,7 +314,8 @@ class Project {
 					auto idx = m_dependencies.countUntil!(d => getBasePackageName(d.name) == basename);
 					auto bp = m_dependencies[idx].basePackage;
 					vspec = Dependency(bp.path);
-					p = m_packageManager.getSubPackage(bp, subname, false);
+					if (subname.length) p = m_packageManager.getSubPackage(bp, subname, false);
+					else p = bp;
 				} else {
 					logDiagnostic("%sVersion selection for dependency %s (%s) of %s is missing.",
 						indent, basename, dep.name, pack.name);

--- a/test/issue959-path-based-subpack-dep/dub.sdl
+++ b/test/issue959-path-based-subpack-dep/dub.sdl
@@ -1,0 +1,6 @@
+name "bar"
+mainSourceFile "main.d"
+targetType "executable"
+
+dependency "foo" path="foo"
+dependency "foo:baz" path="foo"

--- a/test/issue959-path-based-subpack-dep/foo/dub.sdl
+++ b/test/issue959-path-based-subpack-dep/foo/dub.sdl
@@ -1,0 +1,8 @@
+name "foo"
+targetType "sourceLibrary"
+
+subPackage {
+    name "baz"
+    targetType "sourceLibrary"
+    dependency "foo"  path="."
+}

--- a/test/issue959-path-based-subpack-dep/main.d
+++ b/test/issue959-path-based-subpack-dep/main.d
@@ -1,0 +1,1 @@
+void main() {}


### PR DESCRIPTION
Having a sub package dependency followed by a dependency to the base package of the sub package incorrectly tried to obtain the base package as a sub package with an empty name.