### PR TITLE
Fix CI errors caused by build options change and drop 2.065.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
       env: [FRONTEND=2.067]
     - d: dmd-2.066.1
       env: [FRONTEND=2.066]
-    - d: dmd-2.065.0
-      env: [FRONTEND=2.065]
     - d: ldc-beta
       env: [FRONTEND=2.073]
     - d: ldc
@@ -49,8 +47,6 @@ matrix:
       env: [FRONTEND=2.066]
     - d: gdc-4.9.2
       env: [FRONTEND=2.066]
-    - d: gdc-4.9.0
-      env: [FRONTEND=2.065]
 
   allow_failures:
     - d: gdc

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.7
 
 echo Running $DMD...
-$DMD -ofbin/dub -g -O -inline -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo


### PR DESCRIPTION
Dials back the accidentally merged changes in #1166 to let the CI tests pass again. The ancient version 2.065.0 of DMD gets dropped to enable using at least the -O option.