### PR TITLE
Don't call getpwuid for the user's name on Android

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -168,6 +168,8 @@ private string getUserName()
 		import core.sys.posix.pwd, core.sys.posix.unistd, core.stdc.string : strlen;
 		import std.algorithm : splitter;
 
+		// Bionic doesn't have pw_gecos on ARM
+		version(CRuntime_Bionic) {} else
 		if (auto pw = getpwuid(getuid))
 		{
 			auto uinfo = pw.pw_gecos[0 .. strlen(pw.pw_gecos)].splitter(',');


### PR DESCRIPTION
Bionic doesn't provide `pw_gecos`, so it doesn't work.  This is the only change I had to make to get a working dub on Android/ARM, pretty nice. :)

I tried running the dub tests on my Android/ARM tablet: around 9 failed because of issues such as some tests trying to compile for x64, linking against a Phobos shared library that isn't available on Android, and invoking `/dev/stdin` when there's no `/dev` on Android.  Also, 5-6 tests fail if I try to pass an absolute path for the D compiler to the unittesting script, which is reproducible on linux/x64 too.  I'll look at putting together a separate pull for that.

Finally, once this commit is in, I'll look at bundling dub along with [the Termux package for ldc](https://github.com/termux/termux-packages/tree/master/disabled-packages/ldc), to make it easy for Android users to use dub packages.