### PR TITLE
Remove defaultlib for ldc shared libs

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -189,9 +189,7 @@ class LDCCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				version(Windows) settings.addDFlags("-shared");
-				else version(OSX) settings.addDFlags("-shared");
-				else settings.addDFlags("-shared", "-defaultlib=phobos2-ldc");
+				settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");


### PR DESCRIPTION
The reason why defaultlib is necessary for dmd is that dmd always chooses static phobos by default, unless you specify defaultlib. Because ldc doesn't do this, the defaultlib flag does nothing useful there and causes problems if the library is renamed on a particular distro.