### PR TITLE
Always use -singleobj when invoking LDC + drop -od/-oq switches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 matrix:
   include:
     - d: dmd-beta
-      env: [FRONTEND=2.071]
-    - d: dmd
+      env: [FRONTEND=2.072]
+    - d: dmd-2.071.2
       env: [FRONTEND=2.071]
     - d: dmd-2.070.2
       env: [FRONTEND=2.070]
@@ -21,6 +21,10 @@ matrix:
     - d: dmd-2.065.0
       env: [FRONTEND=2.065]
     - d: ldc
+    - d: ldc-1.1.0-beta3
+      env: [FRONTEND=2.071]
+    - d: ldc-1.0.0
+      env: [FRONTEND=2.070]
     - d: ldc-0.16.1
       env: [FRONTEND=2.067]
     - d: ldc-0.15.1

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -80,7 +80,7 @@ class LDCCompiler : Compiler {
 		}
 
 		// since LDC always outputs multiple object files, avoid conflicts by default
-		settings.addDFlags("-oq", "-od=.dub/obj");
+		settings.addDFlags("-singleobj");
 
 		if (!(fields & BuildSetting.versions)) {
 			settings.addDFlags(settings.versions.map!(s => "-d-version="~s)().array());

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -2,12 +2,6 @@
 
 set -v -e -o pipefail
 
-if [ -z "$FRONTEND" -o "$FRONTEND" \> 2.066.z ]; then
-    vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
-    dub fetch vibe-d --version=$vibe_ver # get optional dependency
-    dub test --compiler=${DC} -c library-nonet
-fi
-
 if [ "$COVERAGE" = true ]; then
     # library-nonet fails to build with coverage (Issue 13742)
     dub test --compiler=${DC} -b unittest-cov
@@ -15,9 +9,16 @@ if [ "$COVERAGE" = true ]; then
 else
     ./build.sh
 fi
+
+if [ -z "$FRONTEND" -o "$FRONTEND" \> 2.066.z ]; then
+    vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
+    ./bin/dub fetch vibe-d --version=$vibe_ver # get optional dependency
+    ./bin/dub test --compiler=${DC} -c library-nonet
+fi
+
 DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
 
 if [ "$COVERAGE" = true ]; then
-    dub fetch doveralls
-    dub run doveralls --compiler=${DC}
+    ./bin/dub fetch doveralls
+    ./bin/dub run doveralls --compiler=${DC}
 fi


### PR DESCRIPTION
See #938. This is also a workaround for ldc-developers/ldc#1819, but currently testing LDC 1.1.0-beta3 doesn't work through TravisCI, so this yet needs to get verified.
