### PR TITLE
Use multiple registry fallbacks instead of one

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -65,7 +65,7 @@ static this()
 
 /// The URL to the official package registry.
 enum defaultRegistryURL = "http://code.dlang.org/";
-enum fallbackRegistryURL = "https://code-mirror.dlang.io/";
+enum fallbackRegistryURLs = ["https://code-mirror.dlang.io/"];
 
 /** Returns a default list of package suppliers.
 
@@ -80,7 +80,7 @@ PackageSupplier[] defaultPackageSuppliers()
 	return [
 		new FallbackPackageSupplier(
 			new RegistryPackageSupplier(URL(defaultRegistryURL)),
-			new RegistryPackageSupplier(URL(fallbackRegistryURL))
+			fallbackRegistryURLs.map!(x => cast(PackageSupplier) new RegistryPackageSupplier(URL(x))).array
 		)
 	];
 }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -64,8 +64,14 @@ static this()
 }
 
 /// The URL to the official package registry.
-enum defaultRegistryURL = "http://code.dlang.org/";
-enum fallbackRegistryURLs = ["https://code-mirror.dlang.io/"];
+enum defaultRegistryURL = "https://code.dlang.org/";
+enum fallbackRegistryURLs = [
+	// fallback in case of HTTPS problems
+	"http://code.dlang.org/",
+	"https://code-mirror.dlang.io/",
+	"https://code-mirror2.dlang.io/",
+	"https://dub-registry.herokuapp.com/",
+];
 
 /** Returns a default list of package suppliers.
 

--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -303,7 +303,7 @@ package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 
 	override @property string description()
 	{
-		import std.algorithm.iteration : map;
+		import std.algorithm : map;
 		return format("%s (fallback %s)", m_default.description, m_fallbacks.map!(x => x.description));
 	}
 

--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -325,14 +325,15 @@ private template fallback(T, alias func)
 {
 	enum fallback = q{
 		import std.range : back, dropBackOne;
+		import dub.internal.vibecompat.core.log : logDebug;
 		scope (failure)
 		{
 			foreach (m_fallback; m_fallbacks.dropBackOne)
 			{
 				try
 					return m_fallback.%1$s(args);
-				catch(Throwable)
-				    assert(1);
+				catch(Exception)
+					logDebug("Package supplier %s failed. Trying next fallback.", m_fallback);
 			}
 			return m_fallbacks.back.%1$s(args);
 		}


### PR DESCRIPTION
As we already see sometimes errors on Travis while downloading the installer script due to dlang.org and nightlies.dlang.org being down, it's imho a good idea to have multiple fallbacks by default for DUB.

https://code-mirror2.dlang.io is maintained by myself and the Heroku-App is based on https://github.com/dlang/dub-registry/pull/231