### PR TITLE
Fix cubic runtime complexity for collecting source/import files.

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -149,14 +149,14 @@ struct BuildSettings {
 	// add string import files (avoids file name duplicates in addition to path duplicates)
 	private void addSI(ref string[] arr, in string[] vals)
 	{
-		outer:
+		bool[string] existing;
+		foreach (v; arr) existing[Path(v).head.toString()] = true;
 		foreach (v; vals) {
-			auto vh = Path(v).head;
-			foreach (ve; arr) {
-				if (Path(ve).head == vh)
-					continue outer;
+			auto s = Path(v).head.toString();
+			if (s !in existing) {
+				existing[s] = true;
+				arr ~= v;
 			}
-			arr ~= v;
 		}
 	}
 

--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -175,7 +175,7 @@ struct Path {
 	}
 
 	/// The last entry of the path
-	@property ref immutable(PathEntry) head() const { enforce(m_nodes.length > 0); return m_nodes[$-1]; }
+	@property ref immutable(PathEntry) head() const { enforce(m_nodes.length > 0, "Getting head of empty path."); return m_nodes[$-1]; }
 
 	/// The parent path
 	@property Path parentPath() const { return this[0 .. length-1]; }

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -175,6 +175,8 @@ struct BuildSettingsTemplate {
 
 		void collectFiles(string method)(in string[][string] paths_map, string pattern)
 		{
+			auto files = appender!(string[]);
+
 			foreach (suffix, paths; paths_map) {
 				if (!platform.matchesSpecification(suffix))
 					continue;
@@ -192,10 +194,12 @@ struct BuildSettingsTemplate {
 						import std.path : baseName;
 						if (baseName(d.name)[0] == '.' || isDir(d.name)) continue;
 						auto src = Path(d.name).relativeTo(base_path);
-						__traits(getMember, dst, method)(src.toNativeString());
+						files ~= src.toNativeString();
 					}
 				}
 			}
+
+			__traits(getMember, dst, method)(files.data);
 		}
 
 		// collect files from all source/import folders


### PR DESCRIPTION
See rejectedsoftware/vibe.d#1690.

This is still not very efficient, doing several temporary allocations and copies, but replaces cubic runtime by almost linear (except for allocation and AA creation times).