### PR TITLE
Remove POSIX special-casing from copyFile

### DIFF
--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -112,20 +112,26 @@ void copyFile(Path from, Path to, bool overwrite = false)
 		removeFile(to);
 	}
 
-	.copy(from.toNativeString(), to.toNativeString());
-
-	// try to preserve ownership/permissions in Posix
-	version (Posix) {
-		import core.sys.posix.sys.stat;
-		import core.sys.posix.unistd;
-		import std.utf;
-		auto cspath = toUTFz!(const(char)*)(from.toNativeString());
-		auto cdpath = toUTFz!(const(char)*)(to.toNativeString());
-		stat_t st;
-		enforce(stat(cspath, &st) == 0, "Failed to get attributes of source file.");
-		if (chown(cdpath, st.st_uid, st.st_gid) != 0)
-			st.st_mode &= ~(S_ISUID | S_ISGID);
-		chmod(cdpath, st.st_mode);
+	static if (is(PreserveAttributes))
+	{
+		.copy(from.toNativeString(), to.toNativeString(), PreserveAttributes.yes);
+	}
+	else
+	{
+		.copy(from.toNativeString(), to.toNativeString());
+		// try to preserve ownership/permissions in Posix
+		version (Posix) {
+			import core.sys.posix.sys.stat;
+			import core.sys.posix.unistd;
+			import std.utf;
+			auto cspath = toUTFz!(const(char)*)(from.toNativeString());
+			auto cdpath = toUTFz!(const(char)*)(to.toNativeString());
+			stat_t st;
+			enforce(stat(cspath, &st) == 0, "Failed to get attributes of source file.");
+			if (chown(cdpath, st.st_uid, st.st_gid) != 0)
+				st.st_mode &= ~(S_ISUID | S_ISGID);
+			chmod(cdpath, st.st_mode);
+		}
 	}
 }
 /// ditto


### PR DESCRIPTION
Since `std.file.copy` already provides a means to preserve attributes of a file, it is preferable to use that functionality rather than having a custom-written solution.

Note that where the original dub code used a `chown` call followed by a `chmod` call, `std.file.copy` only uses a `chmod`.  This is not expected to cause any issues but should be borne in mind as a possible breaking change for some use-cases.

Fixes https://github.com/dlang/dub/issues/992.