### PR TITLE
Improve testing of executable configurations.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -513,6 +513,9 @@ class Dub {
 			m_project.rootPackage.recipe.buildSettings.versions[""] = m_project.rootPackage.recipe.buildSettings.versions.get("", null).remove!(v => v == "VibeDefaultMain");
 			// TODO: remove this ^ once vibe.d has removed the default main implementation
 
+			auto mainfil = tcinfo.mainSourceFile;
+			if (!mainfil.length) mainfil = m_project.rootPackage.recipe.buildSettings.mainSourceFile;
+
 			string custommodname;
 			if (custom_main_file.length) {
 				import std.path;
@@ -526,9 +529,9 @@ class Dub {
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
 					auto fname = Path(file).head.toString();
-					if (Path(file).relativeTo(m_project.rootPackage.path) == Path(tcinfo.mainSourceFile)) {
-						logWarn("Excluding main source file %s from test.", tcinfo.mainSourceFile);
-						tcinfo.excludedSourceFiles[""] ~= tcinfo.mainSourceFile;
+					if (Path(file).relativeTo(m_project.rootPackage.path) == Path(mainfil)) {
+						logWarn("Excluding main source file %s from test.", mainfil);
+						tcinfo.excludedSourceFiles[""] ~= mainfil;
 						continue;
 					}
 					if (fname == "package.d") {


### PR DESCRIPTION
Previously, running "dub test" for an executable configuration would simply be lowered to "dub -b unittest <config>". This meant that the usual testing logic, including custom test runners and executable name were not applied. With this change, executable configurations are treated much like library ones. The main source file gets removed from the build/test to avoid conflicts with the generated main().

In addition to the functional change, the name of the generated test executable has been changed to `<package>-test-<config>`.

See #840 