### PR TITLE
Fix #895, so that dub looks for a compiler next to itself first

### DIFF
--- a/test/issue895-local-configuration.sh
+++ b/test/issue895-local-configuration.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
-cd ${CURR_DIR}
-mkdir ../etc
-mkdir ../etc/dub
-echo "{\"defaultCompiler\": \"foo\"}" > ../etc/dub/settings.json
-
 if [ -e /var/lib/dub/settings.json ]; then
 	die $LINENO 'Found existing system wide DUB configuration. Aborting.'
 fi
@@ -14,9 +9,68 @@ if [ -e ~/.dub/settings.json ]; then
 	die $LINENO 'Found existing user wide DUB configuration. Aborting.'
 fi
 
-if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF 'Unknown compiler: foo'; then
-	rm -r ../etc
-	die $LINENO 'DUB did not find the local configuration'
+cd ${CURR_DIR}
+mkdir -p ../etc/dub
+echo "{\"defaultCompiler\": \"foo\"}" > ../etc/dub/settings.json
+echo "Empty file named foo." > ../bin/foo
+
+function cleanup {
+    rm -r ../etc
+}
+
+trap cleanup EXIT
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: $(dirname $CURR_DIR)/bin/foo"; then
+	rm ../bin/foo
+	die $LINENO 'DUB did not find the local configuration with an adjacent compiler.'
 fi
 
-rm -r ../etc
+echo "{\"defaultCompiler\": \"$CURR_DIR/foo\"}" > ../etc/dub/settings.json
+mv ../bin/foo $CURR_DIR
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: $CURR_DIR/foo"; then
+	rm $CURR_DIR/foo
+	die $LINENO 'DUB did not find a locally-configured compiler with an absolute path.'
+fi
+
+echo "{\"defaultCompiler\": \"~/.dub/foo\"}" > ../etc/dub/settings.json
+mv $CURR_DIR/foo ~/.dub/
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: "; then
+	rm ~/.dub/foo
+	die $LINENO 'DUB did not find a locally-configured compiler with a tilde-prefixed path.'
+fi
+
+echo "{\"defaultCompiler\": \"\$DUB_BINARY_PATH/../foo\"}" > ../etc/dub/settings.json
+mv ~/.dub/foo ..
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: $(dirname $CURR_DIR)/bin/../foo"; then
+	rm ../foo
+	die $LINENO 'DUB did not find a locally-configured compiler with a DUB-relative path.'
+fi
+
+echo "{\"defaultCompiler\": \"../foo\"}" > ../etc/dub/settings.json
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "defaultCompiler specified in a DUB config file cannot use an unqualified relative path"; then
+	rm ../foo
+	die $LINENO 'DUB did not error properly for a locally-configured compiler with a relative path.'
+fi
+
+rm ../etc/dub/settings.json
+echo "Empty file named ldc2." > ../bin/ldc2
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Failed to invoke the compiler $(dirname $CURR_DIR)/bin/ldc2 to determine the build platform"; then
+	rm ../bin/ldc2
+	die $LINENO 'DUB did not find ldc2 adjacent to it.'
+fi
+
+echo "{\"defaultCompiler\": \"foo\"}" > ../etc/dub/settings.json
+rm ../bin/ldc2
+export PATH=$(dirname $CURR_DIR)${PATH:+:$PATH}
+
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: foo"; then
+	rm ../foo
+	die $LINENO 'DUB did not find a locally-configured compiler in its PATH.'
+fi
+
+rm ../foo


### PR DESCRIPTION
Since [I didn't get a response about how checking for a compiler next to dub should interact with the one specified in a DUB config file](https://github.com/dlang/dub/issues/895#issuecomment-317688828), I went ahead and implemented what I thought makes sense.  I can add some tests once the behavior is approved.

Also puts some restrictions on the defaultCompiler specified in a DUB `settings.json`, such that it must be a compiler name or an absolute path, including a tilde-prefixed local path.  Relative paths are no longer
allowed, as they make no sense for how dub invokes the compiler.  You could argue that even a compiler name should be disallowed, as it's unlikely anyone will specify one that's not already on the default list that dub tries, but I suppose the sdc devs may want to try out dub some day. ;)

If a compiler name like `sdc` is specified in a DUB `settings.json`, I have dub check for other common compilers in the `PATH` only if `sdc` isn't found next to dub or on the `PATH` (__Update:__ which is probably why the test for #895 now fails on Travis CI, though the test will be changed), though you could argue the user only wants `sdc` used.  However, dub always says what compiler it's using and if the user hasn't provided an `sdc`, it's a convenience to search for another compiler.  I could change it to only check the `PATH` for `sdc` in that case, if wanted, as I do when checking next to dub.

Finally, all this changes nothing about specifying a compiler with `--compiler`, where none of this is used and you can specify any D compiler you want, including one with a relative path.