### PR TITLE
Prefer absolute paths in build generator if shorter than the relative one.

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -568,3 +568,10 @@ private string shrinkPath(Path path, Path base)
 	auto ret = path.relativeTo(base).toNativeString();
 	return ret.length < orig.length ? ret : orig;
 }
+
+unittest {
+	assert(shrinkPath(Path("/foo/bar/baz"), Path("/foo")) == Path("bar/baz").toNativeString());
+	assert(shrinkPath(Path("/foo/bar/baz"), Path("/foo/baz")) == Path("../bar/baz").toNativeString());
+	assert(shrinkPath(Path("/foo/bar/baz"), Path("/bar/")) == Path("/foo/bar/baz").toNativeString());
+	assert(shrinkPath(Path("/foo/bar/baz"), Path("/bar/baz")) == Path("/foo/bar/baz").toNativeString());
+}


### PR DESCRIPTION
This pushes the boundaries a bit more on Windows with its short default path length limit, especially in CI settings where the dub package cache is often in a completely different directory hierarchy than the main code that is being compiled.