### PR TITLE
Add missing / suffix in URL type

### DIFF
--- a/source/dub/internal/vibecompat/inet/url.d
+++ b/source/dub/internal/vibecompat/inet/url.d
@@ -107,7 +107,7 @@ struct URL {
 			}
 		}
 
-		this.localURI = str;
+		this.localURI = (str == "") ? "/" : str;
 	}
 	/// ditto
 	static URL parse(string url_string)
@@ -277,4 +277,10 @@ unittest {
 	assert(url.path.toString() == "/sub2/index.html", url.path.toString());
 	assert(url.queryString == "query", url.queryString);
 	assert(url.anchor == "anchor", url.anchor);
+
+	url = URL("http://localhost")~Path("packages");
+	assert(url.toString() == "http://localhost/packages", url.toString());
+
+	url = URL("http://localhost/")~Path("packages");
+	assert(url.toString() == "http://localhost/packages", url.toString());
 }


### PR DESCRIPTION
Fixes issue #1161
The functionality can be tested with: dub build --skip-registry=standard --registry=http://code.dlang.org

Squashing was not working, therefore I created a new clean pull request
@jacob-carlborg 