### PR TITLE
Refactor determinePlatform, determineArchitecture, determineCompiler so their checks can be reused

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -18,7 +18,6 @@ import dub.internal.vibecompat.inet.url;
 import dub.package_;
 import dub.packagemanager;
 import dub.packagesupplier;
-import dub.platform : determineCompiler;
 import dub.project;
 import dub.internal.utils : getDUBVersion, getClosestMatch;
 

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.platform;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.platform;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.platform;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -8,7 +8,7 @@
 module dub.compilers.utils;
 
 import dub.compilers.buildsettings;
-import dub.platform;
+import dub.platform : BuildPlatform, archCheck, compilerCheck, platformCheck;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
 import std.algorithm : canFind, endsWith, filter;
@@ -255,9 +255,9 @@ Path generatePlatformProbeFile()
 		fil.close();
 	}
 
-	// NOTE: This must be kept in sync with the dub.platform module
 	fil.write(q{
 		module dub_platform_probe;
+		import std.array;
 
 		template toString(int v) { enum toString = v.stringof; }
 
@@ -273,83 +273,13 @@ Path generatePlatformProbeFile()
 		pragma(msg, `   ],`);
 		pragma(msg, `}`);
 
-		string determinePlatform()
-		{
-			string ret;
-			version(Windows) ret ~= `"windows", `;
-			version(linux) ret ~= `"linux", `;
-			version(Posix) ret ~= `"posix", `;
-			version(OSX) ret ~= `"osx", `;
-			version(FreeBSD) ret ~= `"freebsd", `;
-			version(OpenBSD) ret ~= `"openbsd", `;
-			version(NetBSD) ret ~= `"netbsd", `;
-			version(DragonFlyBSD) ret ~= `"dragonflybsd", `;
-			version(BSD) ret ~= `"bsd", `;
-			version(Solaris) ret ~= `"solaris", `;
-			version(AIX) ret ~= `"aix", `;
-			version(Haiku) ret ~= `"haiku", `;
-			version(SkyOS) ret ~= `"skyos", `;
-			version(SysV3) ret ~= `"sysv3", `;
-			version(SysV4) ret ~= `"sysv4", `;
-			version(Hurd) ret ~= `"hurd", `;
-			version(Android) ret ~= `"android", `;
-			version(Cygwin) ret ~= `"cygwin", `;
-			version(MinGW) ret ~= `"mingw", `;
-			return ret;
-		}
+		string determinePlatform() } ~ '{' ~ platformCheck ~
+		`	return '"' ~ ret.data.join("\", \"") ~ "\", "; }` ~ q{
 
-		string determineArchitecture()
-		{
-			string ret;
-			version(X86) ret ~= `"x86", `;
-			version(X86_64) ret ~= `"x86_64", `;
-			version(ARM) ret ~= `"arm", `;
-			version(ARM_Thumb) ret ~= `"arm_thumb", `;
-			version(ARM_SoftFloat) ret ~= `"arm_softfloat", `;
-			version(ARM_HardFloat) ret ~= `"arm_hardfloat", `;
-			version(ARM64) ret ~= `"arm64", `;
-			version(PPC) ret ~= `"ppc", `;
-			version(PPC_SoftFP) ret ~= `"ppc_softfp", `;
-			version(PPC_HardFP) ret ~= `"ppc_hardfp", `;
-			version(PPC64) ret ~= `"ppc64", `;
-			version(IA64) ret ~= `"ia64", `;
-			version(MIPS) ret ~= `"mips", `;
-			version(MIPS32) ret ~= `"mips32", `;
-			version(MIPS64) ret ~= `"mips64", `;
-			version(MIPS_O32) ret ~= `"mips_o32", `;
-			version(MIPS_N32) ret ~= `"mips_n32", `;
-			version(MIPS_O64) ret ~= `"mips_o64", `;
-			version(MIPS_N64) ret ~= `"mips_n64", `;
-			version(MIPS_EABI) ret ~= `"mips_eabi", `;
-			version(MIPS_NoFloat) ret ~= `"mips_nofloat", `;
-			version(MIPS_SoftFloat) ret ~= `"mips_softfloat", `;
-			version(MIPS_HardFloat) ret ~= `"mips_hardfloat", `;
-			version(SPARC) ret ~= `"sparc", `;
-			version(SPARC_V8Plus) ret ~= `"sparc_v8plus", `;
-			version(SPARC_SoftFP) ret ~= `"sparc_softfp", `;
-			version(SPARC_HardFP) ret ~= `"sparc_hardfp", `;
-			version(SPARC64) ret ~= `"sparc64", `;
-			version(S390) ret ~= `"s390", `;
-			version(S390X) ret ~= `"s390x", `;
-			version(HPPA) ret ~= `"hppa", `;
-			version(HPPA64) ret ~= `"hppa64", `;
-			version(SH) ret ~= `"sh", `;
-			version(SH64) ret ~= `"sh64", `;
-			version(Alpha) ret ~= `"alpha", `;
-			version(Alpha_SoftFP) ret ~= `"alpha_softfp", `;
-			version(Alpha_HardFP) ret ~= `"alpha_hardfp", `;
-			return ret;
-		}
+		string determineArchitecture() } ~ '{' ~ archCheck ~
+		`	return '"' ~ ret.data.join("\", \"") ~ "\", "; }` ~ q{
 
-		string determineCompiler()
-		{
-			version(DigitalMars) return "dmd";
-			else version(GNU) return "gdc";
-			else version(LDC) return "ldc";
-			else version(SDC) return "sdc";
-			else return null;
-		}
-	});
+		string determineCompiler() } ~ '{' ~ compilerCheck ~ "	}");
 
 	fil.close();
 

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -19,6 +19,7 @@ import std.array;
 // archCheck, compilerCheck, and platformCheck are used below and in
 // generatePlatformProbeFile, so they've been extracted into these strings
 // that can be reused.
+/// private
 enum string platformCheck = q{
 	auto ret = appender!(string[])();
 	version(Windows) ret.put("windows");
@@ -42,6 +43,7 @@ enum string platformCheck = q{
 	version(MinGW) ret.put("mingw");
 };
 
+/// private
 enum string archCheck = q{
 	auto ret = appender!(string[])();
 	version(X86) ret.put("x86");
@@ -83,6 +85,7 @@ enum string archCheck = q{
 	version(Alpha_HardFP) ret.put("alpha_hardfp");
 };
 
+/// private
 enum string compilerCheck = q{
 	version(DigitalMars) return "dmd";
 	else version(GNU) return "gdc";

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -1,5 +1,5 @@
 /**
-	Build platform identification and speficiation matching.
+	Build platform identification and specification matching.
 
 	This module is useful for determining the build platform for a certain
 	machine and compiler invocation. Example applications include classifying
@@ -8,7 +8,7 @@
 	It also contains means to match build platforms against a platform
 	specification string as used in package reciptes.
 
-	Copyright: © 2012-2016 rejectedsoftware e.K.
+	Copyright: © 2012-2017 rejectedsoftware e.K.
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */
@@ -16,35 +16,10 @@ module dub.platform;
 
 import std.array;
 
-
-/** Determines the full build platform used for the current build.
-
-	Note that the `BuildPlatform.compilerBinary` field will be left empty.
-
-	See_Also: `determinePlatform`, `determineArchitecture`, `determineCompiler`
-*/
-BuildPlatform determineBuildPlatform()
-{
-	BuildPlatform ret;
-	ret.platform = determinePlatform();
-	ret.architecture = determineArchitecture();
-	ret.compiler = determineCompiler();
-	ret.frontendVersion = __VERSION__;
-	return ret;
-}
-
-
-/** Returns a list of platform identifiers that apply to the current
-	build.
-
-	Example results are `["windows"]` or `["posix", "osx"]`. The identifiers
-	correspond to the compiler defined version constants built into the
-	language, except that they are converted to lower case.
-
-	See_Also: `determineBuildPlatform`
-*/
-string[] determinePlatform()
-{
+// archCheck, compilerCheck, and platformCheck are used below and in
+// generatePlatformProbeFile, so they've been extracted into these strings
+// that can be reused.
+enum string platformCheck = q{
 	auto ret = appender!(string[])();
 	version(Windows) ret.put("windows");
 	version(linux) ret.put("linux");
@@ -65,20 +40,9 @@ string[] determinePlatform()
 	version(Android) ret.put("android");
 	version(Cygwin) ret.put("cygwin");
 	version(MinGW) ret.put("mingw");
-	return ret.data;
-}
+};
 
-/** Returns a list of architecture identifiers that apply to the current
-	build.
-
-	Example results are `["x86_64"]` or `["arm", "arm_softfloat"]`. The
-	identifiers correspond to the compiler defined version constants built into
-	the language, except that they are converted to lower case.
-
-	See_Also: `determineBuildPlatform`
-*/
-string[] determineArchitecture()
-{
+enum string archCheck = q{
 	auto ret = appender!(string[])();
 	version(X86) ret.put("x86");
 	version(X86_64) ret.put("x86_64");
@@ -117,23 +81,73 @@ string[] determineArchitecture()
 	version(Alpha) ret.put("alpha");
 	version(Alpha_SoftFP) ret.put("alpha_softfp");
 	version(Alpha_HardFP) ret.put("alpha_hardfp");
+};
+
+enum string compilerCheck = q{
+	version(DigitalMars) return "dmd";
+	else version(GNU) return "gdc";
+	else version(LDC) return "ldc";
+	else version(SDC) return "sdc";
+	else return null;
+};
+
+/** Determines the full build platform used for the current build.
+
+	Note that the `BuildPlatform.compilerBinary` field will be left empty.
+
+	See_Also: `determinePlatform`, `determineArchitecture`, `determineCompiler`
+*/
+BuildPlatform determineBuildPlatform()
+{
+	BuildPlatform ret;
+	ret.platform = determinePlatform();
+	ret.architecture = determineArchitecture();
+	ret.compiler = determineCompiler();
+	ret.frontendVersion = __VERSION__;
+	return ret;
+}
+
+
+/** Returns a list of platform identifiers that apply to the current
+	build.
+
+	Example results are `["windows"]` or `["posix", "osx"]`. The identifiers
+	correspond to the compiler defined version constants built into the
+	language, except that they are converted to lower case.
+
+	See_Also: `determineBuildPlatform`
+*/
+string[] determinePlatform()
+{
+	mixin(platformCheck);
+	return ret.data;
+}
+
+/** Returns a list of architecture identifiers that apply to the current
+	build.
+
+	Example results are `["x86_64"]` or `["arm", "arm_softfloat"]`. The
+	identifiers correspond to the compiler defined version constants built into
+	the language, except that they are converted to lower case.
+
+	See_Also: `determineBuildPlatform`
+*/
+string[] determineArchitecture()
+{
+	mixin(archCheck);
 	return ret.data;
 }
 
 /** Determines the canonical compiler name used for the current build.
 
-	The possible values currently are "dmd", "gdc", "ldc2" or "sdc". If an
+	The possible values currently are "dmd", "gdc", "ldc" or "sdc". If an
 	unknown compiler is used, this function will return an empty string.
 
 	See_Also: `determineBuildPlatform`
 */
 string determineCompiler()
 {
-	version(DigitalMars) return "dmd";
-	else version(GNU) return "gdc";
-	else version(LDC) return "ldc2";
-	else version(SDC) return "sdc";
-	else return null;
+	mixin(compilerCheck);
 }
 
 /** Matches a platform specification string against a build platform.


### PR DESCRIPTION
~~Only `determinePlatform` was used anywhere, in a single unit test.  Cut-and-pasted the doc comments into `dub.compilers.utils`, where the versions of these functions were actually used.~~  [Mentioned this duplication before when I was looking at a different issue](https://github.com/dlang/dub/issues/1206#issuecomment-318161102), ~~thought I'd get rid of~~ refactored it.