### PR TITLE
VisualD : generate all build modes

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -108,6 +108,7 @@ struct BuildSettings {
 	void addOptions(in BuildOptions value) { this.options |= value; }
 	void removeOptions(in BuildOption[] value...) { foreach (v; value) this.options &= ~v; }
 	void removeOptions(in BuildOptions value) { this.options &= ~value; }
+	void resetOptions() { this.options = BuildOption.none; }
 
 	// Adds vals to arr without adding duplicates.
 	private void add(ref string[] arr, in string[] vals, bool no_duplicates = true)


### PR DESCRIPTION
Hi,

This changes make the VisualD solution always generated with debug, release and unittest modes. 
Any Visual Studio should expect that as every c++ projects comes with debug and release modes by default. This improve Windows user productivity by reducing the usage of terminal.