### PR TITLE
Provide HTTPStatusException in dub.internal.utils in dmd > 2.075

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -231,6 +231,8 @@ version(DubUseCurl) {
 
 		int status; /// The HTTP status code
 	}
+	else
+		public import std.net.curl : HTTPStatusException;
 } else version (Have_vibe_d_http) {
 	public import vibe.http.common : HTTPStatusException;
 }


### PR DESCRIPTION
I couldn't build with the latest dmd beta otherwise.