### PR TITLE
Fix #555, tweak sed pattern in build.sh to check dmd version properly for ldc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ if [ "$DMD" = "" ]; then
 	exit 1
 fi
 
-VERSION=$($DMD --version 2>/dev/null | sed -n 's|DMD.* v||p')
+VERSION=$($DMD --version 2>/dev/null | sed -En 's|.*DMD.* v([[:digit:]\.]+).*|\1|p')
 # workaround for link order issues with libcurl (phobos needs to come before curl)
 if [[ $VERSION < 2.069.0 ]]; then
 	# link against libcurl


### PR DESCRIPTION
After this, it shouldn't apply the old fix for dmd before 2.069.