### PR TITLE
Implement selective package upgrades.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -212,6 +212,7 @@ int runDubCommandLine(string[] args)
 	if (!cmd.skipDubInitialization) {
 		if (options.bare) {
 			dub = new Dub(Path(getcwd()));
+			dub.rootPath = Path(options.root_path);
 			dub.defaultPlacementLocation = options.placementLocation;
 		} else {
 			// initialize DUB

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1089,14 +1089,14 @@ class UpgradeCommand : Command {
 	this()
 	{
 		this.name = "upgrade";
-		this.argumentsPattern = "[<package>]";
-		this.description = "Forces an upgrade of all dependencies";
+		this.argumentsPattern = "[<packages...>]";
+		this.description = "Forces an upgrade of the dependencies";
 		this.helpText = [
 			"Upgrades all dependencies of the package by querying the package registry(ies) for new versions.",
 			"",
-			"This will also update the versions stored in the selections file ("~SelectedVersions.defaultFile~") accordingly.",
+			"This will update the versions stored in the selections file ("~SelectedVersions.defaultFile~") accordingly.",
 			"",
-			"If a package specified, (only) that package will be upgraded. Otherwise all direct and indirect dependencies of the current package will get upgraded."
+			"If one or more package names are specified, only those dependencies will be upgraded. Otherwise all direct and indirect dependencies of the root package will get upgraded."
 		];
 	}
 

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1126,7 +1126,6 @@ class UpgradeCommand : Command {
 		auto options = UpgradeOptions.upgrade|UpgradeOptions.select;
 		if (m_missingOnly) options &= ~UpgradeOptions.upgrade;
 		if (m_prerelease) options |= UpgradeOptions.preRelease;
-		if (m_forceRemove) options |= UpgradeOptions.forceRemove;
 		dub.upgrade(options, free_args);
 		return 0;
 	}

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1125,8 +1125,8 @@ class UpgradeCommand : Command {
 		auto options = UpgradeOptions.upgrade|UpgradeOptions.select;
 		if (m_missingOnly) options &= ~UpgradeOptions.upgrade;
 		if (m_prerelease) options |= UpgradeOptions.preRelease;
-		enforceUsage(free_args.length == 0, "Upgrading a specific package is not yet implemented.");
-		dub.upgrade(options);
+		if (m_forceRemove) options |= UpgradeOptions.forceRemove;
+		dub.upgrade(options, free_args);
 		return 0;
 	}
 }

--- a/test/issue1024-selective-upgrade.sh
+++ b/test/issue1024-selective-upgrade.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+cd ${CURR_DIR}/issue1024-selective-upgrade
+echo "{\"fileVersion\": 1,\"versions\": {\"a\": \"1.0.0\", \"b\": \"1.0.0\"}}" > main/dub.selections.json
+$DUB upgrade --bare --root=main a || exit 1
+
+if ! grep -c -e "\"a\": \"1.0.1\"" main/dub.selections.json; then
+	echo "Specified dependency was not upgraded."
+	exit 1
+fi
+
+if grep -c -e "\"b\": \"1.0.1\"" main/dub.selections.json; then
+	echo "Non-specified dependency got upgraded."
+	exit 1
+fi

--- a/test/issue1024-selective-upgrade/a-1.0.0/dub.sdl
+++ b/test/issue1024-selective-upgrade/a-1.0.0/dub.sdl
@@ -1,0 +1,2 @@
+name "a"
+version "1.0.0"

--- a/test/issue1024-selective-upgrade/a-1.0.1/dub.sdl
+++ b/test/issue1024-selective-upgrade/a-1.0.1/dub.sdl
@@ -1,0 +1,2 @@
+name "a"
+version "1.0.1"

--- a/test/issue1024-selective-upgrade/b-1.0.0/dub.sdl
+++ b/test/issue1024-selective-upgrade/b-1.0.0/dub.sdl
@@ -1,0 +1,2 @@
+name "b"
+version "1.0.0"

--- a/test/issue1024-selective-upgrade/b-1.0.1/dub.sdl
+++ b/test/issue1024-selective-upgrade/b-1.0.1/dub.sdl
@@ -1,0 +1,2 @@
+name "b"
+version "1.0.1"

--- a/test/issue1024-selective-upgrade/main/dub.sdl
+++ b/test/issue1024-selective-upgrade/main/dub.sdl
@@ -1,0 +1,3 @@
+name "test"
+dependency "a" version="~>1.0.0"
+dependency "b" version="~>1.0.0"


### PR DESCRIPTION
See #1012. This makes it possible to pass a list of package names to "dub upgrade". The upgrade will be restricted to those packages.