### PR TITLE
Fix interactive remove test on systems with dub installed

### DIFF
--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+$DUB remove dub --version=\* || echo "No initial cleanup necessary."
+
 $DUB fetch dub --version=0.9.20 && [ -d $HOME/.dub/packages/dub-0.9.20/dub ]
 $DUB fetch dub --version=0.9.21 && [ -d $HOME/.dub/packages/dub-0.9.21/dub ]
 if $DUB remove dub --non-interactive; then


### PR DESCRIPTION
On my system and the Project-Tester the interactive remove test fails with 1.3.0:

```
Fetching dub 0.9.20...
Fetching dub 0.9.21...
Cannot remove package 'dub', there are multiple possibilities at location
'user'.
Available versions:
  1.3.0
  0.9.20
  0.9.21
Please specify a individual version using --version=... or use the wildcard --version=* to remove all versions.
Select version of 'dub' to remove from location 'user':1) 1.3.02) 0.9.203) 0.9.214) all versions> Removing dub in /home/seb/.dub/packages/dub-1.3.0/dub/Removed package: 'dub'Removed dub, version 1.3.0.
Failed to remove dub-0.9.20
```

Or on the [Project Tester](https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/detail/PR-5495/3/pipeline).

AFAICT for the changes to be propagated to the Project-Tester, a new tag will be required.