### PR TITLE
Use a default package name for single file packages in case none is provided

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -273,6 +273,7 @@ class Dub {
 	{
 		import dub.recipe.io : parsePackageRecipe;
 		import std.file : mkdirRecurse, readText;
+		import std.path : baseName, stripExtension;
 
 		path = makeAbsolute(path);
 
@@ -299,8 +300,9 @@ class Dub {
 		enforce(idx > 0, "Missing recipe file name (e.g. \"dub.sdl:\") in recipe comment");
 		auto recipe_filename = recipe_content[0 .. idx];
 		recipe_content = recipe_content[idx+1 .. $];
+		auto recipe_default_package_name = path.toString.baseName.stripExtension.strip;
 
-		auto recipe = parsePackageRecipe(recipe_content, recipe_filename);
+		auto recipe = parsePackageRecipe(recipe_content, recipe_filename, null, recipe_default_package_name);
 		enforce(recipe.buildSettings.sourceFiles.length == 0, "Single-file packages are not allowed to specify source files.");
 		enforce(recipe.buildSettings.sourcePaths.length == 0, "Single-file packages are not allowed to specify source paths.");
 		enforce(recipe.buildSettings.importPaths.length == 0, "Single-file packages are not allowed to specify import paths.");

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -53,11 +53,14 @@ PackageRecipe readPackageRecipe(Path filename, string parent_name = null)
 			to determine the file format from the file extension
 		parent_name = Optional name of the parent package (if this is a sub
 		package)
+		default_package_name = Optional default package name (if no package name
+		is found in the recipe this value will be used)
 
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe parsePackageRecipe(string contents, string filename, string parent_name = null)
+PackageRecipe parsePackageRecipe(string contents, string filename, string parent_name = null,
+								 string default_package_name = null)
 {
 	import std.algorithm : endsWith;
 	import dub.internal.vibecompat.data.json;
@@ -65,6 +68,8 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 	import dub.recipe.sdl : parseSDL;
 
 	PackageRecipe ret;
+
+	ret.name = default_package_name;
 
 	if (filename.endsWith(".json")) parseJson(ret, parseJsonString(contents, filename), parent_name);
 	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent_name, filename);

--- a/test/single-file-sdl-default-name.d
+++ b/test/single-file-sdl-default-name.d
@@ -1,0 +1,10 @@
+/++dub.sdl:
+dependency "sourcelib-simple" path="1-sourceLib-simple"
++/
+module single;
+
+void main(string[] args)
+{
+	import sourcelib.app;
+	entry();
+}

--- a/test/single-file-sdl-default-name.sh
+++ b/test/single-file-sdl-default-name.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cd ${CURR_DIR}
+rm -f single-file-sdl-default-name
+
+${DUB} run --single single-file-sdl-default-name.d --compiler=${DC}
+if [ ! -f single-file-sdl-default-name ]; then
+	echo "Normal invocation did not produce a binary in the current directory"
+	exit 1
+fi
+rm single-file-sdl-default-name


### PR DESCRIPTION
Usually the `name` is set to the `file_name` without extensions anyways, so imho this a very sane fallback for single file packages.

BTW
- you have a lot of trailing whitespace in your files. How about removing them and enabling a quick CI check to prevent regressions in the future?
- if we are already at this topic: would be quite cool if we could remove the [restriction not to allow source paths](https://github.com/dlang/dub/issues/909)