### PR TITLE
[do not pull] make ~>x.y.z mean >=x.y.z <(x+1).0.0

### DIFF
--- a/source/dub/semver.d
+++ b/source/dub/semver.d
@@ -231,6 +231,7 @@ string bumpVersion(string ver) {
 	// Increment next to last version from a[.b[.c]].
 	auto splitted = split(ver, ".");
 	assert(splitted.length > 0 && splitted.length <= 3, "Version corrupt: " ~ ver);
+	if(splitted.length==3) splitted=splitted[0..2];
 	auto to_inc = splitted.length == 3? 1 : 0;
 	splitted = splitted[0 .. to_inc+1];
 	splitted[to_inc] = to!string(to!int(splitted[to_inc]) + 1);


### PR DESCRIPTION
make ~>x.y.z mean >=x.y.z <(x+1).0.0 instead of >=x.y.z <x.(y+1).z
This solves a lot of problems I keep running into. Theoretically at least, X.Y.Z should be backward compatible with x.y.z so long X.Y.Z>=x.y.z and X=x (ie so long we keep the major version to x; we therefore should allow minor version increments.

eg:
```
"dependencies": {
"gtk-d" : "~>3.4",
"ggplotd": ">=1.1.2",
},
```
Currently fails because
```
"gtk-d ~>3.4" violates "gtk-d:gtkd": "~>3.3.0"
```
This is a common scenario responsible for a lot of breakages.

With this fix, it passes.

[if this idea is accepted, I could update unittests and docs]