### PR TITLE
capture and log output of dub search failures

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -6,8 +6,11 @@ set -ueEo pipefail
 function die() {
     local line=$1
     local msg=${2:-command failed}
-    local rc=${3:-1}
+    local supplemental=${3:-}
     >&2 echo "$SOURCE_FILE:$1 Error: $msg"
-    exit $rc
+    if [ ! -z "$supplemental" ]; then
+        echo "$supplemental" | >&2 sed 's|^|        |g'
+    fi
+    exit 1
 }
 trap 'die $LINENO' ERR

--- a/test/feat663-search.sh
+++ b/test/feat663-search.sh
@@ -7,6 +7,6 @@ fi
 if ${DUB} search nonexistent123456789package 2>/dev/null; then
     die $LINENO '`dub search nonexistent123456789package` succeeded'
 fi
-if ! ${DUB} search dub | grep -q '^dub'; then
-    die $LINENO '`dub search dub` failed'
+if ! OUTPUT=$(${DUB} search dub -v 2>&1) || ! { echo "$OUTPUT" | grep -q '^dub (.*)\s'; } then
+    die $LINENO '`dub search dub` failed' "$OUTPUT"
 fi


### PR DESCRIPTION
As we're still seeing regular dub search failures on ci.dlang.io, e.g. https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/detail/PR-5671/3/.