### PR TITLE
Reduce console/log noise for package linting messages

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -117,7 +117,6 @@ class Package {
 		m_info = recipe;
 
 		fillWithDefaults();
-		simpleLint();
 	}
 
 	/** Searches the given directory for package recipe files.
@@ -674,7 +673,7 @@ class Package {
 		}
 	}
 
-	private void simpleLint()
+	package void simpleLint()
 	const {
 		if (m_parentPackage) {
 			if (m_parentPackage.path != path) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -293,6 +293,9 @@ class Project {
 		// check for version specification mismatches
 		bool[Package] visited;
 		void validateDependenciesRec(Package pack) {
+			// perform basic package linting
+			pack.simpleLint();
+
 			foreach (d; pack.getAllDependencies()) {
 				auto basename = getBasePackageName(d.name);
 				if (m_selections.hasSelectedVersion(basename)) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -303,7 +303,7 @@ class Project {
 					}
 				}
 
-				auto deppack = getDependency(name, true);
+				auto deppack = getDependency(d.name, true);
 				if (deppack in visited) continue;
 				visited[deppack] = true;
 				if (deppack) validateDependenciesRec(deppack);


### PR DESCRIPTION
Only outputs messages for packages in the currect project. Also fixes the recursive part of the package validation code to actually do something.