### PR TITLE
download / registry requests silently fail

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -389,7 +389,7 @@ class Dub {
 							if (versions.canFind!(v => dep.matches(v)))
 								continue next_pack;
 						} catch (Exception e) {
-							logDiagnostic("Error querying versions for %s, %s: %s", p, ps.description, e.msg);
+							logWarn("Error querying versions for %s, %s: %s", p, ps.description, e.msg);
 							logDebug("Full error: %s", e.toString().sanitize());
 						}
 					}
@@ -671,7 +671,7 @@ class Dub {
 				supplier = ps;
 				break;
 			} catch(Exception e) {
-				logDiagnostic("Package %s not found for %s: %s", packageId, ps.description, e.msg);
+				logWarn("Package %s not found for %s: %s", packageId, ps.description, e.msg);
 				logDebug("Full error: %s", e.toString().sanitize());
 			}
 		}
@@ -966,7 +966,7 @@ class Dub {
 		foreach (ps; this.m_packageSuppliers) {
 			try versions ~= ps.getVersions(name);
 			catch (Exception e) {
-				logDebug("Failed to get versions for package %s on provider %s: %s", name, ps.description, e.msg);
+				logWarn("Failed to get versions for package %s on provider %s: %s", name, ps.description, e.msg);
 			}
 		}
 		return versions.sort().uniq.array;
@@ -1264,7 +1264,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 				versions ~= vers;
 				break;
 			} catch (Exception e) {
-				logDebug("Package %s not found in %s: %s", pack, ps.description, e.msg);
+				logWarn("Package %s not found in %s: %s", pack, ps.description, e.msg);
 				logDebug("Full error: %s", e.toString().sanitize);
 			}
 		}

--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -225,8 +225,10 @@ class RegistryPackageSupplier : PackageSupplier {
 		string data;
 		try
 			data = cast(string)download(url);
-		catch (Exception)
+		catch (Exception e) {
+			logWarn("Searching %s for '%s' failed: %s", m_registryUrl, query, e.msg);
 			return null;
+		}
 		import std.algorithm : map;
 		return data.parseJson.opt!(Json[])
 			.map!(j => SearchResult(j["name"].opt!string, j["description"].opt!string, j["version"].opt!string))

--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -170,8 +170,10 @@ class RegistryPackageSupplier : PackageSupplier {
 
 	Version[] getVersions(string package_id)
 	{
+		auto md = getMetadata(package_id);
+		if (md.type == Json.Type.null_)
+			return null;
 		Version[] ret;
-		Json md = getMetadata(package_id);
 		foreach (json; md["versions"]) {
 			auto cur = Version(cast(string)json["version"]);
 			ret ~= cur;
@@ -184,6 +186,8 @@ class RegistryPackageSupplier : PackageSupplier {
 	{
 		import std.array : replace;
 		Json best = getBestPackage(packageId, dep, pre_release);
+		if (best.type == Json.Type.null_)
+			return;
 		auto vers = best["version"].get!string;
 		auto url = m_registryUrl ~ Path(PackagesPath~"/"~packageId~"/"~vers~".zip");
 		logDiagnostic("Downloading from '%s'", url);
@@ -209,7 +213,16 @@ class RegistryPackageSupplier : PackageSupplier {
 		logDebug("Downloading metadata for %s", packageId);
 		logDebug("Getting from %s", url);
 
-		auto jsonData = cast(string)download(url);
+		string jsonData;
+		try
+			jsonData = cast(string)download(url);
+		catch (HTTPStatusException e)
+		{
+			if (e.status != 404)
+				throw e;
+			logDebug("Package %s not found in %s: %s", packageId, description, e.msg);
+			return Json(null);
+		}
 		Json json = parseJsonString(jsonData, url.toString());
 		// strip readme data (to save size and time)
 		foreach (ref v; json["versions"])
@@ -223,12 +236,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		auto url = m_registryUrl;
 		url.localURI = "/api/packages/search?q="~encodeComponent(query);
 		string data;
-		try
-			data = cast(string)download(url);
-		catch (Exception e) {
-			logWarn("Searching %s for '%s' failed: %s", m_registryUrl, query, e.msg);
-			return null;
-		}
+		data = cast(string)download(url);
 		import std.algorithm : map;
 		return data.parseJson.opt!(Json[])
 			.map!(j => SearchResult(j["name"].opt!string, j["description"].opt!string, j["version"].opt!string))
@@ -238,6 +246,8 @@ class RegistryPackageSupplier : PackageSupplier {
 	private Json getBestPackage(string packageId, Dependency dep, bool pre_release)
 	{
 		Json md = getMetadata(packageId);
+		if (md.type == Json.Type.null_)
+			return md;
 		Json best = null;
 		Version bestver;
 		foreach (json; md["versions"]) {


### PR DESCRIPTION
Took me an extra hour of debugging why our builds fails ;).
At least for search the exception that libcurl couldn't be loaded is silently ignored, https://github.com/dlang/dub/blob/756240240e980f0945988ad77e0301b389b06db5/source/dub/packagesupplier.d#L229. But I'm also seeing `Root package assert_writeln_magic references unknown package libdparse` with no further indication of the underlying problem.

Based on v1.1.0, but still seems to be present.