### PR TITLE
skip optional packages when not used

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -760,6 +760,12 @@ class GenerateCommand : PackageBuildCommand {
 			logInfo("");
 		}
 
+		auto cfgs = dub.project.getPackageConfigs(m_buildPlatform, null, true);
+		dub.project.reinit(cfgs);
+		dub.project.removeUnusedAddedDependencies();
+		if (dub.project.selections.dirty)
+			dub.project.saveSelections();
+
 		GeneratorSettings gensettings;
 		gensettings.platform = m_buildPlatform;
 		gensettings.config = m_buildConfig.length ? m_buildConfig : m_defaultConfig;


### PR DESCRIPTION
This PR fixes dub pulling in an optional dependency when it is not used.

I was having problems getting vibe-d to compile on arch linux (see https://github.com/rejectedsoftware/vibe.d/pull/1769), because the deimos openssl bindings target an old and obsolete openssl version that is no longer on arch linux. When trying to switch to botan and avoiding the (optional) openssl I found out that dub was still pulling in openssl and compiling vibe-d with Have_openssl (which in turn causes vibe-d to import openssl).

Here follows some background on optional dependencies, or at least how I understand them.

Dub supports optional dependencies. These dependencies should not get compiled unless the end-user explicitly puts them in its dub.selections.json. There are also default optional dependencies, which will, when the end-user doens't have a dub.selections.json, automatically store the default optional dependency into the dub.selections.json.

So, vibe-d (or the vibe-d:stream subpackage) has a default optional dependency on openssl, and an optional dependency on botan. This means the end-user (me) can choose whether to depend on openssl or on botan. Since I had trouble with openssl on arch linux, I decided to use botan. And the problem described above presented itself.

Here follows an account of me digging through dub's codebase and trying to understand what happens:

When dub collects the transient dependencies, dub will do it for ALL configurations. Which I think is because it doesn't know which configuration it will use yet (chicken-egg problem).

As it happens botan has a subconfiguration with a dependency on openssl. I am not using that subconfiguration but dub regardlessly will append it to its list of dependencies. (And I suppose it has too. But I am not sure.)

At which point dub realises I have a missing dependency and will start to upgrade my project. Here dub fetches openssl, adds it as a dependency to my dub.selections.json and writes the file to disk.

Then it starts its configuration reduction. Here it correctly determines that botan isn't actually using the subconfiguration with openssl, and drops it. But when it gets to vibe-d:stream it notices the openssl dependency in the dub.selections.json and makes the once optional dependency non-optional. Afterwards it will start the build generator and will start building all targets.

As for the solution in the PR, I am not really pleased with it, to put it very mildly. On the other hand, I could not see any other solution besides refactoring existing code.

Here is the breakdown of the changes I felt I had to made.

Initially dub doesn't know which configuration is used for a dependency, so when collecting dependencies for a package it collects ALL dependencies from ALL sub-configurations. After it has successfully selected one configuration for each dependency, I _modified_ dub to redo the collection of dependencies, but this time with the proper config (so it will know which subconfigs - and therefor deps - it can skip).

I wanted to fix the upgrade code, but when dub executes the upgrade code, the configurations aren't available. So, instead I settled for purging any added unused dependency after configuration is determined. (And then write dub.selections.json again). This has the downside that doing `dub upgrade` will *STILL* pull in any optional dependency (when that dependency is used in a subconfiguration of another dependency) and then writes that list of dependencies to dub.selections.json.

There is a lot more to say on the subject, and I feel I haven't expressed everything clearly.

Regardless, this PR does fix the problem I have, but I wonder at what cost...