### PR TITLE
Fix bogus rebuild of packages without dependencies.

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -378,7 +378,7 @@ class BuildGenerator : ProjectGenerator {
 		foreach (p; packages)
 			allfiles ~= (p.recipePath != Path.init ? p : p.basePackage).recipePath.toNativeString();
 		foreach (f; additional_dep_files) allfiles ~= f.toNativeString();
-		if (main_pack is m_project.rootPackage)
+		if (main_pack is m_project.rootPackage && m_project.rootPackage.getAllDependencies().length > 0)
 			allfiles ~= (main_pack.path ~ SelectedVersions.defaultFile).toNativeString();
 
 		foreach (file; allfiles.data) {

--- a/test/issue1091-bogus-rebuild.sh
+++ b/test/issue1091-bogus-rebuild.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+cd ${CURR_DIR}/1-exec-simple
+rm -f dub.selections.json
+${DUB} build --compiler=${DC} 2>&1 | grep -e "building configuration" -c || exit 1
+${DUB} build --compiler=${DC} 2>&1 | grep -e "building configuration" -c && exit 1 || exit 0


### PR DESCRIPTION
Packages without dependencies don't have a dub.selections.json file. Previously the absence of this file was deemed to be a sign that the build output is not up to date, thus always unconditionally rebuilding such a package even if nothing changed. Fixes #1091.