### PR TITLE
Fix AppVeyor for LDC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,15 @@ environment:
   - DC: dmd
     DVersion: stable
     arch: x86
-  - DC: ldc
-    DVersion: beta
-    arch: x64
-  - DC: ldc
-    DVersion: stable
-    arch: x64
-  - DC: ldc
-    DVersion: 1.2.0
-    arch: x64
+  #- DC: ldc
+    #DVersion: beta
+    #arch: x64
+  #- DC: ldc
+    #DVersion: stable
+    #arch: x64
+  #- DC: ldc
+    #DVersion: 1.2.0
+    #arch: x64
 
 skip_tags: false
 branches:


### PR DESCRIPTION
Experiment to use the `curl.lib` shipped with LDC - maybe DUB should always try to use the vendored curl.lib and don't provide its own?