### PR TITLE
dub run <package> should search the registry on failure

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -821,6 +821,45 @@ class BuildCommand : GenerateCommand {
 
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
+		if (free_args.length >= 1) {
+			auto package_name = free_args[0];
+			auto pack = dub.packageManager.getFirstPackage(package_name);
+
+			if (!pack) {
+				bool input(string caption, bool default_value = true) {
+					writef("%s [%s]: ", caption, default_value ? "Y/n" : "y/N");
+					auto inp = readln();
+					string userInput = "y";
+					if (inp.length > 1)
+						userInput = inp[0 .. $ - 1].toLower;
+
+					switch (userInput) {
+						case "no", "n", "0":
+							return false;
+						case "yes", "y", "1":
+						default:
+							return true;
+					}
+				}
+
+				// search for the package and filter for exact matches
+				auto search = dub.searchPackages(package_name)
+					.map!(tup => tup[1].find!(p => p.name == package_name))
+					.filter!(ps => !ps.empty);
+				if (search.empty)
+					return 2;
+
+				auto p = search.front.front;
+				writefln("%s wasn't found locally, but it's available online:", package_name);
+				writefln("Description: %s", p.description);
+				writefln("Version: %s", p.version_);
+
+				bool answer = input("Do you want to fetch %s?".format(package_name));
+				auto dep = Dependency(p.version_);
+				dub.fetch(package_name, dep, dub.defaultPlacementLocation, FetchOptions.none);
+			}
+		}
+
 		return super.execute(dub, free_args, app_args);
 	}
 }

--- a/test/issue877-auto-fetch-package-on-run.sh
+++ b/test/issue877-auto-fetch-package-on-run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -o pipefail
+$DUB remove --version="*" gitcompatibledubpackage || true
+
+echo "y" | $DUB run gitcompatibledubpackage -c exe
+
+$DUB remove gitcompatibledubpackage


### PR DESCRIPTION
Adds a simple fallback to `dub run`, s.t. the following pattern simply works:

```
dub run dlang-tour
dub run dfmt
dub run dscanner
dub run avgtime
...
```

I am not sure how we can best test this _without_ querying the registry. Also I don't know any package that is compatible with all the compilers that DUB supports.
What would be the best strategy here?