### PR TITLE
Allow testing unittests in main() module

### DIFF
--- a/test/issue959-path-based-subpack-dep/dub.sdl
+++ b/test/issue959-path-based-subpack-dep/dub.sdl
@@ -1,6 +1,7 @@
 name "bar"
 mainSourceFile "main.d"
 targetType "executable"
+importPaths "."
 
 dependency "foo" path="foo"
 dependency "foo:baz" path="foo"


### PR DESCRIPTION
We avoid defining our own main() for executables. In order to avoid
running main(), we provide our own test runner that exits when done
instead of ceding control back to the runtime.

The downside is that module destructors are not called.

Fixes #1118.