### PR TITLE
Error message: Getting head of empty path.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -431,7 +431,7 @@ struct CommandGroup {
 class InitCommand : Command {
 	private{
 		string m_templateType = "minimal";
-		PackageFormat m_format = PackageFormat.json;
+		RecipeFormat m_format = RecipeFormat.json;
 		bool m_nonInteractive;
 	}
 	this()
@@ -455,7 +455,7 @@ class InitCommand : Command {
 		]);
 		args.getopt("f|format", &m_format, [
 			"Sets the format to use for the package description file. Possible values:",
-			"  " ~ [__traits(allMembers, PackageFormat)].map!(f => f == m_format.init.to!string ? f ~ " (default)" : f).join(", ")
+			"  " ~ [__traits(allMembers, RecipeFormat)].map!(f => f == m_format.init.to!string ? f ~ " (default)" : f).join(", ")
 		]);
 		args.getopt("n|non-interactive", &m_nonInteractive, ["Don't enter interactive mode."]);
 	}
@@ -477,7 +477,7 @@ class InitCommand : Command {
 			return inp.length > 1 ? inp[0 .. $-1] : default_value;
 		}
 
-		void depCallback(ref PackageRecipe p, ref PackageFormat fmt) {
+		void depCallback(ref PackageRecipe p, ref RecipeFormat fmt) {
 			import std.datetime: Clock;
 
 			if (m_nonInteractive) return;
@@ -486,7 +486,7 @@ class InitCommand : Command {
 				string rawfmt = input("Package recipe format (sdl/json)", fmt.to!string);
 				if (!rawfmt.length) break;
 				try {
-					fmt = rawfmt.to!PackageFormat;
+					fmt = rawfmt.to!RecipeFormat;
 					break;
 				} catch (Exception) {
 					logError("Invalid format, \""~rawfmt~"\", enter either \"sdl\" or \"json\".");

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1007,8 +1007,8 @@ class Dub {
 				customize the recipe before it gets written.
 	*/
 	void createEmptyPackage(Path path, string[] deps, string type,
-		PackageFormat format = PackageFormat.sdl,
-		scope void delegate(ref PackageRecipe, ref PackageFormat) recipe_callback = null)
+		RecipeFormat format = RecipeFormat.sdl,
+		scope void delegate(ref PackageRecipe, ref RecipeFormat) recipe_callback = null)
 	{
 		if (!path.absolute) path = m_rootPath ~ path;
 		path.normalize();

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -9,7 +9,7 @@ module dub.init;
 
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
-import dub.package_ : PackageFormat, packageInfoFiles, defaultPackageFilename;
+import dub.package_ : packageInfoFiles, defaultPackageFilename;
 import dub.recipe.packagerecipe;
 import dub.dependency;
 
@@ -39,7 +39,7 @@ import std.string;
 			writing it to disk.
 */
 void initPackage(Path root_path, string[string] deps, string type,
-	PackageFormat format, scope RecipeCallback recipe_callback = null)
+	RecipeFormat format, scope RecipeCallback recipe_callback = null)
 {
 	import std.conv : to;
 	import dub.recipe.io : writePackageRecipe;
@@ -90,7 +90,7 @@ void initPackage(Path root_path, string[string] deps, string type,
 	writeGitignore(root_path);
 }
 
-alias RecipeCallback = void delegate(ref PackageRecipe, ref PackageFormat);
+alias RecipeCallback = void delegate(ref PackageRecipe, ref RecipeFormat);
 
 private void initMinimalPackage(Path root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -54,6 +54,7 @@ void initPackage(Path root_path, string[string] deps, string type,
 	p.name = root_path.head.toString().toLower();
 	p.authors ~= username;
 	p.license = "proprietary";
+	p.format = format;
 	foreach (pack, v; deps) {
 		import std.ascii : isDigit;
 		p.buildSettings.dependencies[pack] = Dependency(v);

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -12,8 +12,6 @@ public import dub.recipe.packagerecipe;
 import dub.compilers.compiler;
 import dub.dependency;
 import dub.description;
-import dub.recipe.json;
-import dub.recipe.sdl;
 
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
@@ -31,22 +29,19 @@ import std.string;
 import std.typecons : Nullable;
 
 
-/// Lists the supported package recipe formats.
-enum PackageFormat {
-	json, /// JSON based, using the ".json" file extension
-	sdl   /// SDLang based, using the ".sdl" file extension
-}
+deprecated("Use dub.recipe.packagerecipe.RecipeFormat instead")
+alias PackageFormat = RecipeFormat;
 
 struct FilenameAndFormat {
 	string filename;
-	PackageFormat format;
+	RecipeFormat format;
 }
 
 /// Supported package descriptions in decreasing order of preference.
 static immutable FilenameAndFormat[] packageInfoFiles = [
-	{"dub.json", PackageFormat.json},
-	{"dub.sdl", PackageFormat.sdl},
-	{"package.json", PackageFormat.json}
+	{"dub.json", RecipeFormat.json},
+	{"dub.sdl", RecipeFormat.sdl},
+	{"package.json", RecipeFormat.json}
 ];
 
 /// Returns a list of all recognized package recipe file names in descending order of precedence.
@@ -81,7 +76,7 @@ class Package {
 	*/
 	this(Json json_recipe, Path root = Path(), Package parent = null, string version_override = "")
 	{
-		import dub.recipe.json;
+		import dub.recipe.json : parseJson;
 
 		PackageRecipe recipe;
 		parseJson(recipe, json_recipe, parent ? parent.name : null);
@@ -268,6 +263,8 @@ class Package {
 	/// ditto
 	void storeInfo(Path path)
 	const {
+		import dub.recipe.json : toJson;
+
 		enforce(!version_.isUnknown, "Trying to store a package with an 'unknown' version, this is not supported.");
 		auto filename = path ~ defaultPackageFilename;
 		auto dstFile = openFile(filename.toNativeString(), FileMode.createTrunc);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -243,10 +243,14 @@ class Project {
 			string ret;
 			ret ~= `Please modify the "name" field in %s accordingly.`.format(m_rootPackage.recipePath.toNativeString());
 			if (!m_rootPackage.recipe.buildSettings.targetName.length) {
-				if (m_rootPackage.recipePath.head.toString().endsWith(".sdl")) {
-					ret ~= ` You can then add 'targetName "%s"' to keep the current executable name.`.format(m_rootPackage.name);
-				} else {
+				with (RecipeFormat) final switch (m_rootPackage.recipe.format)
+				{
+				case json:
 					ret ~= ` You can then add '"targetName": "%s"' to keep the current executable name.`.format(m_rootPackage.name);
+					break;
+				case sdl:
+					ret ~= ` You can then add 'targetName "%s"' to keep the current executable name.`.format(m_rootPackage.name);
+					break;
 				}
 			}
 			return ret;
@@ -1419,4 +1423,3 @@ final class SelectedVersions {
 			m_selections[p] = Selected(dependencyFromJson(v));
 	}
 }
-

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -123,6 +123,23 @@ unittest { // issue #711 - configuration default target type not correct for SDL
 	}
 }
 
+unittest {
+	import std.path : extension;
+	import dub.compilers.buildsettings : TargetType;
+	auto inputs = [
+		"dub.sdl": "name \"test\"\n",
+		"dub.json": "{\"name\": \"test\"}"
+	];
+	foreach (file, content; inputs) {
+		auto pr = parsePackageRecipe(content, file);
+		assert(pr.name == "test");
+		with (RecipeFormat) final switch (pr.format)
+		{
+		case json: assert(file == "dub.json"); break;
+		case sdl: assert(file == "dub.sdl"); break;
+		}
+	}
+}
 
 /** Writes the textual representation of a package recipe to a file.
 
@@ -160,4 +177,3 @@ void serializePackageRecipe(R)(ref R dst, in ref PackageRecipe recipe, string fi
 		toSDL(recipe).toSDLDocument(dst);
 	else assert(false, "writePackageRecipe called with filename with unknown extension: "~filename);
 }
-

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -23,6 +23,7 @@ import std.traits : EnumMembers;
 
 void parseJson(ref PackageRecipe recipe, Json json, string parent_name)
 {
+	recipe.format = RecipeFormat.json;
 	foreach (string field, value; json) {
 		switch (field) {
 			default: break;

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -72,6 +72,7 @@ unittest
 	For higher level package handling, see the $(D Package) class.
 */
 struct PackageRecipe {
+	RecipeFormat format; /// format of the original recipe file (json, sdl)
 	string name;
 	string version_;
 	string description;

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -106,6 +106,11 @@ struct SubPackage
 	PackageRecipe recipe;
 }
 
+enum RecipeFormat
+{
+	json,
+	sdl,
+}
 
 /// Bundles information about a build configuration.
 struct ConfigurationInfo {

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -30,6 +30,7 @@ void parseSDL(ref PackageRecipe recipe, Tag sdl, string parent_name)
 	Tag[] subpacks;
 	Tag[] configs;
 
+	recipe.format = RecipeFormat.sdl;
 	// parse top-level fields
 	foreach (n; sdl.all.tags) {
 		enforceSDL(n.name.length > 0, "Anonymous tags are not allowed at the root level.", n);


### PR DESCRIPTION
Create a file with name "appTest.d" and this content:

```
/+ dub.json:
{
	"name": "appTest",
}
+/

void main(){}
```


Execute dub with command: dub appTest.d
Error is shown: Getting head of empty path.

The issue is the use of upper case letters in the name. The issue disappears by changing the name to apptest:

```
/+ dub.json:
{
	"name": "apptest",
}
+/
```
