### PR TITLE
Output a warning for sub configurations that have no effect.

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -270,16 +270,16 @@ class Project {
 
 		// search for orphan sub configurations
 		void warnSubConfig(string pack, string config) {
-			logWarn("The sub configuration directive %s -> %s references a "
-				~ "package that is not specified as a dependency and will have "
-				~ "no effect.", pack, config);
+			logWarn("The sub configuration directive \"%s\" -> \"%s\" "
+				~ "references a package that is not specified as a dependency "
+				~ "and will have no effect.", pack, config);
 		}
 		void checkSubConfig(string pack, string config) {
 			auto p = getDependency(pack, true);
 			if (p && !p.configurations.canFind(config)) {
-				logWarn("The sub configuration directive %s -> %s references "
-					~ " a configuration that does not exist and will have no "
-					~ "effect.", pack, config);
+				logWarn("The sub configuration directive \"%s\" -> \"%s\" "
+					~ "references a configuration that does not exist.",
+					pack, config);
 			}
 		}
 		auto globalbs = m_rootPackage.getBuildSettings();

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -268,6 +268,35 @@ class Project {
 					d.name, SelectedVersions.defaultFile);
 			}
 
+		// search for orphan sub configurations
+		void warnSubConfig(string pack, string config) {
+			logWarn("The sub configuration directive %s -> %s references a "
+				~ "package that is not specified as a dependency and will have "
+				~ "no effect.", pack, config);
+		}
+		void checkSubConfig(string pack, string config) {
+			auto p = getDependency(pack, true);
+			if (p && !p.configurations.canFind(config)) {
+				logWarn("The sub configuration directive %s -> %s references "
+					~ " a configuration that does not exist and will have no "
+					~ "effect.", pack, config);
+			}
+		}
+		auto globalbs = m_rootPackage.getBuildSettings();
+		foreach (p, c; globalbs.subConfigurations) {
+			if (p !in globalbs.dependencies) warnSubConfig(p, c);
+			else checkSubConfig(p, c);
+		}
+		foreach (c; m_rootPackage.configurations) {
+			auto bs = m_rootPackage.getBuildSettings(c);
+			foreach (p, c; bs.subConfigurations) {
+				if (p !in bs.dependencies && p !in globalbs.dependencies)
+					warnSubConfig(p, c);
+				else checkSubConfig(p, c);
+			}
+		}
+
+		// check for version specification mismatches
 		bool[Package] visited;
 		void validateDependenciesRec(Package pack) {
 			foreach (d; pack.getAllDependencies()) {

--- a/test/issue1194-warn-wrong-subconfig.sh
+++ b/test/issue1194-warn-wrong-subconfig.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+OUTPUT=`${DUB} build --root ${CURR_DIR}/issue1194-warn-wrong-subconfig 2>&1 || true`
+
+# make sure the proper errors occur in the output
+echo $OUTPUT | grep -c "sub configuration directive \"bar\" -> \"baz\" references a package that is not specified as a dependency" > /dev/null
+echo $OUTPUT | grep -c "sub configuration directive \"staticlib-simple\" -> \"foo\" references a configuration that does not exist" > /dev/null
+! echo $OUTPUT | grep -c "sub configuration directive \"sourcelib-simple\" -> \"library\" references a package that is not specified as a dependency" > /dev/null
+! echo $OUTPUT | grep -c "sub configuration directive \"sourcelib-simple\" -> \"library\" references a configuration that does not exist" > /dev/null
+
+# make sure no bogs warnings are issued for packages with no sub configuration directives
+OUTPUT=`${DUB} build --root ${CURR_DIR}/1-exec-simple 2>&1`
+! echo $OUTPUT | grep -c "sub configuration directive.*references" > /dev/null

--- a/test/issue1194-warn-wrong-subconfig/dub.sdl
+++ b/test/issue1194-warn-wrong-subconfig/dub.sdl
@@ -1,0 +1,8 @@
+name "test"
+dependency "staticlib-simple" path="../1-staticLib-simple"
+dependency "sourcelib-simple" path="../1-sourceLib-simple"
+targetType "executable"
+
+subConfiguration "staticlib-simple" "foo"
+subConfiguration "bar" "baz"
+subConfiguration "sourcelib-simple" "library"

--- a/test/issue1194-warn-wrong-subconfig/source/app.d
+++ b/test/issue1194-warn-wrong-subconfig/source/app.d
@@ -1,0 +1,1 @@
+void main() {}


### PR DESCRIPTION
Using a warning instead of an error to avoid breaking existing packages.

Affected issues: #1188, #1178