### PR TITLE
Allow digits in package names.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -496,7 +496,7 @@ class InitCommand : Command {
 			while (true) {
 				// Tries getting the name until a valid one is given.
 				import std.regex;
-				auto nameRegex = regex(`^[a-z\-_]+$`);
+				auto nameRegex = regex(`^[a-z0-9\-_]+$`);
 				string triedName = input("Name", p.name);
 				if (triedName.matchFirst(nameRegex).empty) {
 					logError("Invalid name, \""~triedName~"\", names should consist only of lowercase alphanumeric characters, - and _.");


### PR DESCRIPTION
Previously, attempting to use digits in a package name during
"dub init ..." would give this error message:

Invalid name, "abc123", names should consist only of lowercase alphanumeric characters, - and _.

Thus it was not honoring the "numeric" part of "alphanumeric",
but now it does.