### PR TITLE
Log [ERROR] on the line of a failure

### DIFF
--- a/test/run-unittest.sh
+++ b/test/run-unittest.sh
@@ -7,7 +7,7 @@ function log() {
 }
 
 function logError() {
-    echo -e 1>&2 "\033[0;31m"$@"\033[0m"
+    echo -e 1>&2 "\033[0;31m[ERROR] "$@"\033[0m"
     any_errors=1
 }
 
@@ -20,7 +20,7 @@ export -f log
 export -f die
 
 if [ -z ${DUB} ]; then
-    die 'Error: Variable $DUB must be defined to run the tests.'
+    die 'Variable $DUB must be defined to run the tests.'
 fi
 
 if [ -z ${DC} ]; then


### PR DESCRIPTION
It's very hard to read the output of DUB's testsuite. As it's used on the Project-Tester, normal human beings (e.g. the ones that don't know that they need to search for "31m"), can search for "error" on the log output with this PR.

Discussion on Phobos:

https://github.com/dlang/phobos/pull/5495#issuecomment-309430487