### PR TITLE
Fix defaultlib

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -81,6 +81,7 @@ struct BuildSettings {
 	}
 
 	void addDFlags(in string[] value...) { dflags ~= value; }
+	void prependDFlags(in string[] value...) { prepend(dflags, value); }
 	void removeDFlags(in string[] value...) { remove(dflags, value); }
 	void addLFlags(in string[] value...) { lflags ~= value; }
 	void addLibs(in string[] value...) { add(libs, value); }

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -181,7 +181,7 @@ class DMDCompiler : Compiler {
 			case TargetType.dynamicLibrary:
 				version (Windows) settings.addDFlags("-shared");
 				else version (OSX) settings.addDFlags("-shared");
-				else settings.addDFlags("-shared", "-defaultlib=libphobos2.so");
+				else settings.prependDFlags("-shared", "-defaultlib=libphobos2.so");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -189,9 +189,7 @@ class LDCCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				version(Windows) settings.addDFlags("-shared");
-				else version(OSX) settings.addDFlags("-shared");
-				else settings.addDFlags("-shared", "-defaultlib=phobos2-ldc");
+				settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");


### PR DESCRIPTION
replaces https://github.com/dlang/dub/pull/977 and https://github.com/dlang/dub/pull/978

The reason why defaultlib is necessary for dmd is that dmd always chooses static phobos by default, unless you specify defaultlib. Because ldc doesn't do this, the defaultlib flag does nothing useful there and causes problems if the library is renamed on a particular distro.

if we add defaultlib, we should prepend it, because otherwise the user can't override it (the last one is used, all others are ignored)