### PR TITLE
Add a way to manually override chosen configurations from the CLI.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -616,12 +616,6 @@ abstract class PackageBuildCommand : Command {
 			else m_buildType = default_build_type;
 		}
 
-		foreach (sc; m_overrideConfigs) {
-			auto idx = sc.indexOf('/');
-			enforceUsage(idx >= 0, "Expected \"<package>/<configuration>\" as argument to --override-config.");
-			dub.project.overrideConfiguration(sc[0 .. idx], sc[idx+1 .. $]);
-		}
-
 		if (!m_nodeps) {
 			// TODO: only upgrade(select) if necessary, only upgrade(upgrade) every now and then
 
@@ -640,6 +634,12 @@ abstract class PackageBuildCommand : Command {
 		}
 
 		dub.project.validate();
+
+		foreach (sc; m_overrideConfigs) {
+			auto idx = sc.indexOf('/');
+			enforceUsage(idx >= 0, "Expected \"<package>/<configuration>\" as argument to --override-config.");
+			dub.project.overrideConfiguration(sc[0 .. idx], sc[idx+1 .. $]);
+		}
 	}
 
 	private bool loadSpecificPackage(Dub dub, string package_name)

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -542,6 +542,7 @@ abstract class PackageBuildCommand : Command {
 		string m_compilerName;
 		string m_arch;
 		string[] m_debugVersions;
+		string[] m_overrideConfigs;
 		Compiler m_compiler;
 		BuildPlatform m_buildPlatform;
 		BuildSettings m_buildSettings;
@@ -560,6 +561,10 @@ abstract class PackageBuildCommand : Command {
 		]);
 		args.getopt("c|config", &m_buildConfig, [
 			"Builds the specified configuration. Configurations can be defined in dub.json"
+		]);
+		args.getopt("override-config", &m_overrideConfigs, [
+			"Uses the specified configuration for a certain dependency (format: --override-config <dependency>/<config>).",
+			"Can be specified multiple fimes."
 		]);
 		args.getopt("compiler", &m_compilerName, [
 			"Specifies the compiler binary to use (can be a path).",
@@ -609,6 +614,12 @@ abstract class PackageBuildCommand : Command {
 		if (m_buildType.length == 0) {
 			if (environment.get("DFLAGS") !is null) m_buildType = "$DFLAGS";
 			else m_buildType = default_build_type;
+		}
+
+		foreach (sc; m_overrideConfigs) {
+			auto idx = sc.indexOf('/');
+			enforceUsage(idx >= 0, "Expected \"<package>/<configuration>\" as argument to --override-config.");
+			dub.project.overrideConfiguration(sc[0 .. idx], sc[idx+1 .. $]);
 		}
 
 		if (!m_nodeps) {

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -563,8 +563,8 @@ abstract class PackageBuildCommand : Command {
 			"Builds the specified configuration. Configurations can be defined in dub.json"
 		]);
 		args.getopt("override-config", &m_overrideConfigs, [
-			"Uses the specified configuration for a certain dependency (format: --override-config <dependency>/<config>).",
-			"Can be specified multiple fimes."
+			"Uses the specified configuration for a certain dependency. Can be specified multiple times.",
+			"Format: --override-config=<dependency>/<config>"
 		]);
 		args.getopt("compiler", &m_compilerName, [
 			"Specifies the compiler binary to use (can be a path).",

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -51,7 +51,7 @@ class Project {
 		Package[][Package] m_dependees;
 		SelectedVersions m_selections;
 		bool m_hasAllDependencies;
-		string[string] m_overridenConfigs;
+		string[string] m_overriddenConfigs;
 	}
 
 	/** Loads a project.
@@ -218,7 +218,7 @@ class Project {
 		Params:
 			package_ = The package for which to force selecting a certain
 				dependency
-			config = Name of the configuration to force.
+			config = Name of the configuration to force
 	*/
 	void overrideConfiguration(string package_, string config)
 	{
@@ -227,7 +227,7 @@ class Project {
 			format("Package '%s', marked for configuration override, is not present in dependency graph.", package_));
 		enforce(p.configurations.canFind(config),
 			format("Package '%s' does not have a configuration named '%s'.", package_, config));
-		m_overridenConfigs[package_] = config;
+		m_overriddenConfigs[package_] = config;
 	}
 
 	/** Performs basic validation of various aspects of the package.
@@ -404,7 +404,7 @@ class Project {
 			foreach (i, v; configs)
 				if (v.pack == pack && v.config == config)
 					return i;
-			assert(pack !in m_overridenConfigs || config == m_overridenConfigs[pack]);
+			assert(pack !in m_overriddenConfigs || config == m_overriddenConfigs[pack]);
 			logDebug("Add config %s %s", pack, config);
 			configs ~= Vertex(pack, config);
 			return configs.length-1;
@@ -462,7 +462,7 @@ class Project {
 				if (!dp) continue;
 
 				string[] cfgs;
-				if (auto pc = dp.name in m_overridenConfigs) cfgs = [*pc];
+				if (auto pc = dp.name in m_overriddenConfigs) cfgs = [*pc];
 				else {
 					auto subconf = p.getSubConfiguration(c, dp, platform);
 					if (!subconf.empty) cfgs = [subconf];
@@ -502,7 +502,7 @@ class Project {
 			}
 
 			// for each configuration, determine the configurations usable for the dependencies
-			if (auto pc = p.name in m_overridenConfigs)
+			if (auto pc = p.name in m_overriddenConfigs)
 				determineDependencyConfigs(p, *pc);
 			else
 				foreach (c; p.getPlatformConfigurations(platform, p is m_rootPackage && allow_non_library))

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -51,6 +51,7 @@ class Project {
 		Package[][Package] m_dependees;
 		SelectedVersions m_selections;
 		bool m_hasAllDependencies;
+		string[string] m_overridenConfigs;
 	}
 
 	/** Loads a project.
@@ -206,6 +207,27 @@ class Project {
 	const {
 		auto cfgs = getPackageConfigs(platform, null, allow_non_library_configs);
 		return cfgs[m_rootPackage.name];
+	}
+
+	/** Overrides the configuration chosen for a particular package in the
+		dependency graph.
+
+		Setting a certain configuration here is equivalent to removing all
+		but one configuration from the package.
+
+		Params:
+			package_ = The package for which to force selecting a certain
+				dependency
+			config = Name of the configuration to force.
+	*/
+	void overrideConfiguration(string package_, string config)
+	{
+		auto p = getDependency(package_, true);
+		enforce(p !is null,
+			format("Package '%s', marked for configuration override, is not present in dependency graph.", package_));
+		enforce(p.configurations.canFind(config),
+			format("Package '%s' does not have a configuration named '%s'.", package_, config));
+		m_overridenConfigs[package_] = config;
 	}
 
 	/** Performs basic validation of various aspects of the package.
@@ -382,6 +404,7 @@ class Project {
 			foreach (i, v; configs)
 				if (v.pack == pack && v.config == config)
 					return i;
+			assert(pack !in m_overridenConfigs || config == m_overridenConfigs[pack]);
 			logDebug("Add config %s %s", pack, config);
 			configs ~= Vertex(pack, config);
 			return configs.length-1;
@@ -430,6 +453,39 @@ class Project {
 		}
 
 		string[] allconfigs_path;
+
+		void determineDependencyConfigs(in Package p, string c)
+		{
+			string[][string] depconfigs;
+			foreach (d; p.getAllDependencies()) {
+				auto dp = getDependency(d.name, true);
+				if (!dp) continue;
+
+				string[] cfgs;
+				if (auto pc = dp.name in m_overridenConfigs) cfgs = [*pc];
+				else {
+					auto subconf = p.getSubConfiguration(c, dp, platform);
+					if (!subconf.empty) cfgs = [subconf];
+					else cfgs = dp.getPlatformConfigurations(platform);
+				}
+				cfgs = cfgs.filter!(c => haveConfig(d.name, c)).array;
+
+				// if no valid configuration was found for a dependency, don't include the
+				// current configuration
+				if (!cfgs.length) {
+					logDebug("Skip %s %s (missing configuration for %s)", p.name, c, dp.name);
+					return;
+				}
+				depconfigs[d.name] = cfgs;
+			}
+
+			// add this configuration to the graph
+			size_t cidx = createConfig(p.name, c);
+			foreach (d; p.getAllDependencies())
+				foreach (sc; depconfigs.get(d.name, null))
+					createEdge(cidx, createConfig(d.name, sc));
+		}
+
 		// create a graph of all possible package configurations (package, config) -> (subpackage, subconfig)
 		void determineAllConfigs(in Package p)
 		{
@@ -446,33 +502,11 @@ class Project {
 			}
 
 			// for each configuration, determine the configurations usable for the dependencies
-			outer: foreach (c; p.getPlatformConfigurations(platform, p is m_rootPackage && allow_non_library)) {
-				string[][string] depconfigs;
-				foreach (d; p.getAllDependencies()) {
-					auto dp = getDependency(d.name, true);
-					if (!dp) continue;
-
-					string[] cfgs;
-					auto subconf = p.getSubConfiguration(c, dp, platform);
-					if (!subconf.empty) cfgs = [subconf];
-					else cfgs = dp.getPlatformConfigurations(platform);
-					cfgs = cfgs.filter!(c => haveConfig(d.name, c)).array;
-
-					// if no valid configuration was found for a dependency, don't include the
-					// current configuration
-					if (!cfgs.length) {
-						logDebug("Skip %s %s (missing configuration for %s)", p.name, c, dp.name);
-						continue outer;
-					}
-					depconfigs[d.name] = cfgs;
-				}
-
-				// add this configuration to the graph
-				size_t cidx = createConfig(p.name, c);
-				foreach (d; p.getAllDependencies())
-					foreach (sc; depconfigs.get(d.name, null))
-						createEdge(cidx, createConfig(d.name, sc));
-			}
+			if (auto pc = p.name in m_overridenConfigs)
+				determineDependencyConfigs(p, *pc);
+			else
+				foreach (c; p.getPlatformConfigurations(platform, p is m_rootPackage && allow_non_library))
+					determineDependencyConfigs(p, c);
 		}
 		if (config.length) createConfig(m_rootPackage.name, config);
 		determineAllConfigs(m_rootPackage);

--- a/test/issue1004-override-config.sh
+++ b/test/issue1004-override-config.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ${CURR_DIR}/issue1004-override-config
+${DUB} build --bare main --override-config a/success || exit 1

--- a/test/issue1004-override-config/a/a.d
+++ b/test/issue1004-override-config/a/a.d
@@ -1,0 +1,5 @@
+module a;
+
+void test()
+{
+}

--- a/test/issue1004-override-config/a/dub.sdl
+++ b/test/issue1004-override-config/a/dub.sdl
@@ -1,0 +1,9 @@
+name "a"
+
+configuration "fail" {
+}
+
+configuration "success" {
+	sourceFiles "a.d"
+	importPaths "."
+}

--- a/test/issue1004-override-config/main/dub.sdl
+++ b/test/issue1004-override-config/main/dub.sdl
@@ -1,0 +1,2 @@
+name "main"
+dependency "a" version="*"

--- a/test/issue1004-override-config/main/source/main.d
+++ b/test/issue1004-override-config/main/source/main.d
@@ -1,0 +1,6 @@
+import a;
+
+void main()
+{
+	test();
+}


### PR DESCRIPTION
While there is a `subConfiguration` directive for package recipes, it is only possible to override the configuration of the root package from the command line. But in certain situations it can be useful to override dependency configurations without altering any package recipes. For example, the tests or examples of a library could be built with different configurations of the library.