### PR TITLE
sublimetext: add dependencies as folders

### DIFF
--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -36,7 +36,7 @@ class SublimeTextGenerator : ProjectGenerator {
 		logDebug("About to generate sublime project for %s.", m_project.rootPackage.name);
 
 		auto root = Json([
-			"folders": targets.byValue.map!(f => targetFolderJson(f)).array.Json,
+			"folders": (targets.byValue.map!(f => targetFolderJson(f)).array ~ buildSettings.importPaths.map!Json.array).Json,
 			"build_systems": buildSystems(settings.platform),
 			"settings": [ "include_paths": buildSettings.importPaths.map!Json.array.Json ].Json,
 		]);


### PR DESCRIPTION
When generating the sublime-text project file, add the dependencies as the list of folders to
open in Sublime editor when the project is open.

This allows quick lookup of symbols in the libraries from within Sublime.

Note: Although these are already included in the `include_paths`, this doesn't make the symbols in these paths searchable within the editor. I'm not sure if there's a better way to do this, but the approach in this PR works.