### PR TITLE
Make issue884 unittest more portable by not using /dev/stdin anymore

### DIFF
--- a/test/issue884-init-defer-file-creation.sh
+++ b/test/issue884-init-defer-file-creation.sh
@@ -9,8 +9,7 @@ mkdir ${TMPDIR}
 cd ${TMPDIR}
 
 # kill dub init during interactive mode
-${DUB} init < /dev/stdin &
-sleep 1
+${DUB} init <(while :; do sleep 1; done) &
 kill $!
 
 # ensure that no files are left behind


### PR DESCRIPTION
The title says it all.
I had problems running the issue884 unittest within the checkPhase of my Nix build derivation for dub.

More information can be found here: https://groups.google.com/forum/#!topic/nix-devel/1LLxSCROgGY

I think it's worthwhile to change it to this more portable construct.