### PR TITLE
rethink of caching and user/system repos

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -32,7 +32,7 @@ import std.getopt;
 import std.process;
 import std.stdio;
 import std.string;
-import std.typecons : Tuple, tuple;
+import std.typecons : Tuple, tuple, Nullable;
 import std.variant;
 
 
@@ -208,17 +208,28 @@ int runDubCommandLine(string[] args)
 
 	Dub dub;
 
+	void setRepoPath()
+	{
+		// only one can be true, because of check in CommonOptions.prepare
+		if (!options.repoLocation.isNull)
+			dub.defaultRepoPath = dub.toPath(options.repoLocation);
+		if (!options.repoPath.empty)
+			dub.defaultRepoPath = Path(options.repoPath);
+		if (!options.cacheLocation.isNull)
+			dub.defaultRepoPath = dub.toPath(options.cacheLocation);
+	}
+
 	// initialize the root package
 	if (!cmd.skipDubInitialization) {
 		if (options.bare) {
 			dub = new Dub(Path(getcwd()));
-			dub.defaultPlacementLocation = options.placementLocation;
+			setRepoPath();
 		} else {
 			// initialize DUB
 			auto package_suppliers = options.registry_urls.map!(url => cast(PackageSupplier)new RegistryPackageSupplier(URL(url))).array;
-			dub = new Dub(options.root_path, package_suppliers, options.skipRegistry);
+			dub = new Dub(Path(options.root_path), package_suppliers, options.skipRegistry, options.repoPath.empty ? [] : [Path(options.repoPath)]);
 			dub.dryRun = options.annotate;
-			dub.defaultPlacementLocation = options.placementLocation;
+			setRepoPath();
 
 			// make the CWD package available so that for example sub packages can reference their
 			// parent package.
@@ -251,7 +262,8 @@ struct CommonOptions {
 	string[] registry_urls;
 	string root_path;
 	SkipPackageSuppliers skipRegistry = SkipPackageSuppliers.none;
-	PlacementLocation placementLocation = PlacementLocation.user;
+	Nullable!PlacementLocation cacheLocation, repoLocation;
+	string repoPath;
 
 	/// Parses all common options and stores the result in the struct instance.
 	void prepare(CommandArgs args)
@@ -271,7 +283,26 @@ struct CommonOptions {
 		args.getopt("vverbose", &vverbose, ["Print debug output"]);
 		args.getopt("q|quiet", &quiet, ["Only print warnings and errors"]);
 		args.getopt("vquiet", &vquiet, ["Print no messages"]);
-		args.getopt("cache", &placementLocation, ["Puts any fetched packages in the specified location [local|system|user]."]);
+
+		string tmp = null;
+		args.getopt("cache", &tmp, ["Deprecated, please use --defaultRepo.",
+				"  Puts any fetched packages in the specified location [local|system|user].",
+				"  Has no effect on override/local/path listings.",
+				"  Conflicts with --defaultRepo and --defaultRepoPath"]);
+		if (tmp !is null) cacheLocation = tmp.to!PlacementLocation;
+
+		tmp = null;
+		args.getopt("defaultRepo", &tmp, ["Specifies the default respository for packages and override/local/path listings.",
+				"  Allowed values are [local|system|user]",
+				"  If specified, this path is used for storing newly fetched packages and adding/changing listings. All repos will still be searched for existing packages and listings.",
+				"  Conflicts with --cache and --defaultRepoPath"]);
+		if (tmp !is null) repoLocation = tmp.to!PlacementLocation;
+
+		args.getopt("defaultRepoPath", &repoPath, ["Similar to --defaultRepo, but allows a path to be specified for a custom repository.",
+				"  Conflicts with --defaultRepo and --cache"]);
+
+		enforce(int(!cacheLocation.isNull) + int(!repoLocation.isNull) + int(!repoPath.empty) < 2,
+				"Only one of --defaultRepo, --defaultRepoPath and --cache can be specified at once.");
 	}
 }
 
@@ -1295,11 +1326,10 @@ abstract class RegistrationCommand : Command {
 	private {
 		bool m_system;
 	}
-
 	override void prepare(scope CommandArgs args)
 	{
 		args.getopt("system", &m_system, [
-			"Register system-wide instead of user-wide"
+			"Deprecated, please use --defaultRepo=system. Register system-wide instead of user-wide. Overrides --defaultRepo and --defaultRepoPath"
 		]);
 	}
 
@@ -1327,7 +1357,7 @@ class AddPathCommand : RegistrationCommand {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		enforceUsage(free_args.length == 1, "Missing search path.");
-		dub.addSearchPath(free_args[0], m_system);
+		dub.addSearchPath(Path(free_args[0]), m_system ? dub.systemRepoPath : dub.defaultRepoPath);
 		return 0;
 	}
 }
@@ -1344,7 +1374,7 @@ class RemovePathCommand : RegistrationCommand {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		enforceUsage(free_args.length == 1, "Expected one argument.");
-		dub.removeSearchPath(free_args[0], m_system);
+		dub.removeSearchPath(Path(free_args[0]), m_system ? dub.systemRepoPath : dub.defaultRepoPath);
 		return 0;
 	}
 }
@@ -1368,7 +1398,7 @@ class AddLocalCommand : RegistrationCommand {
 	{
 		enforceUsage(free_args.length == 1 || free_args.length == 2, "Expecting one or two arguments.");
 		string ver = free_args.length == 2 ? free_args[1] : null;
-		dub.addLocalPackage(free_args[0], ver, m_system);
+		dub.addLocalPackage(Path(free_args[0]), ver, m_system ? dub.systemRepoPath : dub.defaultRepoPath);
 		return 0;
 	}
 }
@@ -1386,7 +1416,7 @@ class RemoveLocalCommand : RegistrationCommand {
 	{
 		enforceUsage(free_args.length >= 1, "Missing package path argument.");
 		enforceUsage(free_args.length <= 1, "Expected the package path to be the only argument.");
-		dub.removeLocalPackage(free_args[0], m_system);
+		dub.removeLocalPackage(Path(free_args[0]), m_system ? dub.systemRepoPath : dub.defaultRepoPath);
 		return 0;
 	}
 }
@@ -1480,7 +1510,7 @@ class AddOverrideCommand : Command {
 	override void prepare(scope CommandArgs args)
 	{
 		args.getopt("system", &m_system, [
-			"Register system-wide instead of user-wide"
+			"Deprecated, please use --defaultRepo=system. Register system-wide instead of user-wide. Overrides --defaultRepo and --defaultRepoPath"
 		]);
 	}
 
@@ -1488,16 +1518,17 @@ class AddOverrideCommand : Command {
 	{
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 		enforceUsage(free_args.length == 3, "Expected three arguments, not "~free_args.length.to!string);
-		auto scope_ = m_system ? LocalPackageType.system : LocalPackageType.user;
+		auto repoPath = m_system ? dub.systemRepoPath : dub.defaultRepoPath;
+
 		auto pack = free_args[0];
 		auto ver = Dependency(free_args[1]);
 		if (existsFile(Path(free_args[2]))) {
 			auto target = Path(free_args[2]);
-			dub.packageManager.addOverride(scope_, pack, ver, target);
+			dub.packageManager.addOverride(repoPath, pack, ver, target);
 			logInfo("Added override %s %s => %s", pack, ver, target);
 		} else {
 			auto target = Version(free_args[2]);
-			dub.packageManager.addOverride(scope_, pack, ver, target);
+			dub.packageManager.addOverride(repoPath, pack, ver, target);
 			logInfo("Added override %s %s => %s", pack, ver, target);
 		}
 		return 0;
@@ -1521,7 +1552,7 @@ class RemoveOverrideCommand : Command {
 	override void prepare(scope CommandArgs args)
 	{
 		args.getopt("system", &m_system, [
-			"Register system-wide instead of user-wide"
+			"Deprecated, please use --defaultRepo=system. Register system-wide instead of user-wide. Overrides --defaultRepo and --defaultRepoPath"
 		]);
 	}
 
@@ -1529,8 +1560,8 @@ class RemoveOverrideCommand : Command {
 	{
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 		enforceUsage(free_args.length == 2, "Expected two arguments, not "~free_args.length.to!string);
-		auto scope_ = m_system ? LocalPackageType.system : LocalPackageType.user;
-		dub.packageManager.removeOverride(scope_, free_args[0], Dependency(free_args[1]));
+		auto repoPath = m_system ? dub.systemRepoPath : dub.defaultRepoPath;
+		dub.packageManager.removeOverride(repoPath, free_args[0], Dependency(free_args[1]));
 		return 0;
 	}
 }
@@ -1557,8 +1588,8 @@ class ListOverridesCommand : Command {
 				else logInfo("%s %s => %s", ovr.package_, ovr.version_, ovr.targetVersion);
 			}
 		}
-		printList(dub.packageManager.getOverrides(LocalPackageType.user), "User wide overrides");
-		printList(dub.packageManager.getOverrides(LocalPackageType.system), "System wide overrides");
+		foreach (path; dub.packageManager.allRepoPaths)
+			printList(dub.packageManager.getOverrides(path), "Overrides from repo: " ~ path.toString);
 		return 0;
 	}
 }

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1176,7 +1176,7 @@ class FetchCommand : FetchRemoveCommand {
 		enforceUsage(free_args.length == 1, "Expecting exactly one argument.");
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
-		auto location = dub.defaultPlacementLocation;
+		auto location = dub.defaultRepoPath;
 
 		auto name = free_args[0];
 
@@ -1239,7 +1239,7 @@ class RemoveCommand : FetchRemoveCommand {
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
 		auto package_id = free_args[0];
-		auto location = dub.defaultPlacementLocation;
+		auto location = dub.defaultRepoPath;
 
 		size_t resolveVersion(in Package[] packages) {
 			// just remove only package version

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -88,7 +88,7 @@ interface Compiler {
 
 	/// Convert linker flags to compiler format
 	string[] lflagsToDFlags(in string[] lflags) const;
-	
+
 	/** Runs a tool and provides common boilerplate code.
 
 		This method should be used by `Compiler` implementations to invoke the

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -31,7 +31,7 @@ import std.datetime;
 import std.exception;
 import std.file;
 import std.process;
-import std.range : only;
+import std.range : chain, only;
 import std.string;
 import std.typecons;
 import std.zip;
@@ -148,7 +148,7 @@ class Dub {
 	}
 	/// ditto
 	this(Path root_path = Path("."), PackageSupplier[] additional_package_suppliers = null,
-			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none)
+			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none, Path[] extraRepoPaths = null)
 	{
 		m_rootPath = makeAbsoluteRelativeToCwd(root_path);
 
@@ -165,7 +165,8 @@ class Dub {
 			ps ~= defaultPackageSuppliers();
 
 		m_packageSuppliers = ps;
-		m_packageManager = new PackageManager(only(userRepoPath, systemRepoPath));
+		m_packageManager = new PackageManager(
+				chain(extraRepoPaths, only(userRepoPath, systemRepoPath)));
 		updatePackageSearchPath();
 	}
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -31,6 +31,7 @@ import std.datetime;
 import std.exception;
 import std.file;
 import std.process;
+import std.range : only;
 import std.string;
 import std.typecons;
 import std.zip;
@@ -97,6 +98,7 @@ class Dub {
 		Path m_projectPath;
 		Project m_project;
 		Path m_overrideSearchPath;
+		Path m_defaultRepoPath;
 		string m_defaultCompiler;
 	}
 
@@ -106,8 +108,22 @@ class Dub {
 		of the normal upgrade process are stored in a certain location. This is
 		how the "--local" and "--system" command line switches operate.
 	*/
-	PlacementLocation defaultPlacementLocation = PlacementLocation.user;
-
+	Path defaultRepoPath() @property
+	{
+		return m_defaultRepoPath;
+	}
+	/// Ditto
+	void defaultRepoPath(Path path) @property
+	{
+		path = makeAbsolute(path);
+		assert(m_packageManager.isManagedPath(path, false));
+		m_defaultRepoPath = path;
+	}
+	/// Ditto
+	deprecated defaultPlacementLocation(PlacementLocation location) @property
+	{
+		defaultRepoPath = toPath(location);
+	}
 
 	/** Initializes the instance for use with a specific root package.
 
@@ -141,7 +157,7 @@ class Dub {
 			ps ~= defaultPackageSuppliers();
 
 		m_packageSuppliers = ps;
-		m_packageManager = new PackageManager(m_dirs.userSettings, m_dirs.systemSettings);
+		m_packageManager = new PackageManager(only(userRepoPath, systemRepoPath));
 		updatePackageSearchPath();
 	}
 
@@ -149,13 +165,13 @@ class Dub {
 		loading a package.
 
 		This constructor corresponds to the "--bare" option of the command line
-		interface. Use 
+		interface. Use
 	*/
 	this(Path override_path)
 	{
 		init();
 		m_overrideSearchPath = override_path;
-		m_packageManager = new PackageManager(Path(), Path(), false);
+		m_packageManager = new PackageManager(cast(Path[])[], false);
 		updatePackageSearchPath();
 	}
 
@@ -172,6 +188,11 @@ class Dub {
 				m_dirs.userSettings = Path(getcwd()) ~ m_dirs.userSettings;
 		}
 
+		m_dirs.systemRepo = m_dirs.systemSettings ~ "packages/";
+		m_dirs.userRepo = m_dirs.userSettings ~ "packages/";
+
+		m_defaultRepoPath = m_dirs.userRepo;
+
 		m_dirs.temp = Path(tempDir);
 
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
@@ -179,6 +200,15 @@ class Dub {
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		determineDefaultCompiler();
+	}
+
+	Path toPath(PlacementLocation location) const
+	{
+		final switch (location) {
+			case PlacementLocation.local: return m_rootPath;
+			case PlacementLocation.user: return m_dirs.userRepo;
+			case PlacementLocation.system: return m_dirs.systemRepo;
+		}
 	}
 
 	@property void dryRun(bool v) { m_dryRun = v; }
@@ -192,6 +222,12 @@ class Dub {
 		m_rootPath = root_path;
 		if (!m_rootPath.absolute) m_rootPath = Path(getcwd()) ~ m_rootPath;
 	}
+
+	/// Returns the user repository path (e.g. ~/.dub/)
+	@property Path userRepoPath() const { return m_dirs.userRepo; }
+
+	/// Returns the system repository path
+	@property Path systemRepoPath() const { return m_dirs.systemRepo; }
 
 	/// Returns the name listed in the dub.json of the current
 	/// application.
@@ -243,7 +279,7 @@ class Dub {
 
 		Single-file packages are D files that contain a package receipe comment
 		at their top. A recipe comment must be a nested `/+ ... +/` style
-		comment, containing the virtual recipe file name and a colon, followed by the 
+		comment, containing the virtual recipe file name and a colon, followed by the
 		recipe contents (what would normally be in dub.sdl/dub.json).
 
 		Example:
@@ -435,7 +471,7 @@ class Dub {
 			FetchOptions fetchOpts;
 			fetchOpts |= (options & UpgradeOptions.preRelease) != 0 ? FetchOptions.usePrerelease : FetchOptions.none;
 			fetchOpts |= (options & UpgradeOptions.forceRemove) != 0 ? FetchOptions.forceRemove : FetchOptions.none;
-			if (!pack) fetch(p, ver, defaultPlacementLocation, fetchOpts, "getting selected version");
+			if (!pack) fetch(p, ver, defaultRepoPath, fetchOpts, "getting selected version");
 			if ((options & UpgradeOptions.select) && p != m_project.rootPackage.name) {
 				if (ver.path.empty) m_project.selections.selectVersion(p, ver.version_);
 				else {
@@ -614,8 +650,8 @@ class Dub {
 		if (existsFile(path ~ ".dub/obj")) rmdirRecurse((path ~ ".dub/obj").toNativeString());
 	}
 
-	/// Fetches the package matching the dependency and places it in the specified location.
-	Package fetch(string packageId, const Dependency dep, PlacementLocation location, FetchOptions options, string reason = "")
+	/// Fetches the package matching the dependency and places it in the specified repository
+	Package fetch(string packageId, const Dependency dep, Path repoPath, FetchOptions options, string reason = "")
 	{
 		Json pinfo;
 		PackageSupplier supplier;
@@ -632,16 +668,9 @@ class Dub {
 		enforce(pinfo.type != Json.Type.undefined, "No package "~packageId~" was found matching the dependency "~dep.toString());
 		string ver = pinfo["version"].get!string;
 
-		Path placement;
-		final switch (location) {
-			case PlacementLocation.local: placement = m_rootPath; break;
-			case PlacementLocation.user: placement = m_dirs.userSettings ~ "packages/"; break;
-			case PlacementLocation.system: placement = m_dirs.systemSettings ~ "packages/"; break;
-		}
-
 		// always upgrade branch based versions - TODO: actually check if there is a new commit available
 		Package existing;
-		try existing = m_packageManager.getPackage(packageId, ver, placement);
+		try existing = m_packageManager.getPackage(packageId, ver, repoPath);
 		catch (Exception e) {
 			logWarn("Failed to load existing package %s: %s", ver, e.msg);
 			logDiagnostic("Full error: %s", e.toString().sanitize);
@@ -655,10 +684,10 @@ class Dub {
 		}
 
 		if (existing) {
-			if (!ver.startsWith("~") || !(options & FetchOptions.forceBranchUpgrade) || location == PlacementLocation.local) {
+			if (!ver.startsWith("~") || !(options & FetchOptions.forceBranchUpgrade) || repoPath == rootPath) {
 				// TODO: support git working trees by performing a "git pull" instead of this
 				logDiagnostic("Package %s %s (%s) is already present with the latest version, skipping upgrade.",
-					packageId, ver, placement);
+					packageId, ver, repoPath);
 				return existing;
 			} else {
 				logInfo("Removing %s %s to prepare replacement with a new version.", packageId, ver);
@@ -674,9 +703,9 @@ class Dub {
 
 		auto clean_package_version = ver[ver.startsWith("~") ? 1 : 0 .. $];
 		clean_package_version = clean_package_version.replace("+", "_"); // + has special meaning for Optlink
-		if (!placement.existsFile())
-			mkdirRecurse(placement.toNativeString());
-		Path dstpath = placement ~ (packageId ~ "-" ~ clean_package_version);
+		if (!repoPath.existsFile())
+			mkdirRecurse(repoPath.toNativeString());
+		Path dstpath = repoPath ~ (packageId ~ "-" ~ clean_package_version);
 		if (!dstpath.existsFile())
 			mkdirRecurse(dstpath.toNativeString());
 
@@ -696,8 +725,13 @@ class Dub {
 		supplier.fetchPackage(path, packageId, dep, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
 		scope(exit) std.file.remove(path.toNativeString());
 
-		logDiagnostic("Placing to %s...", placement.toNativeString());
+		logDiagnostic("Placing to %s...", repoPath.toNativeString());
 		return m_packageManager.storeFetchedPackage(path, pinfo, dstpath);
+	}
+	/// ditto
+	deprecated Package fetch(string packageId, const Dependency dep, PlacementLocation location, FetchOptions options, string reason = "")
+	{
+		return fetch(packageId, dep, toPath(location), options, reason);
 	}
 
 	/** Removes a specific locally cached package.
@@ -727,17 +761,17 @@ class Dub {
 
 		Params:
 			package_id = Name of the package to be removed
-			location_ = Specifies the location to look for the given package
+			repoPath = Specifies the location to look for the given package
 				name/version.
 			force_remove = Forces removal of the package, even if untracked
 				files are found in its folder.
 			resolve_version = Callback to select package version.
 	*/
-	void remove(string package_id, PlacementLocation location, bool force_remove,
+	void remove(string package_id, Path repoPath, bool force_remove,
 				scope size_t delegate(in Package[] packages) resolve_version)
 	{
 		enforce(!package_id.empty);
-		if (location == PlacementLocation.local) {
+		if (repoPath == rootPath) {
 			logInfo("To remove a locally placed package, make sure you don't have any data"
 					~ "\nleft in it's directory and then simply remove the whole directory.");
 			throw new Exception("dub cannot remove locally installed packages.");
@@ -753,7 +787,7 @@ class Dub {
 		// Check validity of packages to be removed.
 		if(packages.empty) {
 			throw new Exception("Cannot find package to remove. ("
-				~ "id: '" ~ package_id ~ "', location: '" ~ to!string(location) ~ "'"
+				~ "id: '" ~ package_id ~ "', location: '" ~ to!string(repoPath) ~ "'"
 				~ ")");
 		}
 
@@ -774,6 +808,12 @@ class Dub {
 			}
 		}
 	}
+	deprecated void remove(string package_id, PlacementLocation location, bool force_remove,
+				scope size_t delegate(in Package[] packages) resolve_version)
+	{
+		remove(package_id, toPath(location), force_remove, resolve_version);
+	}
+
 
 	/** Removes a specific version of a package.
 
@@ -783,19 +823,19 @@ class Dub {
 				is passed, the package will be removed from the location, if
 				there is only one version retrieved. This will throw an
 				exception, if there are multiple versions retrieved.
-			location_ = Specifies the location to look for the given package
+			repoPath = Specifies the location to look for the given package
 				name/version.
 			force_remove = Forces removal of the package, even if untracked
 				files are found in its folder.
 	 */
-	void remove(string package_id, string version_, PlacementLocation location, bool force_remove)
+	void remove(string package_id, string version_, Path repoPath, bool force_remove)
 	{
-		remove(package_id, location, force_remove, (in packages) {
+		remove(package_id, repoPath, force_remove, (in packages) {
 			if (version_ == RemoveVersionWildcard)
 				return packages.length;
 			if (version_.empty && packages.length > 1) {
 				logError("Cannot remove package '" ~ package_id ~ "', there are multiple possibilities at location\n"
-						 ~ "'" ~ to!string(location) ~ "'.");
+						 ~ "'" ~ to!string(repoPath) ~ "'.");
 				logError("Available versions:");
 				foreach(pack; packages)
 					logError("  %s", pack.version_);
@@ -807,9 +847,13 @@ class Dub {
 					return i;
 			}
 			throw new Exception("Cannot find package to remove. ("
-				~ "id: '" ~ package_id ~ "', version: '" ~ version_ ~ "', location: '" ~ to!string(location) ~ "'"
+				~ "id: '" ~ package_id ~ "', version: '" ~ version_ ~ "', location: '" ~ to!string(repoPath) ~ "'"
 				~ ")");
 		});
+	}
+	deprecated void remove(string package_id, string version_, PlacementLocation location, bool force_remove)
+	{
+		remove(package_id, version_, toPath(location), force_remove);
 	}
 
 	/** Adds a directory to the list of locally known packages.
@@ -820,15 +864,21 @@ class Dub {
 			path = Path to the package
 			ver = Optional version to associate with the package (can be left
 				empty)
-			system = Make the package known system wide instead of user wide
-				(requires administrator privileges).
+			repoPath = location of the repository to be used, e.g. to use the default
+				user path, pass the `userRepoPath` property
 
 		See_Also: `removeLocalPackage`
 	*/
-	void addLocalPackage(string path, string ver, bool system)
+	void addLocalPackage(Path path, string ver, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.addLocalPackage(makeAbsolute(path), ver, system ? LocalPackageType.system : LocalPackageType.user);
+		m_packageManager.addLocalPackage(makeAbsolute(path), ver, repoPath);
+	}
+	/// override of addLocalPackage that takes the path as a string and a bool
+	/// to specify whether to use the system or user repository
+	deprecated void addLocalPackage(string path, string ver, bool system)
+	{
+		addLocalPackage(Path(path), ver, system ? systemRepoPath : userRepoPath);
 	}
 
 	/** Removes a directory from the list of locally known packages.
@@ -837,15 +887,21 @@ class Dub {
 
 		Params:
 			path = Path to the package
-			system = Make the package known system wide instead of user wide
-				(requires administrator privileges).
+			repoPath = location of the repository to be used, e.g. to use the default
+				user path, pass the `userRepoPath` property
 
 		See_Also: `addLocalPackage`
 	*/
-	void removeLocalPackage(string path, bool system)
+	void removeLocalPackage(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.removeLocalPackage(makeAbsolute(path), system ? LocalPackageType.system : LocalPackageType.user);
+		m_packageManager.removeLocalPackage(makeAbsolute(path), repoPath);
+	}
+	/// override of removeLocalPath that takes the path as a string and a bool
+	/// to specify whether to use the system or user repository
+	deprecated void removeLocalPackage(string path, bool system)
+	{
+		removeLocalPackage(Path(path), system ? systemRepoPath : userRepoPath);
 	}
 
 	/** Registers a local directory to search for packages to use for satisfying
@@ -853,31 +909,46 @@ class Dub {
 
 		Params:
 			path = Path to a directory containing package directories
-			system = Make the package known system wide instead of user wide
-				(requires administrator privileges).
+			repoPath = location of the repository to be used, e.g. to use the default
+				user path, pass the `userRepoPath` property
 
 		See_Also: `removeSearchPath`
 	*/
-	void addSearchPath(string path, bool system)
+	void addSearchPath(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.addSearchPath(makeAbsolute(path), system ? LocalPackageType.system : LocalPackageType.user);
+		m_packageManager.addSearchPath(makeAbsolute(path), repoPath);
+	}
+	/// override of addSearchPath that takes the path as a string and a bool
+	/// to specify whether to use the system or user repository
+	deprecated void addSearchPath(string path, bool system)
+	{
+		addSearchPath(Path(path), system ? systemRepoPath : userRepoPath);
 	}
 
 	/** Unregisters a local directory search path.
 
 		Params:
 			path = Path to a directory containing package directories
-			system = Make the package known system wide instead of user wide
-				(requires administrator privileges).
+			repoPath = location of the repository to be used, e.g. to use the default
+				user path, pass the `userRepoPath` property
 
 		See_Also: `addSearchPath`
 	*/
-	void removeSearchPath(string path, bool system)
+	void removeSearchPath(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.removeSearchPath(makeAbsolute(path), system ? LocalPackageType.system : LocalPackageType.user);
+		m_packageManager.removeSearchPath(makeAbsolute(path), repoPath);
 	}
+	/// override of addSearchPath that takes the path as a string and a bool
+	/// to specify whether to use the system or user repository
+	deprecated void removeSearchPath(string path, bool system)
+	{
+		removeSearchPath(Path(path), system ? systemRepoPath : userRepoPath);
+	}
+
+	/// override of addSearchPath that takes the path as a string and a bool
+	/// to specify whether to use the system or user repository
 
 	/** Queries all package suppliers with the given query string.
 
@@ -1031,7 +1102,7 @@ class Dub {
 		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("% is not present, getting and storing it user wide", tool);
-			tool_pack = fetch(tool, Dependency(">=0.0.0"), defaultPlacementLocation, FetchOptions.none);
+			tool_pack = fetch(tool, Dependency(">=0.0.0"), defaultRepoPath, FetchOptions.none);
 		}
 
 		auto ddox_dub = new Dub(null, m_packageSuppliers);
@@ -1075,7 +1146,7 @@ class Dub {
 	private void updatePackageSearchPath()
 	{
 		if (m_overrideSearchPath.length) {
-			m_packageManager.disableDefaultSearchPaths = true;
+			m_packageManager.disableRepoSearchPaths = true;
 			m_packageManager.searchPath = [m_overrideSearchPath];
 		} else {
 			auto p = environment.get("DUBPATH");
@@ -1084,7 +1155,7 @@ class Dub {
 			version(Windows) enum pathsep = ";";
 			else enum pathsep = ":";
 			if (p.length) paths ~= p.split(pathsep).map!(p => Path(p))().array();
-			m_packageManager.disableDefaultSearchPaths = false;
+			m_packageManager.disableRepoSearchPaths = false;
 			m_packageManager.searchPath = paths;
 		}
 	}
@@ -1357,7 +1428,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 					FetchOptions fetchOpts;
 					fetchOpts |= prerelease ? FetchOptions.usePrerelease : FetchOptions.none;
 					fetchOpts |= (m_options & UpgradeOptions.forceRemove) != 0 ? FetchOptions.forceRemove : FetchOptions.none;
-					m_dub.fetch(rootpack, dep, m_dub.defaultPlacementLocation, fetchOpts, "need sub package description");
+					m_dub.fetch(rootpack, dep, m_dub.defaultRepoPath, fetchOpts, "need sub package description");
 					auto ret = m_dub.m_packageManager.getBestPackage(name, dep);
 					if (!ret) {
 						logWarn("Package %s %s doesn't have a sub package %s", rootpack, dep.version_, name);
@@ -1383,6 +1454,8 @@ private struct SpecialDirs {
 	Path temp;
 	Path userSettings;
 	Path systemSettings;
+	Path userRepo;
+	Path systemRepo;
 }
 
 private class DubConfig {

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -107,6 +107,8 @@ class Dub {
 		This property can be altered, so that packages which are downloaded as part
 		of the normal upgrade process are stored in a certain location. This is
 		how the "--local" and "--system" command line switches operate.
+
+		If it is relative, it is resolved relative to the current working directory
 	*/
 	Path defaultRepoPath() @property
 	{
@@ -115,8 +117,8 @@ class Dub {
 	/// Ditto
 	void defaultRepoPath(Path path) @property
 	{
-		path = makeAbsolute(path);
-		assert(m_packageManager.isManagedPath(path, false));
+		path = makeAbsoluteRelativeToCwd(path);
+		//assert(m_packageManager.isManagedPath(path, false), path.toNativeString);
 		m_defaultRepoPath = path;
 	}
 	/// Ditto
@@ -131,18 +133,24 @@ class Dub {
 		`loadPackage` overloads.
 
 		Params:
-			root_path = Path to the root package
+			root_path = Path to the root package. If relative, it will be resolved
+				relative to the current working directory.
 			additional_package_suppliers = A list of package suppliers to try
 				before the suppliers found in the configurations files and the
 				`defaultPackageSuppliers`.
 			skip_registry = Can be used to skip using the configured package
 				suppliers, as well as the default suppliers.
 	*/
-	this(string root_path = ".", PackageSupplier[] additional_package_suppliers = null,
+	this(string root_path, PackageSupplier[] additional_package_suppliers = null,
 			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none)
 	{
-		m_rootPath = Path(root_path);
-		if (!m_rootPath.absolute) m_rootPath = Path(getcwd()) ~ m_rootPath;
+		this(Path(root_path), additional_package_suppliers, skip_registry);
+	}
+	/// ditto
+	this(Path root_path = Path("."), PackageSupplier[] additional_package_suppliers = null,
+			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none)
+	{
+		m_rootPath = makeAbsoluteRelativeToCwd(root_path);
 
 		init();
 
@@ -165,12 +173,15 @@ class Dub {
 		loading a package.
 
 		This constructor corresponds to the "--bare" option of the command line
-		interface. Use
+		interface.
+
+		If override_path is relative, it is resolved relative to the current working
+		directory
 	*/
-	this(Path override_path)
+	this(Path overridePath)
 	{
 		init();
-		m_overrideSearchPath = override_path;
+		m_overrideSearchPath = makeAbsoluteRelativeToCwd(overridePath);
 		m_packageManager = new PackageManager(cast(Path[])[], false);
 		updatePackageSearchPath();
 	}
@@ -183,9 +194,8 @@ class Dub {
 			m_dirs.userSettings = Path(environment.get("APPDATA")) ~ "dub/";
 		} else version(Posix){
 			m_dirs.systemSettings = Path("/var/lib/dub/");
-			m_dirs.userSettings = Path(environment.get("HOME")) ~ ".dub/";
-			if (!m_dirs.userSettings.absolute)
-				m_dirs.userSettings = Path(getcwd()) ~ m_dirs.userSettings;
+			m_dirs.userSettings = makeAbsoluteRelativeToCwd(
+					Path(environment.get("HOME")) ~ ".dub/");
 		}
 
 		m_dirs.systemRepo = m_dirs.systemSettings ~ "packages/";
@@ -216,11 +226,10 @@ class Dub {
 	/** Returns the root path (usually the current working directory).
 	*/
 	@property Path rootPath() const { return m_rootPath; }
-	/// ditto
+	/// Sets the root path. If relative, resolved relative to the current working directory.
 	@property void rootPath(Path root_path)
 	{
-		m_rootPath = root_path;
-		if (!m_rootPath.absolute) m_rootPath = Path(getcwd()) ~ m_rootPath;
+		m_rootPath = makeAbsoluteRelativeToCwd(root_path);
 	}
 
 	/// Returns the user repository path (e.g. ~/.dub/)
@@ -260,9 +269,10 @@ class Dub {
 	}
 
 	/// Loads the package from the specified path as the main project package.
+	/// If path is relative, it is resolved relative to the current working directory
 	void loadPackage(Path path)
 	{
-		m_projectPath = path;
+		m_projectPath = makeAbsoluteRelativeToCwd(path);
 		updatePackageSearchPath();
 		m_project = new Project(m_packageManager, m_projectPath);
 	}
@@ -276,6 +286,8 @@ class Dub {
 	}
 
 	/** Loads a single file package.
+
+		If path is relative it is resolved relative to the root path
 
 		Single-file packages are D files that contain a package receipe comment
 		at their top. A recipe comment must be a nested `/+ ... +/` style
@@ -310,7 +322,7 @@ class Dub {
 		import dub.recipe.io : parsePackageRecipe;
 		import std.file : mkdirRecurse, readText;
 
-		path = makeAbsolute(path);
+		path = makeAbsoluteRelativeToRoot(path);
 
 		string file_content = readText(path.toNativeString());
 
@@ -357,12 +369,12 @@ class Dub {
 	}
 
 	/** Disables the default search paths and only searches a specific directory
-		for packages.
+		for packages. Relative paths are resolved relative to the current working
+		directory
 	*/
 	void overrideSearchPath(Path path)
 	{
-		if (!path.absolute) path = Path(getcwd()) ~ path;
-		m_overrideSearchPath = path;
+		m_overrideSearchPath = makeAbsoluteRelativeToCwd(path);
 		updatePackageSearchPath();
 	}
 
@@ -384,7 +396,7 @@ class Dub {
 				auto dep = m_project.selections.getSelectedVersion(p);
 				if (!dep.path.empty) {
 					auto path = dep.path;
-					if (!path.absolute) path = this.rootPath ~ path;
+					path = makeAbsoluteRelativeToRoot(path);
 					try if (m_packageManager.getOrLoadPackage(path)) continue;
 					catch (Exception e) { logDebug("Failed to load path based selection: %s", e.toString().sanitize); }
 				} else {
@@ -502,10 +514,12 @@ class Dub {
 	/** Executes tests on the current project.
 
 		Throws an exception, if unittests failed.
+
+		If it is a relative path, custom_main_file is resolved relative to the current working directory
 	*/
 	void testProject(GeneratorSettings settings, string config, Path custom_main_file)
 	{
-		if (custom_main_file.length && !custom_main_file.absolute) custom_main_file = getWorkingDirectory() ~ custom_main_file;
+		if (custom_main_file.length) custom_main_file = makeAbsoluteRelativeToCwd(custom_main_file);
 
 		if (config.length == 0) {
 			// if a custom main file was given, favor the first library configuration, so that it can be applied
@@ -638,9 +652,11 @@ class Dub {
 		if (delimiter != "\0\0") writeln();
 	}
 
-	/// Cleans intermediate/cache files of the given package
+	/// Cleans intermediate/cache files of the given package.
+	/// Relative paths are resolved relative to the current working directory.
 	void cleanPackage(Path path)
 	{
+		path = makeAbsoluteRelativeToCwd(path);
 		logInfo("Cleaning package at %s...", path.toNativeString());
 		enforce(!Package.findPackageFile(path).empty, "No package found.", path.toNativeString());
 
@@ -651,8 +667,10 @@ class Dub {
 	}
 
 	/// Fetches the package matching the dependency and places it in the specified repository
+	/// Relative repoPaths are resolved relative to the current working directory
 	Package fetch(string packageId, const Dependency dep, Path repoPath, FetchOptions options, string reason = "")
 	{
+		repoPath = makeAbsoluteRelativeToCwd(repoPath);
 		Json pinfo;
 		PackageSupplier supplier;
 		foreach(ps; m_packageSuppliers){
@@ -684,7 +702,10 @@ class Dub {
 		}
 
 		if (existing) {
-			if (!ver.startsWith("~") || !(options & FetchOptions.forceBranchUpgrade) || repoPath == rootPath) {
+			repoPath.normalize();
+			auto rootNormalized = rootPath;
+			rootNormalized.normalize();
+			if (!ver.startsWith("~") || !(options & FetchOptions.forceBranchUpgrade) || repoPath == rootNormalized) {
 				// TODO: support git working trees by performing a "git pull" instead of this
 				logDiagnostic("Package %s %s (%s) is already present with the latest version, skipping upgrade.",
 					packageId, ver, repoPath);
@@ -762,7 +783,8 @@ class Dub {
 		Params:
 			package_id = Name of the package to be removed
 			repoPath = Specifies the location to look for the given package
-				name/version.
+				name/version. Relative paths are resolved relative to the
+				current working directory.
 			force_remove = Forces removal of the package, even if untracked
 				files are found in its folder.
 			resolve_version = Callback to select package version.
@@ -771,7 +793,12 @@ class Dub {
 				scope size_t delegate(in Package[] packages) resolve_version)
 	{
 		enforce(!package_id.empty);
-		if (repoPath == rootPath) {
+
+		auto rootNormalized = rootPath;
+		rootNormalized.normalize();
+		repoPath = makeAbsoluteRelativeToCwd(repoPath);
+		repoPath.normalize();
+		if (repoPath == rootNormalized) {
 			logInfo("To remove a locally placed package, make sure you don't have any data"
 					~ "\nleft in it's directory and then simply remove the whole directory.");
 			throw new Exception("dub cannot remove locally installed packages.");
@@ -824,7 +851,8 @@ class Dub {
 				there is only one version retrieved. This will throw an
 				exception, if there are multiple versions retrieved.
 			repoPath = Specifies the location to look for the given package
-				name/version.
+				name/version. Relative paths are resolved relative to the current
+				working directory.
 			force_remove = Forces removal of the package, even if untracked
 				files are found in its folder.
 	 */
@@ -861,18 +889,21 @@ class Dub {
 		Forwards to `PackageManager.addLocalPackage`.
 
 		Params:
-			path = Path to the package
+			path = Path to the package. Relative paths are resolved relative to
+				the root package directory
 			ver = Optional version to associate with the package (can be left
 				empty)
 			repoPath = location of the repository to be used, e.g. to use the default
-				user path, pass the `userRepoPath` property
+				user path, pass the `userRepoPath` property. Relative paths are resolved
+				relative to the current working directory
 
 		See_Also: `removeLocalPackage`
 	*/
 	void addLocalPackage(Path path, string ver, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.addLocalPackage(makeAbsolute(path), ver, repoPath);
+		m_packageManager.addLocalPackage(makeAbsoluteRelativeToRoot(path), ver,
+				makeAbsoluteRelativeToCwd(repoPath));
 	}
 	/// override of addLocalPackage that takes the path as a string and a bool
 	/// to specify whether to use the system or user repository
@@ -886,16 +917,18 @@ class Dub {
 		Forwards to `PackageManager.removeLocalPackage`.
 
 		Params:
-			path = Path to the package
+			path = Path to the package. Relative paths are resolved relative to
+				the root package directory
 			repoPath = location of the repository to be used, e.g. to use the default
-				user path, pass the `userRepoPath` property
+				user path, pass the `userRepoPath` property. Relative paths are resolved
+				relative to the current working directory.
 
 		See_Also: `addLocalPackage`
 	*/
 	void removeLocalPackage(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.removeLocalPackage(makeAbsolute(path), repoPath);
+		m_packageManager.removeLocalPackage(makeAbsoluteRelativeToRoot(path), repoPath);
 	}
 	/// override of removeLocalPath that takes the path as a string and a bool
 	/// to specify whether to use the system or user repository
@@ -908,16 +941,20 @@ class Dub {
 		dependencies.
 
 		Params:
-			path = Path to a directory containing package directories
+			path = Path to a directory containing package directories. Relative paths
+				are resolved relative to the root package directory
 			repoPath = location of the repository to be used, e.g. to use the default
-				user path, pass the `userRepoPath` property
+				user path, pass the `userRepoPath` property. Relative paths are resolved
+				relative to the current working directory.
+
 
 		See_Also: `removeSearchPath`
 	*/
 	void addSearchPath(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.addSearchPath(makeAbsolute(path), repoPath);
+		m_packageManager.addSearchPath(makeAbsoluteRelativeToRoot(path),
+				makeAbsoluteRelativeToCwd(repoPath));
 	}
 	/// override of addSearchPath that takes the path as a string and a bool
 	/// to specify whether to use the system or user repository
@@ -929,16 +966,19 @@ class Dub {
 	/** Unregisters a local directory search path.
 
 		Params:
-			path = Path to a directory containing package directories
+			path = Path to a directory containing package directories. Relative paths
+				are resolved relative to the root package directory
 			repoPath = location of the repository to be used, e.g. to use the default
-				user path, pass the `userRepoPath` property
+				user path, pass the `userRepoPath` property. Relative paths are resolved
+				relative to the current working directory.
 
 		See_Also: `addSearchPath`
 	*/
 	void removeSearchPath(Path path, Path repoPath)
 	{
 		if (m_dryRun) return;
-		m_packageManager.removeSearchPath(makeAbsolute(path), repoPath);
+		m_packageManager.removeSearchPath(makeAbsoluteRelativeToRoot(path),
+				makeAbsoluteRelativeToCwd(repoPath));
 	}
 	/// override of addSearchPath that takes the path as a string and a bool
 	/// to specify whether to use the system or user repository
@@ -1011,7 +1051,8 @@ class Dub {
 
 		Params:
 			path = Path of the directory to create the new package in. The
-				directory will be created if it doesn't exist.
+				directory will be created if it doesn't exist. Relative paths
+				will be resolved relative to the root package directory
 			deps = List of dependencies to add to the package recipe.
 			type = Specifies the type of the application skeleton to use.
 			format = Determines the package recipe format to use.
@@ -1022,8 +1063,7 @@ class Dub {
 		PackageFormat format = PackageFormat.sdl,
 		scope void delegate(ref PackageRecipe, ref PackageFormat) recipe_callback = null)
 	{
-		if (!path.absolute) path = m_rootPath ~ path;
-		path.normalize();
+		path = makeAbsoluteRelativeToRoot(path);
 
 		string[string] depVers;
 		string[] notFound; // keep track of any failed packages in here
@@ -1149,14 +1189,13 @@ class Dub {
 			m_packageManager.disableRepoSearchPaths = true;
 			m_packageManager.searchPath = [m_overrideSearchPath];
 		} else {
-			auto p = environment.get("DUBPATH");
-			Path[] paths;
-
 			version(Windows) enum pathsep = ";";
 			else enum pathsep = ":";
-			if (p.length) paths ~= p.split(pathsep).map!(p => Path(p))().array();
+			m_packageManager.searchPath = environment.get("DUBPATH")
+				.splitter(pathsep)
+				.map!(p => makeAbsoluteRelativeToCwd(Path(p)))
+				.array;
 			m_packageManager.disableRepoSearchPaths = false;
-			m_packageManager.searchPath = paths;
 		}
 	}
 
@@ -1177,8 +1216,9 @@ class Dub {
 		m_defaultCompiler = res.empty ? compilers[0] : res.front;
 	}
 
-	private Path makeAbsolute(Path p) const { return p.absolute ? p : m_rootPath ~ p; }
-	private Path makeAbsolute(string p) const { return makeAbsolute(Path(p)); }
+	private Path makeAbsoluteRelativeToRoot(Path p) const { return p.absolute ? p : m_rootPath ~ p; }
+	private Path makeAbsoluteRelativeToRoot(string p) const { return makeAbsoluteRelativeToRoot(Path(p)); }
+	private static Path makeAbsoluteRelativeToCwd(Path p) { return p.absolute ? p : getWorkingDirectory() ~ p; }
 }
 
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -742,12 +742,12 @@ class Dub {
 			return m_packageManager.getPackage(packageId, ver, dstpath);
 		}
 
-		auto path = getTempFile(packageId, ".zip");
-		supplier.fetchPackage(path, packageId, dep, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
-		scope(exit) std.file.remove(path.toNativeString());
+		auto zipPath = getTempFile(packageId, ".zip");
+		supplier.fetchPackage(zipPath, packageId, dep, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
+		scope(exit) std.file.remove(zipPath.toNativeString());
 
 		logDiagnostic("Placing to %s...", repoPath.toNativeString());
-		return m_packageManager.storeFetchedPackage(path, pinfo, dstpath);
+		return m_packageManager.storeFetchedPackage(zipPath, pinfo, dstpath);
 	}
 	/// ditto
 	deprecated Package fetch(string packageId, const Dependency dep, PlacementLocation location, FetchOptions options, string reason = "")

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -58,6 +58,11 @@ class PackageManager {
 		if (refresh_packages) refresh(true);
 	}
 
+	Path[] allRepoPaths() @property
+	{
+		return m_repos.keys;
+	}
+
 	/** Gets/sets the list of paths to search for local packages.
 	*/
 	@property void searchPath(const(Path)[] paths)

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -15,7 +15,7 @@ import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
 import dub.package_;
 
-import std.algorithm : countUntil, filter, sort, canFind, remove;
+import std.algorithm : countUntil, filter, sort, canFind, remove, all;
 import std.array;
 import std.conv;
 import std.encoding : sanitize;
@@ -47,9 +47,14 @@ class PackageManager {
 
 	this(R)(R repo_paths, bool refresh_packages = true)
 	if (isInputRange!R && is(typeof(Repository(repo_paths.front))))
+	in { assert(repo_paths.all!(p => p.absolute )); }
+	body
 	{
 		foreach (path; repo_paths)
+		{
+			path.normalize();
 			m_repos[path] = Repository(path);
+		}
 		if (refresh_packages) refresh(true);
 	}
 
@@ -255,7 +260,11 @@ class PackageManager {
 		folders to be matched
 	*/
 	bool isManagedPath(Path path, bool allowSubDirs = true)
-	const {
+	const
+	in { assert(path.absolute); }
+	body
+	{
+		path.normalize();
 		if (allowSubDirs) {
 			foreach (rep; m_repos) {
 				auto rpath = rep.packagePath;
@@ -315,11 +324,14 @@ class PackageManager {
 	*/
 	deprecated const(PackageOverride)[] getOverrides(LocalPackageType scope_)
 	{
-		return m_repos[m_defaultPaths[scope_]].getOverrides();
+		return getOverrides(m_defaultPaths[scope_]);
 	}
 	/// ditto
 	const(PackageOverride)[] getOverrides(Path repoPath)
+	in { assert(repoPath.absolute); }
+	body
 	{
+		repoPath.normalize();
 		return m_repos[repoPath].getOverrides();
 	}
 
@@ -327,34 +339,43 @@ class PackageManager {
 	*/
 	deprecated void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Version target)
 	{
-		m_repos[m_defaultPaths[scope_]].addOverride(package_, version_spec, target);
+		addOverride(m_defaultPaths[scope_], package_, version_spec, target);
 	}
 	/// ditto
 	deprecated void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Path target)
 	{
-		m_repos[m_defaultPaths[scope_]].addOverride(package_, version_spec, target);
+		addOverride(m_defaultPaths[scope_], package_, version_spec, target);
 	}
 	/// ditto
-	void addOverride(Path path, string package_, Dependency version_spec, Version target)
+	void addOverride(Path repoPath, string package_, Dependency version_spec, Version target)
+	in { assert(repoPath.absolute); }
+	body
 	{
-		m_repos[path].addOverride(package_, version_spec, target);
+		repoPath.normalize();
+		m_repos[repoPath].addOverride(package_, version_spec, target);
 	}
 	/// ditto
-	void addOverride(Path path, string package_, Dependency version_spec, Path target)
+	void addOverride(Path repoPath, string package_, Dependency version_spec, Path target)
+	in { assert(repoPath.absolute); }
+	body
 	{
-		m_repos[path].addOverride(package_, version_spec, target);
+		repoPath.normalize();
+		m_repos[repoPath].addOverride(package_, version_spec, target);
 	}
 
 	/** Removes an existing package override.
 	*/
 	deprecated void removeOverride(LocalPackageType scope_, string package_, Dependency version_spec)
 	{
-		m_repos[m_defaultPaths[scope_]].removeOverride(package_, version_spec);
+		removeOverride(m_defaultPaths[scope_], package_, version_spec);
 	}
 	/// ditto
-	void removeOverride(Path path, string package_, Dependency version_spec)
+	void removeOverride(Path repoPath, string package_, Dependency version_spec)
+	in { assert(repoPath.absolute); }
+	body
 	{
-		m_repos[path].removeOverride(package_, version_spec);
+		repoPath.normalize();
+		m_repos[repoPath].removeOverride(package_, version_spec);
 	}
 
 	/// Extracts the package supplied as a path to it's zip file to the
@@ -470,41 +491,53 @@ class PackageManager {
 
 	deprecated Package addLocalPackage(Path path, string verName, LocalPackageType type)
 	{
-		return m_repos[m_defaultPaths[type]].addLocalPackage(path, verName);
+		return addLocalPackage(path, verName, m_defaultPaths[type]);
 	}
 	Package addLocalPackage(Path path, string verName, Path repoPath)
-	{
+	in { assert(repoPath.absolute); }
+	body
+{
+		repoPath.normalize();
 		return m_repos[repoPath].addLocalPackage(path, verName);
 	}
 
 	deprecated void removeLocalPackage(Path path, LocalPackageType type)
 	{
-		m_repos[m_defaultPaths[type]].removeLocalPackage(path);
+		removeLocalPackage(path, m_defaultPaths[type]);
 	}
 	void removeLocalPackage(Path path, Path repoPath)
+	in { assert(repoPath.absolute); }
+	body
 	{
+		repoPath.normalize();
 		m_repos[repoPath].removeLocalPackage(path);
 	}
 
 	/// For the given type add another path where packages will be looked up.
 	deprecated void addSearchPath(Path path, LocalPackageType type)
 	{
-		m_repos[m_defaultPaths[type]].addSearchPath(path);
+		addSearchPath(path, m_defaultPaths[type]);
 	}
 	/// ditto
 	void addSearchPath(Path path, Path repoPath)
+	in { assert(repoPath.absolute); }
+	body
 	{
+		repoPath.normalize();
 		m_repos[repoPath].addSearchPath(path);
 	}
 
 	/// Removes a search path from the given type.
 	deprecated void removeSearchPath(Path path, LocalPackageType type)
 	{
-		m_repos[m_defaultPaths[type]].removeSearchPath(path);
+		removeSearchPath(path, m_defaultPaths[type]);
 	}
 	/// ditto
 	void removeSearchPath(Path path, Path repoPath)
+	in { assert(repoPath.absolute); }
+	body
 	{
+		repoPath.normalize();
 		m_repos[repoPath].removeSearchPath(path);
 	}
 
@@ -691,7 +724,7 @@ private struct Repository {
 		this.packagePath = path;
 	}
 
-	private void writeLocalPackageOverridesFile()
+	void writeLocalPackageOverridesFile()
 	{
 		Json[] newlist;
 		foreach (ovr; overrides) {
@@ -706,7 +739,7 @@ private struct Repository {
 		writeJsonFile(packagePath ~ LocalOverridesFilename, Json(newlist));
 	}
 
-	private void writeLocalPackageList()
+	void writeLocalPackageList()
 	{
 		Json[] newlist;
 		foreach (p; searchPath) {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -250,15 +250,22 @@ class PackageManager {
 
 		By default, managed folders are "~/.dub/packages" and
 		"/var/lib/dub/packages".
+
+		Passing allowSubDirs = true will cause only the roots of the managed
+		folders to be matched
 	*/
-	bool isManagedPath(Path path)
+	bool isManagedPath(Path path, bool allowSubDirs = true)
 	const {
-		foreach (rep; m_repos) {
-			auto rpath = rep.packagePath;
-			if (path.startsWith(rpath))
-				return true;
+		if (allowSubDirs) {
+			foreach (rep; m_repos) {
+				auto rpath = rep.packagePath;
+				if (path.startsWith(rpath))
+					return true;
+			}
+			return false;
 		}
-		return false;
+		else
+			return !!(path in m_repos);
 	}
 
 	/** Enables iteration over all known local packages.
@@ -674,7 +681,6 @@ private enum LocalOverridesFilename = "local-overrides.json";
 
 
 private struct Repository {
-	Path path;
 	Path packagePath;
 	Path[] searchPath;
 	Package[] localPackages;
@@ -682,8 +688,7 @@ private struct Repository {
 
 	this(Path path)
 	{
-		this.path = path;
-		this.packagePath = path ~ "packages/";
+		this.packagePath = path;
 	}
 
 	private void writeLocalPackageOverridesFile()

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -18,10 +18,10 @@ import dub.package_;
 import std.algorithm : countUntil, filter, sort, canFind, remove;
 import std.array;
 import std.conv;
-import std.digest.sha;
 import std.encoding : sanitize;
 import std.exception;
 import std.file;
+import std.range : only, isInputRange;
 import std.string;
 import std.zip;
 
@@ -30,23 +30,32 @@ import std.zip;
 /// packages.
 class PackageManager {
 	private {
-		Repository[LocalPackageType] m_repositories;
+		Repository[Path] m_repos;
+		Path[LocalPackageType] m_defaultPaths; // only to support deprecated API
 		Path[] m_searchPath;
 		Package[] m_packages;
 		Package[] m_temporaryPackages;
-		bool m_disableDefaultSearchPaths = false;
+		bool m_disableRepoSearchPaths = false;
 	}
 
-	this(Path user_path, Path system_path, bool refresh_packages = true)
+	deprecated this(Path user_path, Path system_path, bool refresh_packages = true)
 	{
-		m_repositories[LocalPackageType.user] = Repository(user_path);
-		m_repositories[LocalPackageType.system] = Repository(system_path);
+		m_defaultPaths[LocalPackageType.user] = user_path;
+		m_defaultPaths[LocalPackageType.system] = system_path;
+		this(only(user_path, system_path), refresh_packages);
+	}
+
+	this(R)(R repo_paths, bool refresh_packages = true)
+	if (isInputRange!R && is(typeof(Repository(repo_paths.front))))
+	{
+		foreach (path; repo_paths)
+			m_repos[path] = Repository(path);
 		if (refresh_packages) refresh(true);
 	}
 
 	/** Gets/sets the list of paths to search for local packages.
 	*/
-	@property void searchPath(Path[] paths)
+	@property void searchPath(const(Path)[] paths)
 	{
 		if (paths == m_searchPath) return;
 		m_searchPath = paths.dup;
@@ -55,12 +64,14 @@ class PackageManager {
 	/// ditto
 	@property const(Path)[] searchPath() const { return m_searchPath; }
 
+	deprecated alias disableDefaultSearchPaths = disableRepoSearchPaths;
+
 	/** Disables searching DUB's predefined search paths.
 	*/
-	@property void disableDefaultSearchPaths(bool val)
+	@property void disableRepoSearchPaths(bool val)
 	{
-		if (val == m_disableDefaultSearchPaths) return;
-		m_disableDefaultSearchPaths = val;
+		if (val == m_disableRepoSearchPaths) return;
+		m_disableRepoSearchPaths = val;
 		refresh(true);
 	}
 
@@ -70,15 +81,14 @@ class PackageManager {
 	const {
 		auto ret = appender!(Path[])();
 		ret.put(m_searchPath);
-		if (!m_disableDefaultSearchPaths) {
-			ret.put(m_repositories[LocalPackageType.user].searchPath);
-			ret.put(m_repositories[LocalPackageType.user].packagePath);
-			ret.put(m_repositories[LocalPackageType.system].searchPath);
-			ret.put(m_repositories[LocalPackageType.system].packagePath);
+		if (!m_disableRepoSearchPaths) {
+			foreach (repo; m_repos) {
+				ret.put(repo.searchPath);
+				ret.put(repo.packagePath);
+			}
 		}
 		return ret.data;
 	}
-
 
 	/** Looks up a specific package.
 
@@ -99,9 +109,9 @@ class PackageManager {
 	*/
 	Package getPackage(string name, Version ver, bool enable_overrides = true)
 	{
-		if (enable_overrides) {
-			foreach (tp; [LocalPackageType.user, LocalPackageType.system])
-				foreach (ovr; m_repositories[tp].overrides)
+		if (enable_overrides)
+			foreach (repo; m_repos)
+				foreach (ovr; repo.overrides)
 					if (ovr.package_ == name && ovr.version_.matches(ver)) {
 						Package pack;
 						if (!ovr.targetPath.empty) pack = getPackage(name, ovr.targetPath);
@@ -111,7 +121,6 @@ class PackageManager {
 						logWarn("Package override %s %s -> %s %s doesn't reference an existing package.",
 							ovr.package_, ovr.version_, ovr.targetVersion, ovr.targetPath);
 					}
-		}
 
 		foreach (p; getPackageIterator(name))
 			if (p.version_ == ver)
@@ -208,7 +217,7 @@ class PackageManager {
 
 	/** Gets the a specific sub package.
 
-		In contrast to `Package.getSubPackage`, this function supports path
+		In contrast to `Package.getInternalSubPackage`, this function supports path
 		based sub packages.
 
 		Params:
@@ -217,7 +226,6 @@ class PackageManager {
 				package name)
 			silent_fail = If set to true, the function will return `null` if no
 				package is found. Otherwise will throw an exception.
-
 	*/
 	Package getSubPackage(Package base_package, string sub_name, bool silent_fail)
 	{
@@ -227,7 +235,6 @@ class PackageManager {
 		enforce(silent_fail, "Sub package \""~base_package.name~":"~sub_name~"\" doesn't exist.");
 		return null;
 	}
-
 
 	/** Determines if a package is managed by DUB.
 
@@ -246,7 +253,7 @@ class PackageManager {
 	*/
 	bool isManagedPath(Path path)
 	const {
-		foreach (rep; m_repositories) {
+		foreach (rep; m_repos) {
 			auto rpath = rep.packagePath;
 			if (path.startsWith(rpath))
 				return true;
@@ -266,8 +273,8 @@ class PackageManager {
 				if (auto ret = del(tp)) return ret;
 
 			// first search local packages
-			foreach (tp; LocalPackageType.min .. LocalPackageType.max+1)
-				foreach (p; m_repositories[cast(LocalPackageType)tp].localPackages)
+			foreach (ref repo; m_repos) // TODO: is ref necessary here?
+				foreach (p; repo.localPackages)
 					if (auto ret = del(p)) return ret;
 
 			// and then all packages gathered from the search path
@@ -297,41 +304,50 @@ class PackageManager {
 		return &iterator;
 	}
 
-
 	/** Returns a list of all package overrides for the given scope.
 	*/
-	const(PackageOverride)[] getOverrides(LocalPackageType scope_)
-	const {
-		return m_repositories[scope_].overrides;
+	deprecated const(PackageOverride)[] getOverrides(LocalPackageType scope_)
+	{
+		return m_repos[m_defaultPaths[scope_]].getOverrides();
+	}
+	/// ditto
+	const(PackageOverride)[] getOverrides(Path repoPath)
+	{
+		return m_repos[repoPath].getOverrides();
 	}
 
 	/** Adds a new override for the given package.
 	*/
-	void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Version target)
+	deprecated void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Version target)
 	{
-		m_repositories[scope_].overrides ~= PackageOverride(package_, version_spec, target);
-		writeLocalPackageOverridesFile(scope_);
+		m_repos[m_defaultPaths[scope_]].addOverride(package_, version_spec, target);
 	}
 	/// ditto
-	void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Path target)
+	deprecated void addOverride(LocalPackageType scope_, string package_, Dependency version_spec, Path target)
 	{
-		m_repositories[scope_].overrides ~= PackageOverride(package_, version_spec, target);
-		writeLocalPackageOverridesFile(scope_);
+		m_repos[m_defaultPaths[scope_]].addOverride(package_, version_spec, target);
+	}
+	/// ditto
+	void addOverride(Path path, string package_, Dependency version_spec, Version target)
+	{
+		m_repos[path].addOverride(package_, version_spec, target);
+	}
+	/// ditto
+	void addOverride(Path path, string package_, Dependency version_spec, Path target)
+	{
+		m_repos[path].addOverride(package_, version_spec, target);
 	}
 
 	/** Removes an existing package override.
 	*/
-	void removeOverride(LocalPackageType scope_, string package_, Dependency version_spec)
+	deprecated void removeOverride(LocalPackageType scope_, string package_, Dependency version_spec)
 	{
-		Repository* rep = &m_repositories[scope_];
-		foreach (i, ovr; rep.overrides) {
-			if (ovr.package_ != package_ || ovr.version_ != version_spec)
-				continue;
-			rep.overrides = rep.overrides[0 .. i] ~ rep.overrides[i+1 .. $];
-			writeLocalPackageOverridesFile(scope_);
-			return;
-		}
-		throw new Exception(format("No override exists for %s %s", package_, version_spec));
+		m_repos[m_defaultPaths[scope_]].removeOverride(package_, version_spec);
+	}
+	/// ditto
+	void removeOverride(Path path, string package_, Dependency version_spec)
+	{
+		m_repos[path].removeOverride(package_, version_spec);
 	}
 
 	/// Extracts the package supplied as a path to it's zip file to the
@@ -414,7 +430,7 @@ class PackageManager {
 		return pack;
 	}
 
-	/// Removes the given the package.
+	/// Removes the given package.
 	void remove(in Package pack, bool force_remove)
 	{
 		logDebug("Remove %s, version %s, path '%s'", pack.name, pack.version_, pack.path);
@@ -430,7 +446,7 @@ class PackageManager {
 			}
 			return false;
 		}
-		foreach(repo; m_repositories) {
+		foreach(repo; m_repos) {
 			if(removeFrom(repo.localPackages, pack)) {
 				found = true;
 				break;
@@ -445,67 +461,44 @@ class PackageManager {
 		logInfo("Removed package: '"~pack.name~"'");
 	}
 
-	Package addLocalPackage(Path path, string verName, LocalPackageType type)
+	deprecated Package addLocalPackage(Path path, string verName, LocalPackageType type)
 	{
-		path.endsWithSlash = true;
-		auto pack = Package.load(path);
-		enforce(pack.name.length, "The package has no name, defined in: " ~ path.toString());
-		if (verName.length)
-			pack.version_ = Version(verName);
-
-		// don't double-add packages
-		Package[]* packs = &m_repositories[type].localPackages;
-		foreach (p; *packs) {
-			if (p.path == path) {
-				enforce(p.version_ == pack.version_, "Adding the same local package twice with differing versions is not allowed.");
-				logInfo("Package is already registered: %s (version: %s)", p.name, p.version_);
-				return p;
-			}
-		}
-
-		addPackages(*packs, pack);
-
-		writeLocalPackageList(type);
-
-		logInfo("Registered package: %s (version: %s)", pack.name, pack.version_);
-		return pack;
+		return m_repos[m_defaultPaths[type]].addLocalPackage(path, verName);
+	}
+	Package addLocalPackage(Path path, string verName, Path repoPath)
+	{
+		return m_repos[repoPath].addLocalPackage(path, verName);
 	}
 
-	void removeLocalPackage(Path path, LocalPackageType type)
+	deprecated void removeLocalPackage(Path path, LocalPackageType type)
 	{
-		path.endsWithSlash = true;
-
-		Package[]* packs = &m_repositories[type].localPackages;
-		size_t[] to_remove;
-		foreach( i, entry; *packs )
-			if( entry.path == path )
-				to_remove ~= i;
-		enforce(to_remove.length > 0, "No "~type.to!string()~" package found at "~path.toNativeString());
-
-		string[Version] removed;
-		foreach_reverse( i; to_remove ) {
-			removed[(*packs)[i].version_] = (*packs)[i].name;
-			*packs = (*packs)[0 .. i] ~ (*packs)[i+1 .. $];
-		}
-
-		writeLocalPackageList(type);
-
-		foreach(ver, name; removed)
-			logInfo("Deregistered package: %s (version: %s)", name, ver);
+		m_repos[m_defaultPaths[type]].removeLocalPackage(path);
+	}
+	void removeLocalPackage(Path path, Path repoPath)
+	{
+		m_repos[repoPath].removeLocalPackage(path);
 	}
 
 	/// For the given type add another path where packages will be looked up.
-	void addSearchPath(Path path, LocalPackageType type)
+	deprecated void addSearchPath(Path path, LocalPackageType type)
 	{
-		m_repositories[type].searchPath ~= path;
-		writeLocalPackageList(type);
+		m_repos[m_defaultPaths[type]].addSearchPath(path);
+	}
+	/// ditto
+	void addSearchPath(Path path, Path repoPath)
+	{
+		m_repos[repoPath].addSearchPath(path);
 	}
 
 	/// Removes a search path from the given type.
-	void removeSearchPath(Path path, LocalPackageType type)
+	deprecated void removeSearchPath(Path path, LocalPackageType type)
 	{
-		m_repositories[type].searchPath = m_repositories[type].searchPath.filter!(p => p != path)().array();
-		writeLocalPackageList(type);
+		m_repos[m_defaultPaths[type]].removeSearchPath(path);
+	}
+	/// ditto
+	void removeSearchPath(Path path, Path repoPath)
+	{
+		m_repos[repoPath].removeSearchPath(path);
 	}
 
 	void refresh(bool refresh_existing_packages)
@@ -513,70 +506,69 @@ class PackageManager {
 		logDiagnostic("Refreshing local packages (refresh existing: %s)...", refresh_existing_packages);
 
 		// load locally defined packages
-		void scanLocalPackages(LocalPackageType type)
-		{
-			Path list_path = m_repositories[type].packagePath;
-			Package[] packs;
-			Path[] paths;
-			if (!m_disableDefaultSearchPaths) try {
-				auto local_package_file = list_path ~ LocalPackagesFilename;
-				logDiagnostic("Looking for local package map at %s", local_package_file.toNativeString());
-				if( !existsFile(local_package_file) ) return;
-				logDiagnostic("Try to load local package map at %s", local_package_file.toNativeString());
-				auto packlist = jsonFromFile(list_path ~ LocalPackagesFilename);
-				enforce(packlist.type == Json.Type.array, LocalPackagesFilename~" must contain an array.");
-				foreach( pentry; packlist ){
-					try {
-						auto name = pentry["name"].get!string;
-						auto path = Path(pentry["path"].get!string);
-						if (name == "*") {
-							paths ~= path;
-						} else {
-							auto ver = Version(pentry["version"].get!string);
+		if (!m_disableRepoSearchPaths)
+			over_repos: foreach (ref repo; m_repos)
+			{
+				Path list_path = repo.packagePath;
+				Package[] packs;
+				Path[] paths;
+				try {
+					auto local_package_file = list_path ~ LocalPackagesFilename;
+					logDiagnostic("Looking for local package map at %s", local_package_file.toNativeString());
+					if( !existsFile(local_package_file) ) continue over_repos;
+					logDiagnostic("Try to load local package map at %s", local_package_file.toNativeString());
+					auto packlist = jsonFromFile(list_path ~ LocalPackagesFilename);
+					enforce(packlist.type == Json.Type.array, LocalPackagesFilename~" must contain an array.");
+					foreach( pentry; packlist ){
+						try {
+							auto name = pentry["name"].get!string;
+							auto path = Path(pentry["path"].get!string);
+							if (name == "*") {
+								paths ~= path;
+							} else {
+								auto ver = Version(pentry["version"].get!string);
 
-							Package pp;
-							if (!refresh_existing_packages) {
-								foreach (p; m_repositories[type].localPackages)
-									if (p.path == path) {
-										pp = p;
-										break;
-									}
-							}
-
-							if (!pp) {
-								auto infoFile = Package.findPackageFile(path);
-								if (!infoFile.empty) pp = Package.load(path, infoFile);
-								else {
-									logWarn("Locally registered package %s %s was not found. Please run 'dub remove-local \"%s\"'.",
-										name, ver, path.toNativeString());
-									auto info = Json.emptyObject;
-									info["name"] = name;
-									pp = new Package(info, path);
+								Package pp;
+								if (!refresh_existing_packages) {
+									foreach (p; repo.localPackages)
+										if (p.path == path) {
+											pp = p;
+											break;
+										}
 								}
+
+								if (!pp) {
+									auto infoFile = Package.findPackageFile(path);
+									if (!infoFile.empty) pp = Package.load(path, infoFile);
+									else {
+										logWarn("Locally registered package %s %s was not found. Please run 'dub remove-local \"%s\"'.",
+											name, ver, path.toNativeString());
+										auto info = Json.emptyObject;
+										info["name"] = name;
+										pp = new Package(info, path);
+									}
+								}
+
+								if (pp.name != name)
+									logWarn("Local package at %s has different name than %s (%s)", path.toNativeString(), name, pp.name);
+								pp.version_ = ver;
+
+								addPackages(packs, pp);
 							}
-
-							if (pp.name != name)
-								logWarn("Local package at %s has different name than %s (%s)", path.toNativeString(), name, pp.name);
-							pp.version_ = ver;
-
-							addPackages(packs, pp);
+						} catch( Exception e ){
+							logWarn("Error adding local package: %s", e.msg);
 						}
-					} catch( Exception e ){
-						logWarn("Error adding local package: %s", e.msg);
 					}
+				} catch( Exception e ){
+					logDiagnostic("Loading of local package list at %s failed: %s", list_path.toNativeString(), e.msg);
 				}
-			} catch( Exception e ){
-				logDiagnostic("Loading of local package list at %s failed: %s", list_path.toNativeString(), e.msg);
+				repo.localPackages = packs;
+				repo.searchPath = paths;
 			}
-			m_repositories[type].localPackages = packs;
-			m_repositories[type].searchPath = paths;
-		}
-		scanLocalPackages(LocalPackageType.system);
-		scanLocalPackages(LocalPackageType.user);
 
 		auto old_packages = m_packages;
 
-		// rescan the system and user package folder
+		// rescan a given package folder
 		void scanPackageFolder(Path path)
 		{
 			if( path.existsDirectory() ){
@@ -624,10 +616,10 @@ class PackageManager {
 		foreach (p; this.completeSearchPath)
 			scanPackageFolder(p);
 
-		void loadOverrides(LocalPackageType type)
+		foreach (ref repo; m_repos)
 		{
-			m_repositories[type].overrides = null;
-			auto ovrfilepath = m_repositories[type].packagePath ~ LocalOverridesFilename;
+			repo.overrides = null;
+			auto ovrfilepath = repo.packagePath ~ LocalOverridesFilename;
 			if (existsFile(ovrfilepath)) {
 				foreach (entry; jsonFromFile(ovrfilepath)) {
 					PackageOverride ovr;
@@ -635,117 +627,19 @@ class PackageManager {
 					ovr.version_ = Dependency(entry["version"].get!string);
 					if (auto pv = "targetVersion" in entry) ovr.targetVersion = Version(pv.get!string);
 					if (auto pv = "targetPath" in entry) ovr.targetPath = Path(pv.get!string);
-					m_repositories[type].overrides ~= ovr;
+					repo.overrides ~= ovr;
 				}
 			}
 		}
-		loadOverrides(LocalPackageType.user);
-		loadOverrides(LocalPackageType.system);
 	}
 
-	alias Hash = ubyte[];
+	deprecated alias Hash = ubyte[];
 	/// Generates a hash value for a given package.
 	/// Some files or folders are ignored during the generation (like .dub and
 	/// .svn folders)
-	Hash hashPackage(Package pack)
+	deprecated static ubyte[] hashPackage(Package pack)
 	{
-		string[] ignored_directories = [".git", ".dub", ".svn"];
-		// something from .dub_ignore or what?
-		string[] ignored_files = [];
-		SHA1 sha1;
-		foreach(file; dirEntries(pack.path.toNativeString(), SpanMode.depth)) {
-			if(file.isDir && ignored_directories.canFind(Path(file.name).head.toString()))
-				continue;
-			else if(ignored_files.canFind(Path(file.name).head.toString()))
-				continue;
-
-			sha1.put(cast(ubyte[])Path(file.name).head.toString());
-			if(file.isDir) {
-				logDebug("Hashed directory name %s", Path(file.name).head);
-			}
-			else {
-				sha1.put(openFile(Path(file.name)).readAll());
-				logDebug("Hashed file contents from %s", Path(file.name).head);
-			}
-		}
-		auto hash = sha1.finish();
-		logDebug("Project hash: %s", hash);
-		return hash[].dup;
-	}
-
-	private void writeLocalPackageList(LocalPackageType type)
-	{
-		Json[] newlist;
-		foreach (p; m_repositories[type].searchPath) {
-			auto entry = Json.emptyObject;
-			entry["name"] = "*";
-			entry["path"] = p.toNativeString();
-			newlist ~= entry;
-		}
-
-		foreach (p; m_repositories[type].localPackages) {
-			if (p.parentPackage) continue; // do not store sub packages
-			auto entry = Json.emptyObject;
-			entry["name"] = p.name;
-			entry["version"] = p.version_.toString();
-			entry["path"] = p.path.toNativeString();
-			newlist ~= entry;
-		}
-
-		Path path = m_repositories[type].packagePath;
-		if( !existsDirectory(path) ) mkdirRecurse(path.toNativeString());
-		writeJsonFile(path ~ LocalPackagesFilename, Json(newlist));
-	}
-
-	private void writeLocalPackageOverridesFile(LocalPackageType type)
-	{
-		Json[] newlist;
-		foreach (ovr; m_repositories[type].overrides) {
-			auto jovr = Json.emptyObject;
-			jovr["name"] = ovr.package_;
-			jovr["version"] = ovr.version_.versionSpec;
-			if (!ovr.targetPath.empty) jovr["targetPath"] = ovr.targetPath.toNativeString();
-			else jovr["targetVersion"] = ovr.targetVersion.toString();
-			newlist ~= jovr;
-		}
-		auto path = m_repositories[type].packagePath;
-		if (!existsDirectory(path)) mkdirRecurse(path.toNativeString());
-		writeJsonFile(path ~ LocalOverridesFilename, Json(newlist));
-	}
-
-	/// Adds the package and scans for subpackages.
-	private void addPackages(ref Package[] dst_repos, Package pack)
-	const {
-		// Add the main package.
-		dst_repos ~= pack;
-
-		// Additionally to the internally defined subpackages, whose metadata
-		// is loaded with the main dub.json, load all externally defined
-		// packages after the package is available with all the data.
-		foreach (spr; pack.subPackages) {
-			Package sp;
-
-			if (spr.path.length) {
-				auto p = Path(spr.path);
-				p.normalize();
-				enforce(!p.absolute, "Sub package paths must be sub paths of the parent package.");
-				auto path = pack.path ~ p;
-				if (!existsFile(path)) {
-					logError("Package %s declared a sub-package, definition file is missing: %s", pack.name, path.toNativeString());
-					continue;
-				}
-				sp = Package.load(path, Path.init, pack);
-			} else sp = new Package(spr.recipe, pack.path, pack);
-
-			// Add the subpackage.
-			try {
-				dst_repos ~= sp;
-			} catch (Exception e) {
-				logError("Package '%s': Failed to load sub-package %s: %s", pack.name,
-					spr.path.length ? spr.path : spr.recipe.name, e.msg);
-				logDiagnostic("Full error: %s", e.toString().sanitize());
-			}
-		}
+		return pack.hash();
 	}
 }
 
@@ -770,7 +664,7 @@ struct PackageOverride {
 	}
 }
 
-enum LocalPackageType {
+deprecated enum LocalPackageType {
 	user,
 	system
 }
@@ -789,6 +683,171 @@ private struct Repository {
 	this(Path path)
 	{
 		this.path = path;
-		this.packagePath = path ~"packages/";
+		this.packagePath = path ~ "packages/";
+	}
+
+	private void writeLocalPackageOverridesFile()
+	{
+		Json[] newlist;
+		foreach (ovr; overrides) {
+			auto jovr = Json.emptyObject;
+			jovr["name"] = ovr.package_;
+			jovr["version"] = ovr.version_.versionSpec;
+			if (!ovr.targetPath.empty) jovr["targetPath"] = ovr.targetPath.toNativeString();
+			else jovr["targetVersion"] = ovr.targetVersion.toString();
+			newlist ~= jovr;
+		}
+		if (!existsDirectory(packagePath)) mkdirRecurse(packagePath.toNativeString());
+		writeJsonFile(packagePath ~ LocalOverridesFilename, Json(newlist));
+	}
+
+	private void writeLocalPackageList()
+	{
+		Json[] newlist;
+		foreach (p; searchPath) {
+			auto entry = Json.emptyObject;
+			entry["name"] = "*";
+			entry["path"] = p.toNativeString();
+			newlist ~= entry;
+		}
+
+		foreach (p; localPackages) {
+			if (p.parentPackage) continue; // do not store sub packages
+			auto entry = Json.emptyObject;
+			entry["name"] = p.name;
+			entry["version"] = p.version_.toString();
+			entry["path"] = p.path.toNativeString();
+			newlist ~= entry;
+		}
+
+		if( !existsDirectory(packagePath) ) mkdirRecurse(packagePath.toNativeString());
+		writeJsonFile(packagePath ~ LocalPackagesFilename, Json(newlist));
+	}
+
+	Package addLocalPackage(Path path, string verName)
+	{
+		path.endsWithSlash = true;
+		auto pack = Package.load(path);
+		enforce(pack.name.length, "The package has no name, defined in: " ~ path.toString());
+		if (verName.length)
+			pack.version_ = Version(verName);
+
+		// don't double-add packages
+		foreach (p; localPackages) {
+			if (p.path == path) {
+				enforce(p.version_ == pack.version_, "Adding the same local package twice with differing versions is not allowed.");
+				logInfo("Package is already registered: %s (version: %s)", p.name, p.version_);
+				return p;
+			}
+		}
+
+		addPackages(localPackages, pack);
+
+		writeLocalPackageList();
+
+		logInfo("Registered package: %s (version: %s)", pack.name, pack.version_);
+		return pack;
+	}
+
+	void removeLocalPackage(Path path)
+	{
+		path.endsWithSlash = true;
+
+		size_t[] to_remove;
+		foreach (i, entry; localPackages)
+			if (entry.path == path)
+				to_remove ~= i;
+		enforce(to_remove.length > 0, "No package found at "~path.toNativeString());
+
+		string[Version] removed;
+		foreach_reverse( i; to_remove ) {
+			removed[localPackages[i].version_] = localPackages[i].name;
+			localPackages = localPackages[0 .. i] ~ localPackages[i+1 .. $];
+		}
+
+		writeLocalPackageList();
+
+		foreach(ver, name; removed)
+			logInfo("Deregistered package: %s (version: %s)", name, ver);
+	}
+
+	/// Add another path where packages will be looked up.
+	void addSearchPath(Path path)
+	{
+		searchPath ~= path;
+		writeLocalPackageList();
+	}
+
+	/// Removes a search path.
+	void removeSearchPath(Path path)
+	{
+		searchPath = searchPath.filter!(p => p != path)().array();
+		writeLocalPackageList();
+	}
+
+	/** Returns a list of all package overrides.
+	*/
+	const(PackageOverride)[] getOverrides()
+	const {
+		return overrides;
+	}
+
+	/** Adds a new override for the given package.
+	*/
+	void addOverride(T)(string package_, Dependency version_spec, T target)
+	if (is(T : Version) || is(T : Path))
+	{
+		overrides ~= PackageOverride(package_, version_spec, target);
+		writeLocalPackageOverridesFile();
+	}
+
+	/** Removes an existing package override.
+	*/
+	void removeOverride(string package_, Dependency version_spec)
+	{
+		foreach (i, ovr; overrides) {
+			if (ovr.package_ != package_ || ovr.version_ != version_spec)
+				continue;
+			overrides = overrides[0 .. i] ~ overrides[i+1 .. $];
+			writeLocalPackageOverridesFile();
+			return;
+		}
+		throw new Exception(format("No override exists for %s %s", package_, version_spec));
 	}
 }
+
+/// Adds the package and scans for subpackages.
+private void addPackages(ref Package[] dst_repos, Package pack)
+{
+	// Add the main package.
+	dst_repos ~= pack;
+
+	// Additionally to the internally defined subpackages, whose metadata
+	// is loaded with the main dub.json, load all externally defined
+	// packages after the package is available with all the data.
+	foreach (spr; pack.subPackages) {
+		Package sp;
+
+		if (spr.path.length) {
+			auto p = Path(spr.path);
+			p.normalize();
+			enforce(!p.absolute, "Sub package paths must be sub paths of the parent package.");
+			auto path = pack.path ~ p;
+			if (!existsFile(path)) {
+				logError("Package %s declared a sub-package, definition file is missing: %s", pack.name, path.toNativeString());
+				continue;
+			}
+			sp = Package.load(path, Path.init, pack);
+		} else sp = new Package(spr.recipe, pack.path, pack);
+
+		// Add the subpackage.
+		try {
+			dst_repos ~= sp;
+		} catch (Exception e) {
+			logError("Package '%s': Failed to load sub-package %s: %s", pack.name,
+				spr.path.length ? spr.path : spr.recipe.name, e.msg);
+			logDiagnostic("Full error: %s", e.toString().sanitize());
+		}
+	}
+}
+

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -118,7 +118,7 @@ class Project {
 
 		If this function returns `false`, it may be necessary to add more entries
 		to `selections`, or to use `Dub.upgrade` to automatically select all
-		missing dependencies. 
+		missing dependencies.
 	*/
 	bool hasAllDependencies() const { return m_hasAllDependencies; }
 
@@ -607,7 +607,7 @@ class Project {
 		if (usedefflags) {
 			BuildSettings btsettings;
 			m_rootPackage.addBuildTypeSettings(btsettings, platform, build_type);
-			
+
 			if (!for_root_package) {
 				// don't propagate unittest switch to dependencies, as dependent
 				// unit tests aren't run anyway and the additional code may
@@ -664,7 +664,7 @@ class Project {
 		return listBuildSetting!attributeName(platform, getPackageConfigs(platform, config),
 			projectDescription, compiler, disableEscaping);
 	}
-	
+
 	private string[] listBuildSetting(string attributeName)(BuildPlatform platform,
 		string[string] configs, ProjectDescription projectDescription, Compiler compiler, bool disableEscaping)
 	{
@@ -673,7 +673,7 @@ class Project {
 		else
 			return formatBuildSettingPlain!attributeName(platform, configs, projectDescription);
 	}
-	
+
 	// Output a build setting formatted for a compiler
 	private string[] formatBuildSettingCompiler(string attributeName)(BuildPlatform platform,
 		string[string] configs, ProjectDescription projectDescription, Compiler compiler, bool disableEscaping)
@@ -705,7 +705,7 @@ class Project {
 		case "options":
 			auto bs = buildSettings.dup;
 			bs.dflags = null;
-			
+
 			// Ensure trailing slash on directory paths
 			auto ensureTrailingSlash = (string path) => path.endsWith(dirSeparator) ? path : path ~ dirSeparator;
 			static if (attributeName == "importPaths")
@@ -723,9 +723,9 @@ class Project {
 			bs.lflags = null;
 			bs.sourceFiles = null;
 			bs.targetType = TargetType.none; // Force Compiler to NOT omit dependency libs when package is a library.
-			
+
 			compiler.prepareBuildSettings(bs, BuildSetting.all & ~to!BuildSetting(attributeName));
-			
+
 			if (bs.lflags)
 				values = compiler.lflagsToDFlags( bs.lflags );
 			else if (bs.sourceFiles)
@@ -737,7 +737,7 @@ class Project {
 
 		default: assert(0);
 		}
-		
+
 		// Escape filenames and paths
 		if(!disableEscaping)
 		{
@@ -752,7 +752,7 @@ class Project {
 			case "importPaths":
 			case "stringImportPaths":
 				return values.map!(escapeShellFileName).array();
-	
+
 			default:
 				return values;
 			}
@@ -760,7 +760,7 @@ class Project {
 
 		return values;
 	}
-	
+
 	// Output a build setting without formatting for any particular compiler
 	private string[] formatBuildSettingPlain(string attributeName)(BuildPlatform platform, string[string] configs, ProjectDescription projectDescription)
 	{
@@ -771,21 +771,21 @@ class Project {
 
 		enforce(attributeName == "targetType" || projectDescription.lookupRootPackage().targetType != TargetType.none,
 			"Target type is 'none'. Cannot list build settings.");
-		
+
 		static if (attributeName == "targetType")
 			if (projectDescription.rootPackage !in projectDescription.targetLookup)
 				return ["none"];
 
 		auto targetDescription = projectDescription.lookupTarget(projectDescription.rootPackage);
 		auto buildSettings = targetDescription.buildSettings;
-		
+
 		// Return any BuildSetting member attributeName as a range of strings. Don't attempt to fixup values.
 		// allowEmptyString: When the value is a string (as opposed to string[]),
 		//                   is empty string an actual permitted value instead of
 		//                   a missing value?
 		auto getRawBuildSetting(Package pack, bool allowEmptyString) {
 			auto value = __traits(getMember, buildSettings, attributeName);
-			
+
 			static if( is(typeof(value) == string[]) )
 				return value;
 			else static if( is(typeof(value) == string) )
@@ -810,7 +810,7 @@ class Project {
 			else
 				static assert(false, "Type of BuildSettings."~attributeName~" is unsupported.");
 		}
-		
+
 		// Adjust BuildSetting member attributeName as needed.
 		// Returns a range of strings.
 		auto getFixedBuildSetting(Package pack) {
@@ -824,16 +824,16 @@ class Project {
 				attributeName == "sourceFiles" || attributeName == "linkerFiles" ||
 				attributeName == "importFiles" || attributeName == "stringImportFiles" ||
 				attributeName == "copyFiles" || attributeName == "mainSourceFile";
-			
+
 			// For these, empty string means "main project directory", not "missing value"
 			enum allowEmptyString =
 				attributeName == "targetPath" || attributeName == "workingDirectory";
-			
+
 			enum isEnumBitfield =
 				attributeName == "requirements" || attributeName == "options";
 
 			enum isEnum = attributeName == "targetType";
-			
+
 			auto values = getRawBuildSetting(pack, allowEmptyString);
 			string fixRelativePath(string importPath) { return buildNormalizedPath(pack.path.toString(), importPath); }
 			static string ensureTrailingSlash(string path) { return path.endsWith(dirSeparator) ? path : path ~ dirSeparator; }
@@ -925,7 +925,7 @@ class Project {
 			enforce(false, "--data="~requestedData~
 				" is not a valid option. See 'dub describe --help' for accepted --data= values.");
 		}
-		
+
 		assert(0);
 	}
 
@@ -947,7 +947,7 @@ class Project {
 			auto target = projectDescription.lookupTarget(projectDescription.rootPackage);
 			foreach (file; target.buildSettings.sourceFiles.filter!(isLinkerFile))
 				target.buildSettings.addLinkerFiles(file);
-			
+
 			// Remove linker files from sourceFiles
 			target.buildSettings.sourceFiles =
 				target.buildSettings.sourceFiles


### PR DESCRIPTION
I recognise this is an absolute monster diff, so I'll do my best to put in a lot of comments in here to explain motivations soon.

If you like to break things down by commit: https://github.com/dlang/dub/commit/06a40361386cfd746aa152687d535ec50b00ead6, https://github.com/dlang/dub/commit/13d6ec41849b7680076bd5c0f6cb1e10413b23f6 and https://github.com/dlang/dub/commit/82d25b62a151021a2916f4fc9bf36e72046de324 are the places to look, the test suite passes for each of them individually. Not much to be gained by looking at the other two in isolation.

The changes are also broadly contained within each file: `packagemanager.d` first, then `dub.d`, then `commandline.d`. Alternatively, the opposite order might make the "why" clearer.

## The point:
adding support for custom directories for packages and local registration files.