### PR TITLE
Improve build options of the default build script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.7
 
 echo Running $DMD...
-$DMD -ofbin/dub -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -g -O -inline -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo


### PR DESCRIPTION
Uses optimizations, but leaves assertions/contracts and adds debug information to not impede debugging on the user side. This can be considered progress in the direction of #862. It remains to be seen how much of a performance difference -release would make.