### PR TITLE
Perform stricter test for single-file recipe comments.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -313,8 +313,11 @@ class Dub {
 			recipe_content = file_content[0 .. idx].strip();
 		} else throw new Exception("The source file must start with a recipe comment.");
 
+		auto nidx = recipe_content.indexOf('\n');
+
 		auto idx = recipe_content.indexOf(':');
-		enforce(idx > 0, "Missing recipe file name (e.g. \"dub.sdl:\") in recipe comment");
+		enforce(idx > 0 && (nidx < 0 || nidx > idx),
+			"The first line of the recipe comment must list the recipe file name followed by a colon (e.g. \"/+ dub.sdl:\").");
 		auto recipe_filename = recipe_content[0 .. idx];
 		recipe_content = recipe_content[idx+1 .. $];
 

--- a/test/issue103-single-file-package.sh
+++ b/test/issue103-single-file-package.sh
@@ -18,3 +18,8 @@ if [ -f single-file-test ]; then
 	echo "Shebang invocation produced binary in current directory"
 	exit 1
 fi
+
+if ${DUB} "issue103-single-file-package-error.d" 2> /dev/null; then
+	echo "Invalid package comment syntax did not trigger an error."
+	exit 1
+fi


### PR DESCRIPTION
The recipe file name must now be on the first line. The error message also mentions the required format, including the trailing ":" so that it becomes clear what needs to be changed.