### PR TITLE
add code-mirror.dlang.io as fallback registry

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -65,6 +65,7 @@ static this()
 
 /// The URL to the official package registry.
 enum defaultRegistryURL = "http://code.dlang.org/";
+enum fallbackRegistryURL = "https://code-mirror.dlang.io/";
 
 /** Returns a default list of package suppliers.
 
@@ -76,7 +77,12 @@ enum defaultRegistryURL = "http://code.dlang.org/";
 PackageSupplier[] defaultPackageSuppliers()
 {
 	logDiagnostic("Using dub registry url '%s'", defaultRegistryURL);
-	return [new RegistryPackageSupplier(URL(defaultRegistryURL))];
+	return [
+		new FallbackPackageSupplier(
+			new RegistryPackageSupplier(URL(defaultRegistryURL)),
+			new RegistryPackageSupplier(URL(fallbackRegistryURL))
+		)
+	];
 }
 
 


### PR DESCRIPTION
- to handle any code.dlang.org failures
- depends on #1104