### PR TITLE
Make the code compatible with vibe-core

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,15 +3,15 @@
 	"versions": {
 		"botan": "1.12.9",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.4.1",
-		"eventcore": "0.8.14",
+		"diet-ng": "1.4.3",
+		"eventcore": "0.8.21",
 		"libasync": "0.8.3",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
-		"openssl": "1.1.5+1.0.1g",
+		"openssl": "1.1.6+1.0.1g",
 		"taggedalgebraic": "0.10.7",
-		"vibe-core": "1.0.0",
-		"vibe-d": "0.8.0"
+		"vibe-core": "1.2.0",
+		"vibe-d": "0.8.1"
 	}
 }

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1711,7 +1711,7 @@ class DustmiteCommand : PackageBuildCommand {
 			enforceUsage(free_args.length == 1, "Expected destination path.");
 			auto path = Path(free_args[0]);
 			path.normalize();
-			enforceUsage(path.length > 0, "Destination path must not be empty.");
+			enforceUsage(!path.empty, "Destination path must not be empty.");
 			if (!path.absolute) path = Path(getcwd()) ~ path;
 			enforceUsage(!path.startsWith(dub.rootPath), "Destination path must not be a sub directory of the tested package!");
 
@@ -1739,7 +1739,7 @@ class DustmiteCommand : PackageBuildCommand {
 			}
 
 			static void fixPathDependency(string pack, ref Dependency dep) {
-				if (dep.path.length > 0) {
+				if (!dep.path.empty) {
 					auto mainpack = getBasePackageName(pack);
 					dep.path = Path("../") ~ mainpack;
 				}

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -167,9 +167,9 @@ private:
 	static void addSI(ref string[] arr, in string[] vals)
 	{
 		bool[string] existing;
-		foreach (v; arr) existing[Path(v).head.toString()] = true;
+		foreach (v; arr) existing[NativePath(v).head.toString()] = true;
 		foreach (v; vals) {
-			auto s = Path(v).head.toString();
+			auto s = NativePath(v).head.toString();
 			if (s !in existing) {
 				existing[s] = true;
 				arr ~= v;
@@ -191,7 +191,7 @@ private:
 		bool matches(string s)
 		{
 			foreach (p; vals)
-				if (Path(s) == Path(p) || globMatch(s, p))
+				if (NativePath(s) == NativePath(p) || globMatch(s, p))
 					return true;
 			return false;
 		}

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -192,7 +192,7 @@ class DMDCompiler : Compiler {
 		}
 
 		if (tpath is null)
-			tpath = (Path(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
+			tpath = (NativePath(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
 		settings.addDFlags("-of"~tpath);
 	}
 
@@ -210,7 +210,7 @@ class DMDCompiler : Compiler {
 	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback)
 	{
 		import std.string;
-		auto tpath = Path(settings.targetPath) ~ getTargetFileName(settings, platform);
+		auto tpath = NativePath(settings.targetPath) ~ getTargetFileName(settings, platform);
 		auto args = ["-of"~tpath.toNativeString()];
 		args ~= objects;
 		args ~= settings.sourceFiles;

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -182,7 +182,7 @@ class GDCCompiler : Compiler {
 		}
 
 		if (tpath is null)
-			tpath = (Path(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
+			tpath = (NativePath(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
 		settings.addDFlags("-o", tpath);
 	}
 

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -195,7 +195,7 @@ class LDCCompiler : Compiler {
 		}
 
 		if (tpath is null)
-			tpath = (Path(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
+			tpath = (NativePath(settings.targetPath) ~ getTargetFileName(settings, platform)).toNativeString();
 		settings.addDFlags("-of"~tpath);
 	}
 

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -242,7 +242,7 @@ void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, s
 
 	See_Also: `readPlatformProbe`
 */
-Path generatePlatformProbeFile()
+NativePath generatePlatformProbeFile()
 {
 	import dub.internal.vibecompat.core.file;
 	import dub.internal.vibecompat.data.json;

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -53,7 +53,7 @@ struct Dependency {
 		Version m_versA;
 		bool m_inclusiveB = true; // B comparison < (true) or <= (false)
 		Version m_versB;
-		Path m_path;
+		NativePath m_path;
 		bool m_optional = false;
 		bool m_default = false;
 	}
@@ -87,16 +87,16 @@ struct Dependency {
 	/** Constructs a new dependency specification that matches a specific
 		path.
 	*/
-	this(Path path)
+	this(NativePath path)
 	{
 		this(ANY_IDENT);
 		m_path = path;
 	}
 
 	/// If set, overrides any version based dependency selection.
-	@property void path(Path value) { m_path = value; }
+	@property void path(NativePath value) { m_path = value; }
 	/// ditto
-	@property Path path() const { return m_path; }
+	@property NativePath path() const { return m_path; }
 
 	/// Determines if the dependency is required or optional.
 	@property bool optional() const { return m_optional; }
@@ -239,7 +239,7 @@ struct Dependency {
 		based. Otherwise, the given `path` will be prefixed to the existing
 		path.
 	*/
-	Dependency mapToPath(Path path)
+	Dependency mapToPath(NativePath path)
 	const @trusted { // NOTE Path is @system in vibe.d 0.7.x and in the compatibility layer
 		if (m_path.empty || m_path.absolute) return this;
 		else {
@@ -311,7 +311,7 @@ struct Dependency {
 					logDiagnostic("Ignoring version specification (%s) for path based dependency %s", pv.get!string, pp.get!string);
 
 				dep = Dependency.any;
-				dep.path = Path(verspec["path"].get!string);
+				dep.path = NativePath(verspec["path"].get!string);
 			} else {
 				enforce("version" in verspec, "No version field specified!");
 				auto ver = verspec["version"].get!string;
@@ -341,7 +341,7 @@ struct Dependency {
 		Dependency d = Dependency.any; // supposed to ignore the version spec
 		d.optional = true;
 		d.default_ = true;
-		d.path = Path("path/to/package");
+		d.path = NativePath("path/to/package");
 		assert(d == parsed);
 		// optional and path not checked by opEquals.
 		assert(d.optional == parsed.optional);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -516,11 +516,11 @@ class Dub {
 	*/
 	void testProject(GeneratorSettings settings, string config, Path custom_main_file)
 	{
-		if (custom_main_file.length && !custom_main_file.absolute) custom_main_file = getWorkingDirectory() ~ custom_main_file;
+		if (!custom_main_file.empty && !custom_main_file.absolute) custom_main_file = getWorkingDirectory() ~ custom_main_file;
 
 		if (config.length == 0) {
 			// if a custom main file was given, favor the first library configuration, so that it can be applied
-			if (custom_main_file.length) config = m_project.getDefaultConfiguration(settings.platform, false);
+			if (!custom_main_file.empty) config = m_project.getDefaultConfiguration(settings.platform, false);
 			// else look for a "unittest" configuration
 			if (!config.length && m_project.rootPackage.configurations.canFind("unittest")) config = "unittest";
 			// if not found, fall back to the first "library" configuration
@@ -565,7 +565,7 @@ class Dub {
 			if (!mainfil.length) mainfil = m_project.rootPackage.recipe.buildSettings.mainSourceFile;
 
 			string custommodname;
-			if (custom_main_file.length) {
+			if (!custom_main_file.empty) {
 				import std.path;
 				tcinfo.sourceFiles[""] ~= custom_main_file.relativeTo(m_project.rootPackage.path).toNativeString();
 				tcinfo.importPaths[""] ~= custom_main_file.parentPath.toNativeString();
@@ -1090,13 +1090,13 @@ class Dub {
 		}
 
 		auto srcfile = m_project.rootPackage.recipePath;
-		auto srcext = srcfile[$-1].toString().extension;
+		auto srcext = srcfile.head.toString().extension;
 		if (srcext == "."~destination_file_ext) {
 			logInfo("Package format is already %s.", destination_file_ext);
 			return;
 		}
 
-		writePackageRecipe(srcfile[0 .. $-1] ~ ("dub."~destination_file_ext), m_project.rootPackage.rawRecipe);
+		writePackageRecipe(srcfile.parentPath ~ ("dub."~destination_file_ext), m_project.rootPackage.rawRecipe);
 		removeFile(srcfile);
 	}
 
@@ -1165,7 +1165,7 @@ class Dub {
 
 	private void updatePackageSearchPath()
 	{
-		if (m_overrideSearchPath.length) {
+		if (!m_overrideSearchPath.empty) {
 			m_packageManager.disableDefaultSearchPaths = true;
 			m_packageManager.searchPath = [m_overrideSearchPath];
 		} else {

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -99,12 +99,12 @@ class Dub {
 		bool m_dryRun = false;
 		PackageManager m_packageManager;
 		PackageSupplier[] m_packageSuppliers;
-		Path m_rootPath;
+		NativePath m_rootPath;
 		SpecialDirs m_dirs;
 		DubConfig m_config;
-		Path m_projectPath;
+		NativePath m_projectPath;
 		Project m_project;
-		Path m_overrideSearchPath;
+		NativePath m_overrideSearchPath;
 		string m_defaultCompiler;
 	}
 
@@ -133,8 +133,8 @@ class Dub {
 	this(string root_path = ".", PackageSupplier[] additional_package_suppliers = null,
 			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none)
 	{
-		m_rootPath = Path(root_path);
-		if (!m_rootPath.absolute) m_rootPath = Path(getcwd()) ~ m_rootPath;
+		m_rootPath = NativePath(root_path);
+		if (!m_rootPath.absolute) m_rootPath = NativePath(getcwd()) ~ m_rootPath;
 
 		init();
 
@@ -185,11 +185,11 @@ class Dub {
 		This constructor corresponds to the "--bare" option of the command line
 		interface. Use
 	*/
-	this(Path override_path)
+	this(NativePath override_path)
 	{
 		init();
 		m_overrideSearchPath = override_path;
-		m_packageManager = new PackageManager(Path(), Path(), false);
+		m_packageManager = new PackageManager(NativePath(), NativePath(), false);
 		updatePackageSearchPath();
 	}
 
@@ -197,19 +197,19 @@ class Dub {
 	{
 		import std.file : tempDir;
 		version(Windows) {
-			m_dirs.systemSettings = Path(environment.get("ProgramData")) ~ "dub/";
-			m_dirs.userSettings = Path(environment.get("APPDATA")) ~ "dub/";
+			m_dirs.systemSettings = NativePath(environment.get("ProgramData")) ~ "dub/";
+			m_dirs.userSettings = NativePath(environment.get("APPDATA")) ~ "dub/";
 		} else version(Posix){
-			m_dirs.systemSettings = Path("/var/lib/dub/");
-			m_dirs.userSettings = Path(environment.get("HOME")) ~ ".dub/";
+			m_dirs.systemSettings = NativePath("/var/lib/dub/");
+			m_dirs.userSettings = NativePath(environment.get("HOME")) ~ ".dub/";
 			if (!m_dirs.userSettings.absolute)
-				m_dirs.userSettings = Path(getcwd()) ~ m_dirs.userSettings;
+				m_dirs.userSettings = NativePath(getcwd()) ~ m_dirs.userSettings;
 		}
 
-		m_dirs.temp = Path(tempDir);
+		m_dirs.temp = NativePath(tempDir);
 
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
-		m_config = new DubConfig(jsonFromFile(Path(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
+		m_config = new DubConfig(jsonFromFile(NativePath(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		determineDefaultCompiler();
@@ -219,19 +219,19 @@ class Dub {
 
 	/** Returns the root path (usually the current working directory).
 	*/
-	@property Path rootPath() const { return m_rootPath; }
+	@property NativePath rootPath() const { return m_rootPath; }
 	/// ditto
-	@property void rootPath(Path root_path)
+	@property void rootPath(NativePath root_path)
 	{
 		m_rootPath = root_path;
-		if (!m_rootPath.absolute) m_rootPath = Path(getcwd()) ~ m_rootPath;
+		if (!m_rootPath.absolute) m_rootPath = NativePath(getcwd()) ~ m_rootPath;
 	}
 
 	/// Returns the name listed in the dub.json of the current
 	/// application.
 	@property string projectName() const { return m_project.name; }
 
-	@property Path projectPath() const { return m_projectPath; }
+	@property NativePath projectPath() const { return m_projectPath; }
 
 	@property string[] configurations() const { return m_project.configurations; }
 
@@ -258,7 +258,7 @@ class Dub {
 	}
 
 	/// Loads the package from the specified path as the main project package.
-	void loadPackage(Path path)
+	void loadPackage(NativePath path)
 	{
 		m_projectPath = path;
 		updatePackageSearchPath();
@@ -303,7 +303,7 @@ class Dub {
 
 		The script above can be invoked with "dub --single test.d".
 	*/
-	void loadSingleFilePackage(Path path)
+	void loadSingleFilePackage(NativePath path)
 	{
 		import dub.recipe.io : parsePackageRecipe;
 		import std.file : mkdirRecurse, readText;
@@ -356,15 +356,15 @@ class Dub {
 	/// ditto
 	void loadSingleFilePackage(string path)
 	{
-		loadSingleFilePackage(Path(path));
+		loadSingleFilePackage(NativePath(path));
 	}
 
 	/** Disables the default search paths and only searches a specific directory
 		for packages.
 	*/
-	void overrideSearchPath(Path path)
+	void overrideSearchPath(NativePath path)
 	{
-		if (!path.absolute) path = Path(getcwd()) ~ path;
+		if (!path.absolute) path = NativePath(getcwd()) ~ path;
 		m_overrideSearchPath = path;
 		updatePackageSearchPath();
 	}
@@ -486,7 +486,7 @@ class Dub {
 			if ((options & UpgradeOptions.select) && p != m_project.rootPackage.name) {
 				if (ver.path.empty) m_project.selections.selectVersion(p, ver.version_);
 				else {
-					Path relpath = ver.path;
+					NativePath relpath = ver.path;
 					if (relpath.absolute) relpath = relpath.relativeTo(m_project.rootPackage.path);
 					m_project.selections.selectVersion(p, relpath);
 				}
@@ -514,7 +514,7 @@ class Dub {
 
 		Throws an exception, if unittests failed.
 	*/
-	void testProject(GeneratorSettings settings, string config, Path custom_main_file)
+	void testProject(GeneratorSettings settings, string config, NativePath custom_main_file)
 	{
 		if (!custom_main_file.empty && !custom_main_file.absolute) custom_main_file = getWorkingDirectory() ~ custom_main_file;
 
@@ -576,8 +576,8 @@ class Dub {
 			string[] import_modules;
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
-					auto fname = Path(file).head.toString();
-					if (Path(file).relativeTo(m_project.rootPackage.path) == Path(mainfil)) {
+					auto fname = NativePath(file).head.toString();
+					if (NativePath(file).relativeTo(m_project.rootPackage.path) == NativePath(mainfil)) {
 						logWarn("Excluding main source file %s from test.", mainfil);
 						tcinfo.excludedSourceFiles[""] ~= mainfil;
 						continue;
@@ -586,12 +586,12 @@ class Dub {
 						logWarn("Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847");
 						continue;
 					}
-					import_modules ~= dub.internal.utils.determineModuleName(lbuildsettings, Path(file), m_project.rootPackage.path);
+					import_modules ~= dub.internal.utils.determineModuleName(lbuildsettings, NativePath(file), m_project.rootPackage.path);
 				}
 			}
 
 			// generate main file
-			Path mainfile = getTempFile("dub_test_root", ".d");
+			NativePath mainfile = getTempFile("dub_test_root", ".d");
 			tcinfo.sourceFiles[""] ~= mainfile.toNativeString();
 			tcinfo.mainSourceFile = mainfile.toNativeString();
 			if (!m_dryRun) {
@@ -665,7 +665,7 @@ class Dub {
 	}
 
 	/// Cleans intermediate/cache files of the given package
-	void cleanPackage(Path path)
+	void cleanPackage(NativePath path)
 	{
 		logInfo("Cleaning package at %s...", path.toNativeString());
 		enforce(!Package.findPackageFile(path).empty, "No package found.", path.toNativeString());
@@ -696,7 +696,7 @@ class Dub {
 		enforce(pinfo.type != Json.Type.undefined, "No package "~packageId~" was found matching the dependency "~dep.toString());
 		string ver = pinfo["version"].get!string;
 
-		Path placement;
+		NativePath placement;
 		final switch (location) {
 			case PlacementLocation.local: placement = m_rootPath; break;
 			case PlacementLocation.user: placement = m_dirs.userSettings ~ "packages/"; break;
@@ -740,7 +740,7 @@ class Dub {
 		clean_package_version = clean_package_version.replace("+", "_"); // + has special meaning for Optlink
 		if (!placement.existsFile())
 			mkdirRecurse(placement.toNativeString());
-		Path dstpath = placement ~ (packageId ~ "-" ~ clean_package_version);
+		NativePath dstpath = placement ~ (packageId ~ "-" ~ clean_package_version);
 		if (!dstpath.existsFile())
 			mkdirRecurse(dstpath.toNativeString());
 
@@ -1036,7 +1036,7 @@ class Dub {
 			recipe_callback = Optional callback that can be used to
 				customize the recipe before it gets written.
 	*/
-	void createEmptyPackage(Path path, string[] deps, string type,
+	void createEmptyPackage(NativePath path, string[] deps, string type,
 		PackageFormat format = PackageFormat.sdl,
 		scope void delegate(ref PackageRecipe, ref PackageFormat) recipe_callback = null)
 	{
@@ -1170,11 +1170,11 @@ class Dub {
 			m_packageManager.searchPath = [m_overrideSearchPath];
 		} else {
 			auto p = environment.get("DUBPATH");
-			Path[] paths;
+			NativePath[] paths;
 
 			version(Windows) enum pathsep = ";";
 			else enum pathsep = ":";
-			if (p.length) paths ~= p.split(pathsep).map!(p => Path(p))().array();
+			if (p.length) paths ~= p.split(pathsep).map!(p => NativePath(p))().array();
 			m_packageManager.disableDefaultSearchPaths = false;
 			m_packageManager.searchPath = paths;
 		}
@@ -1193,13 +1193,13 @@ class Dub {
 
 		auto compilers = ["dmd", "gdc", "gdmd", "ldc2", "ldmd2"];
 
-		auto paths = environment.get("PATH", "").splitter(sep).map!Path;
+		auto paths = environment.get("PATH", "").splitter(sep).map!NativePath;
 		auto res = compilers.find!(bin => paths.canFind!(p => existsFile(p ~ (bin~exe))));
 		m_defaultCompiler = res.empty ? compilers[0] : res.front;
 	}
 
-	private Path makeAbsolute(Path p) const { return p.absolute ? p : m_rootPath ~ p; }
-	private Path makeAbsolute(string p) const { return makeAbsolute(Path(p)); }
+	private NativePath makeAbsolute(NativePath p) const { return p.absolute ? p : m_rootPath ~ p; }
+	private NativePath makeAbsolute(string p) const { return makeAbsolute(NativePath(p)); }
 }
 
 
@@ -1512,9 +1512,9 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 }
 
 private struct SpecialDirs {
-	Path temp;
-	Path userSettings;
-	Path systemSettings;
+	NativePath temp;
+	NativePath userSettings;
+	NativePath systemSettings;
 }
 
 private class DubConfig {

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -103,7 +103,7 @@ class BuildGenerator : ProjectGenerator {
 		auto buildsettings = targets[m_project.rootPackage.name].buildSettings.dup;
 		if (settings.run && !(buildsettings.options & BuildOption.syntaxOnly)) {
 			Path exe_file_path;
-			if (!m_targetExecutablePath.length)
+			if (m_targetExecutablePath.empty)
 				exe_file_path = getTargetPath(buildsettings, settings);
 			else
 				exe_file_path = m_targetExecutablePath ~ settings.compiler.getTargetFileName(buildsettings, settings.platform);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -33,8 +33,8 @@ else enum objSuffix = ".o";
 class BuildGenerator : ProjectGenerator {
 	private {
 		PackageManager m_packageMan;
-		Path[] m_temporaryFiles;
-		Path m_targetExecutablePath;
+		NativePath[] m_temporaryFiles;
+		NativePath m_targetExecutablePath;
 	}
 
 	this(Project project)
@@ -52,7 +52,7 @@ class BuildGenerator : ProjectGenerator {
 
 		bool any_cached = false;
 
-		Path[string] target_paths;
+		NativePath[string] target_paths;
 
 		bool[string] visited;
 		void buildTargetRec(string target)
@@ -65,7 +65,7 @@ class BuildGenerator : ProjectGenerator {
 			foreach (dep; ti.dependencies)
 				buildTargetRec(dep);
 
-			Path[] additional_dep_files;
+			NativePath[] additional_dep_files;
 			auto bs = ti.buildSettings.dup;
 			foreach (ldep; ti.linkDependencies) {
 				auto dbs = targets[ldep].buildSettings;
@@ -75,7 +75,7 @@ class BuildGenerator : ProjectGenerator {
 					additional_dep_files ~= target_paths[ldep];
 				}
 			}
-			Path tpath;
+			NativePath tpath;
 			if (buildTarget(settings, bs, ti.pack, ti.config, ti.packages, additional_dep_files, tpath))
 				any_cached = true;
 			target_paths[target] = tpath;
@@ -86,7 +86,7 @@ class BuildGenerator : ProjectGenerator {
 		if (settings.rdmd || root_ti.buildSettings.targetType == TargetType.staticLibrary) {
 			// RDMD always builds everything at once and static libraries don't need their
 			// dependencies to be built
-			Path tpath;
+			NativePath tpath;
 			buildTarget(settings, root_ti.buildSettings.dup, m_project.rootPackage, root_ti.config, root_ti.packages, null, tpath);
 		} else {
 			buildTargetRec(m_project.rootPackage.name);
@@ -102,7 +102,7 @@ class BuildGenerator : ProjectGenerator {
 		// run the generated executable
 		auto buildsettings = targets[m_project.rootPackage.name].buildSettings.dup;
 		if (settings.run && !(buildsettings.options & BuildOption.syntaxOnly)) {
-			Path exe_file_path;
+			NativePath exe_file_path;
 			if (m_targetExecutablePath.empty)
 				exe_file_path = getTargetPath(buildsettings, settings);
 			else
@@ -111,15 +111,15 @@ class BuildGenerator : ProjectGenerator {
 		}
 	}
 
-	private bool buildTarget(GeneratorSettings settings, BuildSettings buildsettings, in Package pack, string config, in Package[] packages, in Path[] additional_dep_files, out Path target_path)
+	private bool buildTarget(GeneratorSettings settings, BuildSettings buildsettings, in Package pack, string config, in Package[] packages, in NativePath[] additional_dep_files, out NativePath target_path)
 	{
-		auto cwd = Path(getcwd());
+		auto cwd = NativePath(getcwd());
 		bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
 		auto build_id = computeBuildID(config, buildsettings, settings);
 
 		// make all paths relative to shrink the command line
-		string makeRelative(string path) { return shrinkPath(Path(path), cwd); }
+		string makeRelative(string path) { return shrinkPath(NativePath(path), cwd); }
 		foreach (ref f; buildsettings.sourceFiles) f = makeRelative(f);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);
@@ -149,11 +149,11 @@ class BuildGenerator : ProjectGenerator {
 	}
 
 	private bool performCachedBuild(GeneratorSettings settings, BuildSettings buildsettings, in Package pack, string config,
-		string build_id, in Package[] packages, in Path[] additional_dep_files, out Path target_binary_path)
+		string build_id, in Package[] packages, in NativePath[] additional_dep_files, out NativePath target_binary_path)
 	{
-		auto cwd = Path(getcwd());
+		auto cwd = NativePath(getcwd());
 
-		Path target_path;
+		NativePath target_path;
 		if (settings.tempBuild) {
 			string packageName = pack.basePackage is null ? pack.name : pack.basePackage.name;
 			m_targetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
@@ -198,14 +198,14 @@ class BuildGenerator : ProjectGenerator {
 		return false;
 	}
 
-	private void performRDMDBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out Path target_path)
+	private void performRDMDBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out NativePath target_path)
 	{
-		auto cwd = Path(getcwd());
+		auto cwd = NativePath(getcwd());
 		//Added check for existence of [AppNameInPackagejson].d
 		//If exists, use that as the starting file.
-		Path mainsrc;
+		NativePath mainsrc;
 		if (buildsettings.mainSourceFile.length) {
-			mainsrc = Path(buildsettings.mainSourceFile);
+			mainsrc = NativePath(buildsettings.mainSourceFile);
 			if (!mainsrc.absolute) mainsrc = pack.path ~ mainsrc;
 		} else {
 			mainsrc = getMainSourceFile(pack);
@@ -223,7 +223,7 @@ class BuildGenerator : ProjectGenerator {
 		// or with "/" instead of "\"
 		bool tmp_target = false;
 		if (generate_binary) {
-			if (settings.tempBuild || (settings.run && !isWritableDir(Path(buildsettings.targetPath), true))) {
+			if (settings.tempBuild || (settings.run && !isWritableDir(NativePath(buildsettings.targetPath), true))) {
 				import std.random;
 				auto rnd = to!string(uniform(uint.min, uint.max)) ~ "-";
 				auto tmpdir = getTempDir()~".rdmd/source/";
@@ -259,20 +259,20 @@ class BuildGenerator : ProjectGenerator {
 		if (tmp_target) {
 			m_temporaryFiles ~= target_path;
 			foreach (f; buildsettings.copyFiles)
-				m_temporaryFiles ~= Path(buildsettings.targetPath).parentPath ~ Path(f).head;
+				m_temporaryFiles ~= NativePath(buildsettings.targetPath).parentPath ~ NativePath(f).head;
 		}
 	}
 
-	private void performDirectBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out Path target_path)
+	private void performDirectBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out NativePath target_path)
 	{
-		auto cwd = Path(getcwd());
+		auto cwd = NativePath(getcwd());
 
 		auto generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 		auto is_static_library = buildsettings.targetType == TargetType.staticLibrary || buildsettings.targetType == TargetType.library;
 
 		// make file paths relative to shrink the command line
 		foreach (ref f; buildsettings.sourceFiles) {
-			auto fp = Path(f);
+			auto fp = NativePath(f);
 			if( fp.absolute ) fp = fp.relativeTo(cwd);
 			f = fp.toNativeString();
 		}
@@ -281,7 +281,7 @@ class BuildGenerator : ProjectGenerator {
 
 		// make all target/import paths relative
 		string makeRelative(string path) {
-			auto p = Path(path);
+			auto p = NativePath(path);
 			// storing in a separate temprary to work around #601
 			auto prel = p.absolute ? p.relativeTo(cwd) : p;
 			return prel.toNativeString();
@@ -292,7 +292,7 @@ class BuildGenerator : ProjectGenerator {
 
 		bool is_temp_target = false;
 		if (generate_binary) {
-			if (settings.tempBuild || (settings.run && !isWritableDir(Path(buildsettings.targetPath), true))) {
+			if (settings.tempBuild || (settings.run && !isWritableDir(NativePath(buildsettings.targetPath), true))) {
 				import std.random;
 				auto rnd = to!string(uniform(uint.min, uint.max));
 				auto tmppath = getTempDir()~("dub/"~rnd~"/");
@@ -313,7 +313,7 @@ class BuildGenerator : ProjectGenerator {
 		if (is_temp_target) {
 			m_temporaryFiles ~= target_path;
 			foreach (f; buildsettings.copyFiles)
-				m_temporaryFiles ~= Path(buildsettings.targetPath).parentPath ~ Path(f).head;
+				m_temporaryFiles ~= NativePath(buildsettings.targetPath).parentPath ~ NativePath(f).head;
 		}
 	}
 
@@ -347,17 +347,17 @@ class BuildGenerator : ProjectGenerator {
 			settings.platform.compiler, settings.platform.frontendVersion, hashstr);
 	}
 
-	private void copyTargetFile(Path build_path, BuildSettings buildsettings, GeneratorSettings settings)
+	private void copyTargetFile(NativePath build_path, BuildSettings buildsettings, GeneratorSettings settings)
 	{
 		auto filename = settings.compiler.getTargetFileName(buildsettings, settings.platform);
 		auto src = build_path ~ filename;
 		logDiagnostic("Copying target from %s to %s", src.toNativeString(), buildsettings.targetPath);
-		if (!existsFile(Path(buildsettings.targetPath)))
+		if (!existsFile(NativePath(buildsettings.targetPath)))
 			mkdirRecurse(buildsettings.targetPath);
-		hardLinkFile(src, Path(buildsettings.targetPath) ~ filename, true);
+		hardLinkFile(src, NativePath(buildsettings.targetPath) ~ filename, true);
 	}
 
-	private bool isUpToDate(Path target_path, BuildSettings buildsettings, GeneratorSettings settings, in Package main_pack, in Package[] packages, in Path[] additional_dep_files)
+	private bool isUpToDate(NativePath target_path, BuildSettings buildsettings, GeneratorSettings settings, in Package main_pack, in Package[] packages, in NativePath[] additional_dep_files)
 	{
 		import std.datetime;
 
@@ -374,7 +374,7 @@ class BuildGenerator : ProjectGenerator {
 		allfiles ~= buildsettings.stringImportFiles;
 		// TODO: add library files
 		foreach (p; packages)
-			allfiles ~= (p.recipePath != Path.init ? p : p.basePackage).recipePath.toNativeString();
+			allfiles ~= (p.recipePath != NativePath.init ? p : p.basePackage).recipePath.toNativeString();
 		foreach (f; additional_dep_files) allfiles ~= f.toNativeString();
 		if (main_pack is m_project.rootPackage && m_project.rootPackage.getAllDependencies().length > 0)
 			allfiles ~= (main_pack.path ~ SelectedVersions.defaultFile).toNativeString();
@@ -407,7 +407,7 @@ class BuildGenerator : ProjectGenerator {
 
 	/// Compile a single source file (srcFile), and write the object to objName.
 	static string compileUnit(string srcFile, string objName, BuildSettings bs, GeneratorSettings gs) {
-		Path tempobj = Path(bs.targetPath)~objName;
+		NativePath tempobj = NativePath(bs.targetPath)~objName;
 		string objPath = tempobj.toNativeString();
 		bs.libs = null;
 		bs.lflags = null;
@@ -424,7 +424,7 @@ class BuildGenerator : ProjectGenerator {
 		auto generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 		auto is_static_library = buildsettings.targetType == TargetType.staticLibrary || buildsettings.targetType == TargetType.library;
 
-		Path target_file;
+		NativePath target_file;
 		scope (failure) {
 			logDiagnostic("FAIL %s %s %s" , buildsettings.targetPath, buildsettings.targetName, buildsettings.targetType);
 			auto tpath = getTargetPath(buildsettings, settings);
@@ -473,7 +473,7 @@ class BuildGenerator : ProjectGenerator {
 		} else {
 			// determine path for the temporary object file
 			string tempobjname = buildsettings.targetName ~ objSuffix;
-			Path tempobj = Path(buildsettings.targetPath) ~ tempobjname;
+			NativePath tempobj = NativePath(buildsettings.targetPath) ~ tempobjname;
 
 			// setup linker command line
 			auto lbuildsettings = buildsettings;
@@ -498,13 +498,13 @@ class BuildGenerator : ProjectGenerator {
 		}
 	}
 
-	private void runTarget(Path exe_file_path, in BuildSettings buildsettings, string[] run_args, GeneratorSettings settings)
+	private void runTarget(NativePath exe_file_path, in BuildSettings buildsettings, string[] run_args, GeneratorSettings settings)
 	{
 		if (buildsettings.targetType == TargetType.executable) {
-			auto cwd = Path(getcwd());
+			auto cwd = NativePath(getcwd());
 			auto runcwd = cwd;
 			if (buildsettings.workingDirectory.length) {
-				runcwd = Path(buildsettings.workingDirectory);
+				runcwd = NativePath(buildsettings.workingDirectory);
 				if (!runcwd.absolute) runcwd = cwd ~ runcwd;
 				logDiagnostic("Switching to %s", runcwd.toNativeString());
 				chdir(runcwd.toNativeString());
@@ -548,7 +548,7 @@ class BuildGenerator : ProjectGenerator {
 	}
 }
 
-private Path getMainSourceFile(in Package prj)
+private NativePath getMainSourceFile(in Package prj)
 {
 	foreach (f; ["source/app.d", "src/app.d", "source/"~prj.name~".d", "src/"~prj.name~".d"])
 		if (existsFile(prj.path ~ f))
@@ -556,12 +556,12 @@ private Path getMainSourceFile(in Package prj)
 	return prj.path ~ "source/app.d";
 }
 
-private Path getTargetPath(in ref BuildSettings bs, in ref GeneratorSettings settings)
+private NativePath getTargetPath(in ref BuildSettings bs, in ref GeneratorSettings settings)
 {
-	return Path(bs.targetPath) ~ settings.compiler.getTargetFileName(bs, settings.platform);
+	return NativePath(bs.targetPath) ~ settings.compiler.getTargetFileName(bs, settings.platform);
 }
 
-private string shrinkPath(Path path, Path base)
+private string shrinkPath(NativePath path, NativePath base)
 {
 	auto orig = path.toNativeString();
 	if (!path.absolute) return orig;
@@ -570,10 +570,10 @@ private string shrinkPath(Path path, Path base)
 }
 
 unittest {
-	assert(shrinkPath(Path("/foo/bar/baz"), Path("/foo")) == Path("bar/baz").toNativeString());
-	assert(shrinkPath(Path("/foo/bar/baz"), Path("/foo/baz")) == Path("../bar/baz").toNativeString());
-	assert(shrinkPath(Path("/foo/bar/baz"), Path("/bar/")) == Path("/foo/bar/baz").toNativeString());
-	assert(shrinkPath(Path("/foo/bar/baz"), Path("/bar/baz")) == Path("/foo/bar/baz").toNativeString());
+	assert(shrinkPath(NativePath("/foo/bar/baz"), NativePath("/foo")) == NativePath("bar/baz").toNativeString());
+	assert(shrinkPath(NativePath("/foo/bar/baz"), NativePath("/foo/baz")) == NativePath("../bar/baz").toNativeString());
+	assert(shrinkPath(NativePath("/foo/bar/baz"), NativePath("/bar/")) == NativePath("/foo/bar/baz").toNativeString());
+	assert(shrinkPath(NativePath("/foo/bar/baz"), NativePath("/bar/baz")) == NativePath("/foo/bar/baz").toNativeString());
 }
 
 unittest { // issue #1235 - pass no library files to compiler command line when building a static lib
@@ -585,8 +585,8 @@ unittest { // issue #1235 - pass no library files to compiler command line when 
 	else auto libfile = "bar.a";
 
 	auto desc = parseJsonString(`{"name": "test", "targetType": "library", "sourceFiles": ["foo.d", "`~libfile~`"]}`);
-	auto pack = new Package(desc, Path("/tmp/fooproject"));
-	auto pman = new PackageManager(Path("/tmp/foo/"), Path("/tmp/foo/"), false);
+	auto pack = new Package(desc, NativePath("/tmp/fooproject"));
+	auto pman = new PackageManager(NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), false);
 	auto prj = new Project(pman, pack);
 
 	final static class TestCompiler : GDCCompiler {

--- a/source/dub/generators/cmake.d
+++ b/source/dub/generators/cmake.d
@@ -32,8 +32,8 @@ class CMakeGenerator: ProjectGenerator
         auto script = appender!(char[]);
         auto scripts = appender!(string[]);
         bool[string] visited;
-        Path projectRoot = m_project.rootPackage.path;
-        Path cmakeListsPath = projectRoot ~ "CMakeLists.txt";
+        NativePath projectRoot = m_project.rootPackage.path;
+        NativePath cmakeListsPath = projectRoot ~ "CMakeLists.txt";
 
         foreach(name, info; targets)
         {

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -112,7 +112,7 @@ class ProjectGenerator
 			BuildSettings buildsettings;
 			buildsettings.processVars(m_project, pack, pack.getBuildSettings(settings.platform, configs[pack.name]), true);
 			bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
-			finalizeGeneration(pack, m_project, settings, buildsettings, Path(bs.targetPath), generate_binary);
+			finalizeGeneration(pack, m_project, settings, buildsettings, NativePath(bs.targetPath), generate_binary);
 		}
 
 		performPostGenerateActions(settings, targets);
@@ -246,7 +246,7 @@ class ProjectGenerator
 			// override string import files (used for up to date checking)
 			foreach (ref f; ti.buildSettings.stringImportFiles)
 				foreach (fi; root_settings.stringImportFiles)
-					if (f != fi && Path(f).head == Path(fi).head) {
+					if (f != fi && NativePath(f).head == NativePath(fi).head) {
 						f = fi;
 					}
 
@@ -364,7 +364,7 @@ private void prepareGeneration(in Package pack, in Project proj, in GeneratorSet
 	Runs post-build commands and copies required files to the binary directory.
 */
 private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSettings settings,
-	in BuildSettings buildsettings, Path target_path, bool generate_binary)
+	in BuildSettings buildsettings, NativePath target_path, bool generate_binary)
 {
 	import std.path : globMatch;
 
@@ -378,7 +378,7 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 			mkdirRecurse(buildsettings.targetPath);
 
 		if (buildsettings.copyFiles.length) {
-			void copyFolderRec(Path folder, Path dstfolder)
+			void copyFolderRec(NativePath folder, NativePath dstfolder)
 			{
 				mkdirRecurse(dstfolder.toNativeString());
 				foreach (de; iterateDirectory(folder.toNativeString())) {
@@ -395,9 +395,9 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 
 			void tryCopyDir(string file)
 			{
-				auto src = Path(file);
+				auto src = NativePath(file);
 				if (!src.absolute) src = pack.path ~ src;
-				auto dst = target_path ~ Path(file).head;
+				auto dst = target_path ~ NativePath(file).head;
 				if (src == dst) {
 					logDiagnostic("Skipping copy of %s (same source and destination)", file);
 					return;
@@ -410,9 +410,9 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 
 			void tryCopyFile(string file)
 			{
-				auto src = Path(file);
+				auto src = NativePath(file);
 				if (!src.absolute) src = pack.path ~ src;
-				auto dst = target_path ~ Path(file).head;
+				auto dst = target_path ~ NativePath(file).head;
 				if (src == dst) {
 					logDiagnostic("Skipping copy of %s (same source and destination)", file);
 					return;

--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -11,6 +11,7 @@ import dub.compilers.compiler;
 import dub.generators.generator;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.data.json;
+import dub.internal.vibecompat.inet.path;
 import dub.packagemanager;
 import dub.project;
 

--- a/source/dub/generators/targetdescription.d
+++ b/source/dub/generators/targetdescription.d
@@ -52,7 +52,7 @@ class TargetDescriptionGenerator : ProjectGenerator {
 			foreach (ld; ti.linkDependencies) {
 				auto ltarget = targets[ld];
 				auto ltbs = ltarget.buildSettings;
-				auto targetfil = (Path(ltbs.targetPath) ~ settings.compiler.getTargetFileName(ltbs, settings.platform)).toNativeString();
+				auto targetfil = (NativePath(ltbs.targetPath) ~ settings.compiler.getTargetFileName(ltbs, settings.platform)).toNativeString();
 				d.buildSettings.addLinkerFiles(targetfil);
 			}
 

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -460,8 +460,13 @@ class VisualDGenerator : ProjectGenerator {
 		private final static int sortOrder(ref const SourceFile a, ref const SourceFile b) {
 			assert(!a.structurePath.empty);
 			assert(!b.structurePath.empty);
-			auto as = a.structurePath.bySegment.array;
-			auto bs = b.structurePath.bySegment.array;
+			static if (is(typeof(a.structurePath.nodes))) { // vibe.d < 0.8.2
+				auto as = a.structurePath.nodes;
+				auto bs = b.structurePath.nodes;
+			} else {
+				auto as = a.structurePath.bySegment.array;
+				auto bs = b.structurePath.bySegment.array;
+			}
 
 			// Check for different folders, compare folders only (omit last one).
 			for(uint idx=0; idx<min(as.length-1, bs.length-1); ++idx)

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -170,7 +170,7 @@ class VisualDGenerator : ProjectGenerator {
 			// Add all files
 			auto files = targets[packname].buildSettings;
 			SourceFile[string] sourceFiles;
-			void addSourceFile(Path file_path, Path structure_path, bool build)
+			void addSourceFile(NativePath file_path, NativePath structure_path, bool build)
 			{
 				auto key = file_path.toString();
 				auto sf = sourceFiles.get(key, SourceFile.init);
@@ -183,7 +183,7 @@ class VisualDGenerator : ProjectGenerator {
 			}
 
 			void addFile(string s, bool build) {
-				auto sp = Path(s);
+				auto sp = NativePath(s);
 				assert(sp.absolute, format("Source path in %s expected to be absolute: %s", packname, s));
 				//if( !sp.absolute ) sp = pack.path ~ sp;
 				addSourceFile(sp.relativeTo(project_file_dir), determineStructurePath(sp, targets[packname]), build);
@@ -203,7 +203,7 @@ class VisualDGenerator : ProjectGenerator {
 
 			// Create folders and files
 			ret.formattedWrite("  <Folder name=\"%s\">", getPackageFileName(packname));
-			typeof(Path.init.head)[] lastFolder;
+			typeof(NativePath.init.head)[] lastFolder;
 			foreach(source; sortedSources(sourceFiles.values)) {
 				logDebug("source looking at %s", source.structurePath);
 				auto cur = source.structurePath.parentPath.bySegment.array;
@@ -248,7 +248,7 @@ class VisualDGenerator : ProjectGenerator {
 				auto ret = new string[settings.length];
 				foreach (i; 0 .. settings.length) {
 					// \" is interpreted as an escaped " by cmd.exe, so we need to avoid that
-					auto p = Path(settings[i]).relativeTo(project_file_dir);
+					auto p = NativePath(settings[i]).relativeTo(project_file_dir);
 					p.endsWithSlash = false;
 					ret[i] = '"' ~ p.toNativeString() ~ '"';
 				}
@@ -285,7 +285,7 @@ class VisualDGenerator : ProjectGenerator {
 					output_type = DynamicLib;
 					output_ext = "dll";
 				}
-				auto bin_path = pack == m_project.rootPackage.name ? Path(buildsettings.targetPath) : Path("lib/");
+				auto bin_path = pack == m_project.rootPackage.name ? NativePath(buildsettings.targetPath) : NativePath("lib/");
 				bin_path.endsWithSlash = true;
 				ret.formattedWrite("    <lib>%s</lib>\n", output_type);
 				ret.formattedWrite("    <exefile>%s%s.%s</exefile>\n", bin_path.toNativeString(), buildsettings.targetName, output_ext);
@@ -315,7 +315,7 @@ class VisualDGenerator : ProjectGenerator {
 				// compute directory for intermediate files (need dummy/ because of how -op determines the resulting path)
 				size_t ndummy = 0;
 				foreach (f; buildsettings.sourceFiles) {
-					auto rpath = Path(f).relativeTo(project_file_dir);
+					auto rpath = NativePath(f).relativeTo(project_file_dir);
 					size_t nd = 0;
 					foreach (s; rpath.bySegment)
 						if (s == "..")
@@ -406,7 +406,7 @@ class VisualDGenerator : ProjectGenerator {
 				ret.put("    <libpaths />\n");
 				ret.put("    <deffile />\n");
 				ret.put("    <resfile />\n");
-				auto wdir = Path(buildsettings.workingDirectory);
+				auto wdir = NativePath(buildsettings.workingDirectory);
 				if (!wdir.absolute) wdir = m_project.rootPackage.path ~ wdir;
 				ret.formattedWrite("    <debugworkingdir>%s</debugworkingdir>\n",
 					wdir.relativeTo(project_file_dir).toNativeString());
@@ -441,8 +441,8 @@ class VisualDGenerator : ProjectGenerator {
 			else return getPackageFileName(m_project.rootPackage.name) ~ ".sln";
 		}
 
-		Path projFileName(string pack) const {
-			auto basepath = Path(".dub/");
+		NativePath projFileName(string pack) const {
+			auto basepath = NativePath(".dub/");
 			version(DUBBING) return basepath ~ (getPackageFileName(pack) ~ ".dubbed.visualdproj");
 			else return basepath ~ (getPackageFileName(pack) ~ ".visualdproj");
 		}
@@ -450,8 +450,8 @@ class VisualDGenerator : ProjectGenerator {
 
 	// TODO: nice folders
 	private struct SourceFile {
-		Path structurePath;
-		Path filePath;
+		NativePath structurePath;
+		NativePath filePath;
 		bool build;
 
 		hash_t toHash() const nothrow @trusted { return structurePath.toHash() ^ filePath.toHash() ^ (build * 0x1f3e7b2c); }
@@ -487,33 +487,33 @@ class VisualDGenerator : ProjectGenerator {
 
 	unittest {
 		SourceFile[] sfs = [
-			{ Path("b/file.d"), Path("") },
-			{ Path("b/b/fileA.d"), Path("") },
-			{ Path("a/file.d"), Path("") },
-			{ Path("b/b/fileB.d"), Path("") },
-			{ Path("b/b/b/fileA.d"), Path("") },
-			{ Path("b/c/fileA.d"), Path("") },
+			{ NativePath("b/file.d"), NativePath("") },
+			{ NativePath("b/b/fileA.d"), NativePath("") },
+			{ NativePath("a/file.d"), NativePath("") },
+			{ NativePath("b/b/fileB.d"), NativePath("") },
+			{ NativePath("b/b/b/fileA.d"), NativePath("") },
+			{ NativePath("b/c/fileA.d"), NativePath("") },
 		];
 		auto sorted = sort(sfs);
 		SourceFile[] sortedSfs;
 		foreach(sr; sorted)
 			sortedSfs ~= sr;
-		assert(sortedSfs[0].structurePath == Path("a/file.d"), "1");
-		assert(sortedSfs[1].structurePath == Path("b/b/b/fileA.d"), "2");
-		assert(sortedSfs[2].structurePath == Path("b/b/fileA.d"), "3");
-		assert(sortedSfs[3].structurePath == Path("b/b/fileB.d"), "4");
-		assert(sortedSfs[4].structurePath == Path("b/c/fileA.d"), "5");
-		assert(sortedSfs[5].structurePath == Path("b/file.d"), "6");
+		assert(sortedSfs[0].structurePath == NativePath("a/file.d"), "1");
+		assert(sortedSfs[1].structurePath == NativePath("b/b/b/fileA.d"), "2");
+		assert(sortedSfs[2].structurePath == NativePath("b/b/fileA.d"), "3");
+		assert(sortedSfs[3].structurePath == NativePath("b/b/fileB.d"), "4");
+		assert(sortedSfs[4].structurePath == NativePath("b/c/fileA.d"), "5");
+		assert(sortedSfs[5].structurePath == NativePath("b/file.d"), "6");
 	}
 }
 
-private Path determineStructurePath(Path file_path, in ProjectGenerator.TargetInfo target)
+private NativePath determineStructurePath(NativePath file_path, in ProjectGenerator.TargetInfo target)
 {
 	foreach (p; target.packages) {
 		if (file_path.startsWith(p.path))
-			return Path(getPackageFileName(p.name)) ~ file_path.relativeTo(p.path);
+			return NativePath(getPackageFileName(p.name)) ~ file_path.relativeTo(p.path);
 	}
-	return Path("misc/") ~ file_path.head;
+	return NativePath("misc/") ~ file_path.head;
 }
 
 private string getPackageFileName(string pack)

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -38,7 +38,7 @@ import std.string;
 			package recipe and the file format used to store it prior to
 			writing it to disk.
 */
-void initPackage(Path root_path, string[string] deps, string type,
+void initPackage(NativePath root_path, string[string] deps, string type,
 	PackageFormat format, scope RecipeCallback recipe_callback = null)
 {
 	import std.conv : to;
@@ -92,7 +92,7 @@ void initPackage(Path root_path, string[string] deps, string type,
 
 alias RecipeCallback = void delegate(ref PackageRecipe, ref PackageFormat);
 
-private void initMinimalPackage(Path root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
+private void initMinimalPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
 	p.description = "A minimal D application.";
 	pre_write_callback();
@@ -108,7 +108,7 @@ void main()
 });
 }
 
-private void initVibeDPackage(Path root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
+private void initVibeDPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
 	if ("vibe-d" !in p.buildSettings.dependencies)
 		p.buildSettings.dependencies["vibe-d"] = Dependency("~>0.7.30");
@@ -139,7 +139,7 @@ void hello(HTTPServerRequest req, HTTPServerResponse res)
 });
 }
 
-private void initDeimosPackage(Path root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
+private void initDeimosPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
 	import dub.compilers.buildsettings : TargetType;
 
@@ -153,7 +153,7 @@ private void initDeimosPackage(Path root_path, ref PackageRecipe p, scope void d
 	createDirectory(root_path ~ "deimos");
 }
 
-private void writeGitignore(Path root_path, PackageRecipe p)
+private void writeGitignore(NativePath root_path, PackageRecipe p)
 {
 	write((root_path ~ ".gitignore").toNativeString(),
 q"{.dub

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -30,14 +30,14 @@ version(DubUseCurl)
 }
 
 
-private Path[] temporary_files;
+private NativePath[] temporary_files;
 
-Path getTempDir()
+NativePath getTempDir()
 {
-	return Path(std.file.tempDir());
+	return NativePath(std.file.tempDir());
 }
 
-Path getTempFile(string prefix, string extension = null)
+NativePath getTempFile(string prefix, string extension = null)
 {
 	import std.uuid : randomUUID;
 
@@ -99,13 +99,13 @@ static ~this()
 	}
 }
 
-bool isEmptyDir(Path p) {
+bool isEmptyDir(NativePath p) {
 	foreach(DirEntry e; dirEntries(p.toNativeString(), SpanMode.shallow))
 		return false;
 	return true;
 }
 
-bool isWritableDir(Path p, bool create_if_missing = false)
+bool isWritableDir(NativePath p, bool create_if_missing = false)
 {
 	import std.random;
 	auto fname = p ~ format("__dub_write_test_%08X", uniform(0, uint.max));
@@ -116,7 +116,7 @@ bool isWritableDir(Path p, bool create_if_missing = false)
 	return true;
 }
 
-Json jsonFromFile(Path file, bool silent_fail = false) {
+Json jsonFromFile(NativePath file, bool silent_fail = false) {
 	if( silent_fail && !existsFile(file) ) return Json.emptyObject;
 	auto f = openFile(file.toNativeString(), FileMode.read);
 	scope(exit) f.close();
@@ -124,7 +124,7 @@ Json jsonFromFile(Path file, bool silent_fail = false) {
 	return parseJsonString(text, file.toNativeString());
 }
 
-Json jsonFromZip(Path zip, string filename) {
+Json jsonFromZip(NativePath zip, string filename) {
 	import std.zip : ZipArchive;
 	auto f = openFile(zip, FileMode.read);
 	ubyte[] b = new ubyte[cast(size_t)f.size];
@@ -135,7 +135,7 @@ Json jsonFromZip(Path zip, string filename) {
 	return parseJsonString(text, zip.toNativeString~"/"~filename);
 }
 
-void writeJsonFile(Path path, Json json)
+void writeJsonFile(NativePath path, Json json)
 {
 	auto f = openFile(path, FileMode.createTrunc);
 	scope(exit) f.close();
@@ -143,7 +143,7 @@ void writeJsonFile(Path path, Json json)
 }
 
 /// Performs a write->delete->rename sequence to atomically "overwrite" the destination file
-void atomicWriteJsonFile(Path path, Json json)
+void atomicWriteJsonFile(NativePath path, Json json)
 {
 	import std.random : uniform;
 	auto tmppath = path.parentPath ~ format("%s.%s.tmp", path.head, uniform(0, int.max));
@@ -163,7 +163,7 @@ bool isPathFromZip(string p) {
 	return p[$-1] == '/';
 }
 
-bool existsDirectory(Path path) {
+bool existsDirectory(NativePath path) {
 	if( !existsFile(path) ) return false;
 	auto fi = getFileInfo(path);
 	return fi.isDirectory;
@@ -265,7 +265,7 @@ void download(string url, string filename)
 	} else assert(false);
 }
 /// ditto
-void download(URL url, Path filename)
+void download(URL url, NativePath filename)
 {
 	download(url.toString(), filename.toNativeString());
 }
@@ -442,7 +442,7 @@ string stripDlangSpecialChars(string s)
 	return ret.data;
 }
 
-string determineModuleName(BuildSettings settings, Path file, Path base_path)
+string determineModuleName(BuildSettings settings, NativePath file, NativePath base_path)
 {
 	import std.algorithm : map;
 	import std.array : array;
@@ -452,7 +452,7 @@ string determineModuleName(BuildSettings settings, Path file, Path base_path)
 	if (!file.absolute) file = base_path ~ file;
 
 	size_t path_skip = 0;
-	foreach (ipath; settings.importPaths.map!(p => Path(p))) {
+	foreach (ipath; settings.importPaths.map!(p => NativePath(p))) {
 		if (!ipath.absolute) ipath = base_path ~ ipath;
 		assert(!ipath.empty);
 		if (file.startsWith(ipath) && ipath.bySegment.walkLength > path_skip)

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -54,7 +54,7 @@ struct RangeFile {
 /**
 	Opens a file stream with the specified mode.
 */
-RangeFile openFile(Path path, FileMode mode = FileMode.read)
+RangeFile openFile(NativePath path, FileMode mode = FileMode.read)
 {
 	string fmode;
 	final switch(mode){
@@ -70,14 +70,14 @@ RangeFile openFile(Path path, FileMode mode = FileMode.read)
 /// ditto
 RangeFile openFile(string path, FileMode mode = FileMode.read)
 {
-	return openFile(Path(path), mode);
+	return openFile(NativePath(path), mode);
 }
 
 
 /**
 	Moves or renames a file.
 */
-void moveFile(Path from, Path to)
+void moveFile(NativePath from, NativePath to)
 {
 	moveFile(from.toNativeString(), to.toNativeString());
 }
@@ -93,8 +93,8 @@ void moveFile(string from, string to)
 	Note that attributes and time stamps are currently not retained.
 
 	Params:
-		from = Path of the source file
-		to = Path for the destination file
+		from = NativePath of the source file
+		to = NativePath for the destination file
 		overwrite = If true, any file existing at the destination path will be
 			overwritten. If this is false, an excpetion will be thrown should
 			a file already exist at the destination path.
@@ -102,7 +102,7 @@ void moveFile(string from, string to)
 	Throws:
 		An Exception if the copy operation fails for some reason.
 */
-void copyFile(Path from, Path to, bool overwrite = false)
+void copyFile(NativePath from, NativePath to, bool overwrite = false)
 {
 	enforce(existsFile(from), "Source file does not exist.");
 
@@ -138,13 +138,13 @@ void copyFile(Path from, Path to, bool overwrite = false)
 /// ditto
 void copyFile(string from, string to)
 {
-	copyFile(Path(from), Path(to));
+	copyFile(NativePath(from), NativePath(to));
 }
 
 version (Windows) extern(Windows) int CreateHardLinkW(in wchar* to, in wchar* from, void* attr=null);
 
 // guess whether 2 files are identical, ignores filename and content
-private bool sameFile(Path a, Path b)
+private bool sameFile(NativePath a, NativePath b)
 {
 	version (Posix) {
 		auto st_a = std.file.DirEntry(a.toNativeString).statBuf;
@@ -159,7 +159,7 @@ private bool sameFile(Path a, Path b)
 /**
 	Creates a hardlink.
 */
-void hardLinkFile(Path from, Path to, bool overwrite = false)
+void hardLinkFile(NativePath from, NativePath to, bool overwrite = false)
 {
 	if (existsFile(to)) {
 		enforce(overwrite, "Destination file already exists.");
@@ -189,7 +189,7 @@ void hardLinkFile(Path from, Path to, bool overwrite = false)
 /**
 	Removes a file
 */
-void removeFile(Path path)
+void removeFile(NativePath path)
 {
 	removeFile(path.toNativeString());
 }
@@ -201,7 +201,7 @@ void removeFile(string path) {
 /**
 	Checks if a file exists
 */
-bool existsFile(Path path) {
+bool existsFile(NativePath path) {
 	return existsFile(path.toNativeString());
 }
 /// ditto
@@ -214,7 +214,7 @@ bool existsFile(string path)
 
 	Returns false if the file does not exist.
 */
-FileInfo getFileInfo(Path path)
+FileInfo getFileInfo(NativePath path)
 {
 	auto ent = std.file.DirEntry(path.toNativeString());
 	return makeFileInfo(ent);
@@ -222,26 +222,26 @@ FileInfo getFileInfo(Path path)
 /// ditto
 FileInfo getFileInfo(string path)
 {
-	return getFileInfo(Path(path));
+	return getFileInfo(NativePath(path));
 }
 
 /**
 	Creates a new directory.
 */
-void createDirectory(Path path)
+void createDirectory(NativePath path)
 {
 	mkdir(path.toNativeString());
 }
 /// ditto
 void createDirectory(string path)
 {
-	createDirectory(Path(path));
+	createDirectory(NativePath(path));
 }
 
 /**
 	Enumerates all files in the specified directory.
 */
-void listDirectory(Path path, scope bool delegate(FileInfo info) del)
+void listDirectory(NativePath path, scope bool delegate(FileInfo info) del)
 {
 	foreach( DirEntry ent; dirEntries(path.toNativeString(), SpanMode.shallow) )
 		if( !del(makeFileInfo(ent)) )
@@ -250,10 +250,10 @@ void listDirectory(Path path, scope bool delegate(FileInfo info) del)
 /// ditto
 void listDirectory(string path, scope bool delegate(FileInfo info) del)
 {
-	listDirectory(Path(path), del);
+	listDirectory(NativePath(path), del);
 }
 /// ditto
-int delegate(scope int delegate(ref FileInfo)) iterateDirectory(Path path)
+int delegate(scope int delegate(ref FileInfo)) iterateDirectory(NativePath path)
 {
 	int iterator(scope int delegate(ref FileInfo) del){
 		int ret = 0;
@@ -268,16 +268,16 @@ int delegate(scope int delegate(ref FileInfo)) iterateDirectory(Path path)
 /// ditto
 int delegate(scope int delegate(ref FileInfo)) iterateDirectory(string path)
 {
-	return iterateDirectory(Path(path));
+	return iterateDirectory(NativePath(path));
 }
 
 
 /**
 	Returns the current working directory.
 */
-Path getWorkingDirectory()
+NativePath getWorkingDirectory()
 {
-	return Path(std.file.getcwd());
+	return NativePath(std.file.getcwd());
 }
 
 

--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -18,6 +18,9 @@ import std.exception;
 import std.string;
 
 
+deprecated("Use NativePath instead.")
+alias Path = NativePath;
+
 /**
 	Represents an absolute or relative file system path.
 
@@ -25,7 +28,7 @@ import std.string;
 	are done to disallow invalid operations such as concatenating two absolute paths. It also
 	validates path strings and allows for easy checking of malicious relative paths.
 */
-struct Path {
+struct NativePath {
 	private {
 		immutable(PathEntry)[] m_nodes;
 		bool m_absolute = false;
@@ -36,7 +39,7 @@ struct Path {
 
 	alias bySegment = nodes;
 
-	/// Constructs a Path object by parsing a path string.
+	/// Constructs a NativePath object by parsing a path string.
 	this(string pathstr)
 	{
 		m_nodes = splitPath(pathstr);
@@ -113,7 +116,7 @@ struct Path {
 		return ret.data;
 	}
 
-	/// Converts the Path object to a native path string (backslash as path separator on Windows).
+	/// Converts the NativePath object to a native path string (backslash as path separator on Windows).
 	string toNativeString()
 	const {
 		if (m_nodes.empty) {
@@ -144,7 +147,7 @@ struct Path {
 	}
 
 	/// Tests if `rhs` is an anchestor or the same as this path.
-	bool startsWith(const Path rhs) const {
+	bool startsWith(const NativePath rhs) const {
 		if( rhs.m_nodes.length > m_nodes.length ) return false;
 		foreach( i; 0 .. rhs.m_nodes.length )
 			if( m_nodes[i] != rhs.m_nodes[i] )
@@ -153,7 +156,7 @@ struct Path {
 	}
 
 	/// Computes the relative path from `parentPath` to this path.
-	Path relativeTo(const Path parentPath) const {
+	NativePath relativeTo(const NativePath parentPath) const {
 		assert(this.absolute && parentPath.absolute, "Determining relative path between non-absolute paths.");
 		version(Windows){
 			// a path such as ..\C:\windows is not valid, so force the path to stay absolute in this case
@@ -169,11 +172,11 @@ struct Path {
 			nup++;
 		}
 		assert(m_nodes.length >= parentPath.length - nup);
-		Path ret = Path(null, false);
+		NativePath ret = NativePath(null, false);
 		assert(m_nodes.length >= parentPath.length - nup);
 		ret.m_endsWithSlash = true;
 		foreach( i; 0 .. nup ) ret ~= "..";
-		ret ~= Path(m_nodes[parentPath.length-nup .. $], false);
+		ret ~= NativePath(m_nodes[parentPath.length-nup .. $], false);
 		ret.m_endsWithSlash = this.m_endsWithSlash;
 		return ret;
 	}
@@ -182,7 +185,7 @@ struct Path {
 	@property ref immutable(PathEntry) head() const { enforce(m_nodes.length > 0, "Getting head of empty path."); return m_nodes[$-1]; }
 
 	/// The parent path
-	@property Path parentPath() const { return this[0 .. length-1]; }
+	@property NativePath parentPath() const { return this[0 .. length-1]; }
 
 	/// The ist of path entries of which this path is composed
 	@property immutable(PathEntry)[] nodes() const { return m_nodes; }
@@ -202,16 +205,16 @@ struct Path {
 	@property bool external() const { return !m_absolute && m_nodes.length > 0 && m_nodes[0].m_name == ".."; }
 
 	ref immutable(PathEntry) opIndex(size_t idx) const { return m_nodes[idx]; }
-	Path opSlice(size_t start, size_t end) const {
-		auto ret = Path(m_nodes[start .. end], start == 0 ? absolute : false);
+	NativePath opSlice(size_t start, size_t end) const {
+		auto ret = NativePath(m_nodes[start .. end], start == 0 ? absolute : false);
 		if( end == m_nodes.length ) ret.m_endsWithSlash = m_endsWithSlash;
 		return ret;
 	}
 	size_t opDollar(int dim)() const if(dim == 0) { return m_nodes.length; }
 
 
-	Path opBinary(string OP)(const Path rhs) const if( OP == "~" ) {
-		Path ret;
+	NativePath opBinary(string OP)(const NativePath rhs) const if( OP == "~" ) {
+		NativePath ret;
 		ret.m_nodes = m_nodes;
 		ret.m_absolute = m_absolute;
 		ret.m_endsWithSlash = rhs.m_endsWithSlash;
@@ -234,14 +237,14 @@ struct Path {
 		return ret;
 	}
 
-	Path opBinary(string OP)(string rhs) const if( OP == "~" ) { assert(rhs.length > 0, "Cannot append empty path string."); return opBinary!"~"(Path(rhs)); }
-	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { assert(rhs.toString().length > 0, "Cannot append empty path string."); return opBinary!"~"(Path(rhs)); }
-	void opOpAssign(string OP)(string rhs) if( OP == "~" ) { assert(rhs.length > 0, "Cannot append empty path string."); opOpAssign!"~"(Path(rhs)); }
-	void opOpAssign(string OP)(PathEntry rhs) if( OP == "~" ) { assert(rhs.toString().length > 0, "Cannot append empty path string."); opOpAssign!"~"(Path(rhs)); }
-	void opOpAssign(string OP)(Path rhs) if( OP == "~" ) { auto p = this ~ rhs; m_nodes = p.m_nodes; m_endsWithSlash = rhs.m_endsWithSlash; }
+	NativePath opBinary(string OP)(string rhs) const if( OP == "~" ) { assert(rhs.length > 0, "Cannot append empty path string."); return opBinary!"~"(NativePath(rhs)); }
+	NativePath opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { assert(rhs.toString().length > 0, "Cannot append empty path string."); return opBinary!"~"(NativePath(rhs)); }
+	void opOpAssign(string OP)(string rhs) if( OP == "~" ) { assert(rhs.length > 0, "Cannot append empty path string."); opOpAssign!"~"(NativePath(rhs)); }
+	void opOpAssign(string OP)(PathEntry rhs) if( OP == "~" ) { assert(rhs.toString().length > 0, "Cannot append empty path string."); opOpAssign!"~"(NativePath(rhs)); }
+	void opOpAssign(string OP)(NativePath rhs) if( OP == "~" ) { auto p = this ~ rhs; m_nodes = p.m_nodes; m_endsWithSlash = rhs.m_endsWithSlash; }
 
 	/// Tests two paths for equality using '=='.
-	bool opEquals(ref const Path rhs) const {
+	bool opEquals(ref const NativePath rhs) const {
 		if( m_absolute != rhs.m_absolute ) return false;
 		if( m_endsWithSlash != rhs.m_endsWithSlash ) return false;
 		if( m_nodes.length != rhs.length ) return false;
@@ -251,9 +254,9 @@ struct Path {
 		return true;
 	}
 	/// ditto
-	bool opEquals(const Path other) const { return opEquals(other); }
+	bool opEquals(const NativePath other) const { return opEquals(other); }
 
-	int opCmp(ref const Path rhs) const {
+	int opCmp(ref const NativePath rhs) const {
 		if( m_absolute != rhs.m_absolute ) return cast(int)m_absolute - cast(int)rhs.m_absolute;
 		foreach( i; 0 .. min(m_nodes.length, rhs.m_nodes.length) )
 			if( m_nodes[i] != rhs.m_nodes[i] )
@@ -290,7 +293,7 @@ struct PathEntry {
 
 	@property string name() const { return m_name; }
 
-	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return Path([this, rhs], false); }
+	NativePath opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return NativePath([this, rhs], false); }
 
 	bool opEquals(ref const PathEntry rhs) const { return m_name == rhs.m_name; }
 	bool opEquals(PathEntry rhs) const { return m_name == rhs.m_name; }
@@ -309,8 +312,8 @@ private bool isValidFilename(string str)
 /// Joins two path strings. subpath must be relative.
 string joinPath(string basepath, string subpath)
 {
-	Path p1 = Path(basepath);
-	Path p2 = Path(subpath);
+	NativePath p1 = NativePath(basepath);
+	NativePath p2 = NativePath(subpath);
 	return (p1 ~ p2).toString();
 }
 
@@ -353,13 +356,13 @@ pure {
 
 unittest
 {
-	Path p;
+	NativePath p;
 	assert(p.toNativeString() == ".");
 	p.endsWithSlash = true;
 	version(Windows) assert(p.toNativeString() == ".\\");
 	else assert(p.toNativeString() == "./");
 
-	p = Path("test/");
+	p = NativePath("test/");
 	version(Windows) assert(p.toNativeString() == "test\\");
 	else assert(p.toNativeString() == "test/");
 	p.endsWithSlash = false;
@@ -370,7 +373,7 @@ unittest
 {
 	{
 		auto unc = "\\\\server\\share\\path";
-		auto uncp = Path(unc);
+		auto uncp = NativePath(unc);
 		uncp.normalize();
 		version(Windows) assert(uncp.toNativeString() == unc);
 		assert(uncp.absolute);
@@ -379,7 +382,7 @@ unittest
 
 	{
 		auto abspath = "/test/path/";
-		auto abspathp = Path(abspath);
+		auto abspathp = NativePath(abspath);
 		assert(abspathp.toString() == abspath);
 		version(Windows) {} else assert(abspathp.toNativeString() == abspath);
 		assert(abspathp.absolute);
@@ -391,7 +394,7 @@ unittest
 
 	{
 		auto relpath = "test/path/";
-		auto relpathp = Path(relpath);
+		auto relpathp = NativePath(relpath);
 		assert(relpathp.toString() == relpath);
 		version(Windows) assert(relpathp.toNativeString() == "test\\path\\");
 		else assert(relpathp.toNativeString() == relpath);
@@ -404,7 +407,7 @@ unittest
 
 	{
 		auto winpath = "C:\\windows\\test";
-		auto winpathp = Path(winpath);
+		auto winpathp = NativePath(winpath);
 		version(Windows) {
 			assert(winpathp.toString() == "C:/windows/test", winpathp.toString());
 			assert(winpathp.toNativeString() == winpath);
@@ -422,7 +425,7 @@ unittest
 
 	{
 		auto dotpath = "/test/../test2/././x/y";
-		auto dotpathp = Path(dotpath);
+		auto dotpathp = NativePath(dotpath);
 		assert(dotpathp.toString() == "/test/../test2/././x/y");
 		dotpathp.normalize();
 		assert(dotpathp.toString() == "/test2/x/y");
@@ -430,7 +433,7 @@ unittest
 
 	{
 		auto dotpath = "/test/..////test2//./x/y";
-		auto dotpathp = Path(dotpath);
+		auto dotpathp = NativePath(dotpath);
 		assert(dotpathp.toString() == "/test/..////test2//./x/y");
 		dotpathp.normalize();
 		assert(dotpathp.toString() == "/test2/x/y");
@@ -438,46 +441,46 @@ unittest
 
 	{
 		auto parentpath = "/path/to/parent";
-		auto parentpathp = Path(parentpath);
+		auto parentpathp = NativePath(parentpath);
 		auto subpath = "/path/to/parent/sub/";
-		auto subpathp = Path(subpath);
+		auto subpathp = NativePath(subpath);
 		auto subpath_rel = "sub/";
 		assert(subpathp.relativeTo(parentpathp).toString() == subpath_rel);
 		auto subfile = "/path/to/parent/child";
-		auto subfilep = Path(subfile);
+		auto subfilep = NativePath(subfile);
 		auto subfile_rel = "child";
 		assert(subfilep.relativeTo(parentpathp).toString() == subfile_rel);
 	}
 
 	{ // relative paths across Windows devices are not allowed
 		version (Windows) {
-			auto p1 = Path("\\\\server\\share"); assert(p1.absolute);
-			auto p2 = Path("\\\\server\\othershare"); assert(p2.absolute);
-			auto p3 = Path("\\\\otherserver\\share"); assert(p3.absolute);
-			auto p4 = Path("C:\\somepath"); assert(p4.absolute);
-			auto p5 = Path("C:\\someotherpath"); assert(p5.absolute);
-			auto p6 = Path("D:\\somepath"); assert(p6.absolute);
-			assert(p4.relativeTo(p5) == Path("../somepath"));
-			assert(p4.relativeTo(p6) == Path("C:\\somepath"));
-			assert(p4.relativeTo(p1) == Path("C:\\somepath"));
-			assert(p1.relativeTo(p2) == Path("../share"));
-			assert(p1.relativeTo(p3) == Path("\\\\server\\share"));
-			assert(p1.relativeTo(p4) == Path("\\\\server\\share"));
+			auto p1 = NativePath("\\\\server\\share"); assert(p1.absolute);
+			auto p2 = NativePath("\\\\server\\othershare"); assert(p2.absolute);
+			auto p3 = NativePath("\\\\otherserver\\share"); assert(p3.absolute);
+			auto p4 = NativePath("C:\\somepath"); assert(p4.absolute);
+			auto p5 = NativePath("C:\\someotherpath"); assert(p5.absolute);
+			auto p6 = NativePath("D:\\somepath"); assert(p6.absolute);
+			assert(p4.relativeTo(p5) == NativePath("../somepath"));
+			assert(p4.relativeTo(p6) == NativePath("C:\\somepath"));
+			assert(p4.relativeTo(p1) == NativePath("C:\\somepath"));
+			assert(p1.relativeTo(p2) == NativePath("../share"));
+			assert(p1.relativeTo(p3) == NativePath("\\\\server\\share"));
+			assert(p1.relativeTo(p4) == NativePath("\\\\server\\share"));
 		}
 	}
 }
 
 unittest {
-	assert(Path("/foo/bar/baz").relativeTo(Path("/foo")).toString == "bar/baz");
-	assert(Path("/foo/bar/baz/").relativeTo(Path("/foo")).toString == "bar/baz/");
-	assert(Path("/foo/bar").relativeTo(Path("/foo")).toString == "bar");
-	assert(Path("/foo/bar/").relativeTo(Path("/foo")).toString == "bar/");
-	assert(Path("/foo").relativeTo(Path("/foo/bar")).toString() == "..");
-	assert(Path("/foo/").relativeTo(Path("/foo/bar")).toString() == "../");
-	assert(Path("/foo/baz").relativeTo(Path("/foo/bar/baz")).toString() == "../../baz");
-	assert(Path("/foo/baz/").relativeTo(Path("/foo/bar/baz")).toString() == "../../baz/");
-	assert(Path("/foo/").relativeTo(Path("/foo/bar/baz")).toString() == "../../");
-	assert(Path("/foo/").relativeTo(Path("/foo/bar/baz/mumpitz")).toString() == "../../../");
-	assert(Path("/foo").relativeTo(Path("/foo")).toString() == "");
-	assert(Path("/foo/").relativeTo(Path("/foo")).toString() == "");
+	assert(NativePath("/foo/bar/baz").relativeTo(NativePath("/foo")).toString == "bar/baz");
+	assert(NativePath("/foo/bar/baz/").relativeTo(NativePath("/foo")).toString == "bar/baz/");
+	assert(NativePath("/foo/bar").relativeTo(NativePath("/foo")).toString == "bar");
+	assert(NativePath("/foo/bar/").relativeTo(NativePath("/foo")).toString == "bar/");
+	assert(NativePath("/foo").relativeTo(NativePath("/foo/bar")).toString() == "..");
+	assert(NativePath("/foo/").relativeTo(NativePath("/foo/bar")).toString() == "../");
+	assert(NativePath("/foo/baz").relativeTo(NativePath("/foo/bar/baz")).toString() == "../../baz");
+	assert(NativePath("/foo/baz/").relativeTo(NativePath("/foo/bar/baz")).toString() == "../../baz/");
+	assert(NativePath("/foo/").relativeTo(NativePath("/foo/bar/baz")).toString() == "../../");
+	assert(NativePath("/foo/").relativeTo(NativePath("/foo/bar/baz/mumpitz")).toString() == "../../../");
+	assert(NativePath("/foo").relativeTo(NativePath("/foo")).toString() == "");
+	assert(NativePath("/foo/").relativeTo(NativePath("/foo")).toString() == "");
 }

--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -7,7 +7,8 @@
 */
 module dub.internal.vibecompat.inet.path;
 
-version (Have_vibe_d_core) public import vibe.inet.path;
+version (Have_vibe_core) public import vibe.core.path;
+else version (Have_vibe_d_core) public import vibe.inet.path;
 else:
 
 import std.algorithm;
@@ -30,6 +31,10 @@ struct Path {
 		bool m_absolute = false;
 		bool m_endsWithSlash = false;
 	}
+
+	alias Segment = PathEntry;
+
+	alias bySegment = nodes;
 
 	/// Constructs a Path object by parsing a path string.
 	this(string pathstr)
@@ -282,6 +287,8 @@ struct PathEntry {
 	}
 
 	string toString() const pure { return m_name; }
+
+	@property string name() const { return m_name; }
 
 	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return Path([this, rhs], false); }
 

--- a/source/dub/internal/vibecompat/inet/url.d
+++ b/source/dub/internal/vibecompat/inet/url.d
@@ -27,7 +27,7 @@ struct URL {
 	private {
 		string m_schema;
 		string m_pathString;
-		Path m_path;
+		NativePath m_path;
 		string m_host;
 		ushort m_port;
 		string m_username;
@@ -37,7 +37,7 @@ struct URL {
 	}
 
 	/// Constructs a new URL object from its components.
-	this(string schema, string host, ushort port, Path path)
+	this(string schema, string host, ushort port, NativePath path)
 	{
 		m_schema = schema;
 		m_host = host;
@@ -46,7 +46,7 @@ struct URL {
 		m_pathString = path.toString();
 	}
 	/// ditto
-	this(string schema, Path path)
+	this(string schema, NativePath path)
 	{
 		this(schema, null, 0, path);
 	}
@@ -124,9 +124,9 @@ struct URL {
 	@property string pathString() const { return m_pathString; }
 
 	/// The path part of the URL
-	@property Path path() const { return m_path; }
+	@property NativePath path() const { return m_path; }
 	/// ditto
-	@property void path(Path p)
+	@property void path(NativePath p)
 	{
 		m_path = p;
 		auto pstr = p.toString();
@@ -193,7 +193,7 @@ struct URL {
 		}
 
 		m_pathString = str;
-		m_path = Path(decode(str));
+		m_path = NativePath(decode(str));
 	}
 
 	/// The URL to the parent path with query string and anchor stripped.
@@ -239,9 +239,9 @@ struct URL {
 		return path.startsWith(rhs.m_path);
 	}
 
-	URL opBinary(string OP)(Path rhs) const if( OP == "~" ) { return URL(m_schema, m_host, m_port, m_path ~ rhs); }
+	URL opBinary(string OP)(NativePath rhs) const if( OP == "~" ) { return URL(m_schema, m_host, m_port, m_path ~ rhs); }
 	URL opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return URL(m_schema, m_host, m_port, m_path ~ rhs); }
-	void opOpAssign(string OP)(Path rhs) if( OP == "~" ) { m_path ~= rhs; }
+	void opOpAssign(string OP)(NativePath rhs) if( OP == "~" ) { m_path ~= rhs; }
 	void opOpAssign(string OP)(PathEntry rhs) if( OP == "~" ) { m_path ~= rhs; }
 
 	/// Tests two URLs for equality using '=='.
@@ -266,7 +266,7 @@ unittest {
 	auto url = URL.parse("https://www.example.net/index.html");
 	assert(url.schema == "https", url.schema);
 	assert(url.host == "www.example.net", url.host);
-	assert(url.path == Path("/index.html"), url.path.toString());
+	assert(url.path == NativePath("/index.html"), url.path.toString());
 
 	url = URL.parse("http://jo.doe:password@sub.www.example.net:4711/sub2/index.html?query#anchor");
 	assert(url.schema == "http", url.schema);
@@ -278,9 +278,9 @@ unittest {
 	assert(url.queryString == "query", url.queryString);
 	assert(url.anchor == "anchor", url.anchor);
 
-	url = URL("http://localhost")~Path("packages");
+	url = URL("http://localhost")~NativePath("packages");
 	assert(url.toString() == "http://localhost/packages", url.toString());
 
-	url = URL("http://localhost/")~Path("packages");
+	url = URL("http://localhost/")~NativePath("packages");
 	assert(url.toString() == "http://localhost/packages", url.toString());
 }

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -60,8 +60,8 @@ static immutable FilenameAndFormat[] packageInfoFiles = [
 */
 class Package {
 	private {
-		Path m_path;
-		Path m_infoFile;
+		NativePath m_path;
+		NativePath m_infoFile;
 		PackageRecipe m_info;
 		PackageRecipe m_rawRecipe;
 		Package m_parentPackage;
@@ -79,7 +79,7 @@ class Package {
 				instead of the one declared in the package recipe, or the one
 				determined by invoking the VCS (GIT currently).
 	*/
-	this(Json json_recipe, Path root = Path(), Package parent = null, string version_override = "")
+	this(Json json_recipe, NativePath root = NativePath(), Package parent = null, string version_override = "")
 	{
 		import dub.recipe.json;
 
@@ -88,7 +88,7 @@ class Package {
 		this(recipe, root, parent, version_override);
 	}
 	/// ditto
-	this(PackageRecipe recipe, Path root = Path(), Package parent = null, string version_override = "")
+	this(PackageRecipe recipe, NativePath root = NativePath(), Package parent = null, string version_override = "")
 	{
 		// save the original recipe
 		m_rawRecipe = recipe.clone;
@@ -128,13 +128,13 @@ class Package {
 			Returns the full path to the package file, if any was found.
 			Otherwise returns an empty path.
 	*/
-	static Path findPackageFile(Path directory)
+	static NativePath findPackageFile(NativePath directory)
 	{
 		foreach (file; packageInfoFiles) {
 			auto filename = directory ~ file.filename;
 			if (existsFile(filename)) return filename;
 		}
-		return Path.init;
+		return NativePath.init;
 	}
 
 	/** Constructs a `Package` using a package that is physically present on the local file system.
@@ -149,7 +149,7 @@ class Package {
 				instead of the one declared in the package recipe, or the one
 				determined by invoking the VCS (GIT currently).
 	*/
-	static Package load(Path root, Path recipe_file = Path.init, Package parent = null, string version_override = "")
+	static Package load(NativePath root, NativePath recipe_file = NativePath.init, Package parent = null, string version_override = "")
 	{
 		import dub.recipe.io;
 
@@ -183,7 +183,7 @@ class Package {
 		Note that this can be empty for packages that are not stored in the
 		local file system.
 	*/
-	@property Path path() const { return m_path; }
+	@property NativePath path() const { return m_path; }
 
 
 	/** Accesses the version associated with this package.
@@ -218,7 +218,7 @@ class Package {
 		Note that this can be empty for packages that are not stored in the
 		local file system.
 	*/
-	@property Path recipePath() const { return m_infoFile; }
+	@property NativePath recipePath() const { return m_infoFile; }
 
 
 	/** Returns the base package of this package.
@@ -265,7 +265,7 @@ class Package {
 		m_infoFile = m_path ~ defaultPackageFilename;
 	}
 	/// ditto
-	void storeInfo(Path path)
+	void storeInfo(NativePath path)
 	const {
 		enforce(!version_.isUnknown, "Trying to store a package with an 'unknown' version, this is not supported.");
 		auto filename = path ~ defaultPackageFilename;
@@ -650,7 +650,7 @@ class Package {
 			if( !existsFile(p) ) continue;
 			foreach(fil; ["app.d", "main.d", pkg_name ~ "/main.d", pkg_name ~ "/" ~ "app.d"]){
 				if( existsFile(p ~ fil) ) {
-					app_main_file = (Path(sf) ~ fil).toNativeString();
+					app_main_file = (NativePath(sf) ~ fil).toNativeString();
 					break;
 				}
 			}
@@ -702,7 +702,7 @@ class Package {
 	}
 }
 
-private string determineVersionFromSCM(Path path)
+private string determineVersionFromSCM(NativePath path)
 {
 	// On Windows, which is slow at running external processes,
 	// cache the version numbers that are determined using
@@ -750,7 +750,7 @@ private string determineVersionFromSCM(Path path)
 
 // determines the version of a package that is stored in a GIT working copy
 // by invoking the "git" executable
-private string determineVersionWithGIT(Path path)
+private string determineVersionWithGIT(NativePath path)
 {
 	import std.process;
 	import dub.semver;

--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -59,7 +59,7 @@ interface PackageSupplier {
 			pre_release: If true, matches the latest pre-release version.
 				Otherwise prefers stable versions.
 	*/
-	void fetchPackage(Path path, string package_id, Dependency dep, bool pre_release);
+	void fetchPackage(NativePath path, string package_id, Dependency dep, bool pre_release);
 
 	/** Retrieves only the recipe of a particular package.
 
@@ -88,10 +88,10 @@ interface PackageSupplier {
 */
 class FileSystemPackageSupplier : PackageSupplier {
 	private {
-		Path m_path;
+		NativePath m_path;
 	}
 
-	this(Path root) { m_path = root; }
+	this(NativePath root) { m_path = root; }
 
 	override @property string description() { return "file repository at "~m_path.toNativeString(); }
 
@@ -99,7 +99,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 	{
 		Version[] ret;
 		foreach (DirEntry d; dirEntries(m_path.toNativeString(), package_id~"*", SpanMode.shallow)) {
-			Path p = Path(d.name);
+			NativePath p = NativePath(d.name);
 			logDebug("Entry: %s", p);
 			enforce(to!string(p.head)[$-4..$] == ".zip");
 			auto vers = p.head.toString()[package_id.length+1..$-4];
@@ -110,7 +110,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(Path path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
 	{
 		enforce(path.absolute);
 		logInfo("Storing package '"~packageId~"', version requirements: %s", dep);
@@ -131,9 +131,9 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return null;
 	}
 
-	private Path bestPackageFile(string packageId, Dependency dep, bool pre_release)
+	private NativePath bestPackageFile(string packageId, Dependency dep, bool pre_release)
 	{
-		Path toPath(Version ver) {
+		NativePath toPath(Version ver) {
 			return m_path ~ (packageId ~ "-" ~ ver.toString() ~ ".zip");
 		}
 		auto versions = getVersions(packageId).filter!(v => dep.matches(v)).array;
@@ -183,14 +183,14 @@ class RegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(Path path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
 	{
 		import std.array : replace;
 		Json best = getBestPackage(packageId, dep, pre_release);
 		if (best.type == Json.Type.null_)
 			return;
 		auto vers = best["version"].get!string;
-		auto url = m_registryUrl ~ Path(PackagesPath~"/"~packageId~"/"~vers~".zip");
+		auto url = m_registryUrl ~ NativePath(PackagesPath~"/"~packageId~"/"~vers~".zip");
 		logDiagnostic("Downloading from '%s'", url);
 		foreach(i; 0..3) {
 			try{
@@ -222,7 +222,7 @@ class RegistryPackageSupplier : PackageSupplier {
 			m_metadataCache.remove(packageId);
 		}
 
-		auto url = m_registryUrl ~ Path(PackagesPath ~ "/" ~ packageId ~ ".json");
+		auto url = m_registryUrl ~ NativePath(PackagesPath ~ "/" ~ packageId ~ ".json");
 
 		logDebug("Downloading metadata for %s", packageId);
 		logDebug("Getting from %s", url);
@@ -309,7 +309,7 @@ package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 
 	// Workaround https://issues.dlang.org/show_bug.cgi?id=2525
 	abstract override Version[] getVersions(string package_id);
-	abstract override void fetchPackage(Path path, string package_id, Dependency dep, bool pre_release);
+	abstract override void fetchPackage(NativePath path, string package_id, Dependency dep, bool pre_release);
 	abstract override Json fetchPackageRecipe(string package_id, Dependency dep, bool pre_release);
 	abstract override SearchResult[] searchPackages(string query);
 }

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -56,7 +56,7 @@ class Project {
 			project_path = Path of the root package to load
 			pack = An existing `Package` instance to use as the root package
 	*/
-	this(PackageManager package_manager, Path project_path)
+	this(PackageManager package_manager, NativePath project_path)
 	{
 		Package pack;
 		auto packageFile = Package.findPackageFile(project_path);
@@ -356,7 +356,7 @@ class Project {
 					else {
 						auto path = vspec.path;
 						if (!path.absolute) path = m_rootPackage.path ~ path;
-						p = m_packageManager.getOrLoadPackage(path, Path.init, true);
+						p = m_packageManager.getOrLoadPackage(path, NativePath.init, true);
 						if (subname.length) p = m_packageManager.getSubPackage(p, subname, true);
 					}
 				} else if (m_dependencies.canFind!(d => getBasePackageName(d.name) == basename)) {
@@ -371,10 +371,10 @@ class Project {
 				}
 
 				if (!p && !vspec.path.empty) {
-					Path path = vspec.path;
+					NativePath path = vspec.path;
 					if (!path.absolute) path = pack.path ~ path;
 					logDiagnostic("%sAdding local %s in %s", indent, dep.name, path);
-					p = m_packageManager.getOrLoadPackage(path, Path.init, true);
+					p = m_packageManager.getOrLoadPackage(path, NativePath.init, true);
 					if (p.parentPackage !is null) {
 						logWarn("%sSub package %s must be referenced using the path to it's parent package.", indent, dep.name);
 						p = p.parentPackage;
@@ -1236,7 +1236,7 @@ private string processVars(string var, in Project project, in Package pack, bool
 		var = vres.data;
 	}
 	if (is_path) {
-		auto p = Path(var);
+		auto p = NativePath(var);
 		if (!p.absolute) {
 			return (pack.path ~ p).toNativeString();
 		} else return p.toNativeString();
@@ -1299,7 +1299,7 @@ final class SelectedVersions {
 
 	/** Constructs a new version selections from an existing JSON file.
 	*/
-	this(Path path)
+	this(NativePath path)
 	{
 		auto json = jsonFromFile(path);
 		deserialize(json);
@@ -1342,7 +1342,7 @@ final class SelectedVersions {
 	}
 
 	/// Selects a certain path for a specific package.
-	void selectVersion(string package_id, Path path)
+	void selectVersion(string package_id, NativePath path)
 	{
 		if (auto ps = package_id in m_selections) {
 			if (ps.dep == Dependency(path))
@@ -1384,7 +1384,7 @@ final class SelectedVersions {
 		should be used as the file name and the directory should be the root
 		directory of the project's root package.
 	*/
-	void save(Path path)
+	void save(NativePath path)
 	{
 		Json json = serialize();
 		auto file = openFile(path, FileMode.createTrunc);
@@ -1423,7 +1423,7 @@ final class SelectedVersions {
 		if (j.type == Json.Type.string)
 			return Dependency(Version(j.get!string));
 		else if (j.type == Json.Type.object)
-			return Dependency(Path(j["path"].get!string));
+			return Dependency(NativePath(j["path"].get!string));
 		else throw new Exception(format("Unexpected type for dependency: %s", j.type));
 	}
 

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -16,7 +16,7 @@ import dub.internal.vibecompat.inet.path;
 	The file format (JSON/SDLang) will be determined from the file extension.
 
 	Params:
-		filename = Path of the package recipe file
+		filename = NativePath of the package recipe file
 		parent_name = Optional name of the parent package (if this is a sub package)
 
 	Returns: Returns the package recipe contents
@@ -24,10 +24,10 @@ import dub.internal.vibecompat.inet.path;
 */
 PackageRecipe readPackageRecipe(string filename, string parent_name = null)
 {
-	return readPackageRecipe(Path(filename), parent_name);
+	return readPackageRecipe(NativePath(filename), parent_name);
 }
 /// ditto
-PackageRecipe readPackageRecipe(Path filename, string parent_name = null)
+PackageRecipe readPackageRecipe(NativePath filename, string parent_name = null)
 {
 	import dub.internal.utils : stripUTF8Bom;
 	import dub.internal.vibecompat.core.file : openFile, FileMode;
@@ -137,7 +137,7 @@ void writePackageRecipe(string filename, in ref PackageRecipe recipe)
 }
 
 /// ditto
-void writePackageRecipe(Path filename, in ref PackageRecipe recipe)
+void writePackageRecipe(NativePath filename, in ref PackageRecipe recipe)
 {
 	writePackageRecipe(filename.toNativeString, recipe);
 }

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -162,7 +162,7 @@ struct BuildSettingsTemplate {
 
 
 	/// Constructs a BuildSettings object from this template.
-	void getPlatformSettings(ref BuildSettings dst, in BuildPlatform platform, Path base_path)
+	void getPlatformSettings(ref BuildSettings dst, in BuildPlatform platform, NativePath base_path)
 	const {
 		dst.targetType = this.targetType;
 		if (!this.targetPath.empty) dst.targetPath = this.targetPath;
@@ -183,7 +183,7 @@ struct BuildSettingsTemplate {
 
 				foreach (spath; paths) {
 					enforce(!spath.empty, "Paths must not be empty strings.");
-					auto path = Path(spath);
+					auto path = NativePath(spath);
 					if (!path.absolute) path = base_path ~ path;
 					if (!existsFile(path) || !isDir(path.toNativeString())) {
 						logWarn("Invalid source/import path: %s", path.toNativeString());
@@ -193,7 +193,7 @@ struct BuildSettingsTemplate {
 					foreach (d; dirEntries(path.toNativeString(), pattern, SpanMode.depth)) {
 						import std.path : baseName;
 						if (baseName(d.name)[0] == '.' || d.isDir) continue;
-						auto src = Path(d.name).relativeTo(base_path);
+						auto src = NativePath(d.name).relativeTo(base_path);
 						files ~= src.toNativeString();
 					}
 				}

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -230,7 +230,7 @@ private Tag[] toSDL(in ref BuildSettingsTemplate bs)
 
 	foreach (pack, d; bs.dependencies) {
 		Attribute[] attribs;
-		if (d.path.length) attribs ~= new Attribute(null, "path", Value(d.path.toString()));
+		if (!d.path.empty) attribs ~= new Attribute(null, "path", Value(d.path.toString()));
 		else attribs ~= new Attribute(null, "version", Value(d.versionSpec));
 		if (d.optional) attribs ~= new Attribute(null, "optional", Value(true));
 		ret ~= new Tag(null, "dependency", [Value(pack)], attribs);

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -177,7 +177,7 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package
 		if ("version" in attrs)
 			logDiagnostic("Ignoring version specification (%s) for path based dependency %s", attrs["version"][0].value.get!string, attrs["path"][0].value.get!string);
 		dep.versionSpec = "*";
-		dep.path = Path(attrs["path"][0].value.get!string);
+		dep.path = NativePath(attrs["path"][0].value.get!string);
 	} else {
 		enforceSDL("version" in attrs, "Missing version specification.", t);
 		dep.versionSpec = attrs["version"][0].value.get!string;
@@ -439,7 +439,7 @@ lflags "lf3"
 	assert(rec.ddoxTool == "ddoxtool");
 	assert(rec.buildSettings.dependencies.length == 2);
 	assert(rec.buildSettings.dependencies["projectname:subpackage1"].optional == false);
-	assert(rec.buildSettings.dependencies["projectname:subpackage1"].path == Path("."));
+	assert(rec.buildSettings.dependencies["projectname:subpackage1"].path == NativePath("."));
 	assert(rec.buildSettings.dependencies["somedep"].versionSpec == "1.0.0");
 	assert(rec.buildSettings.dependencies["somedep"].optional == true);
 	assert(rec.buildSettings.dependencies["somedep"].path.empty);


### PR DESCRIPTION
vibe-core has a redesigned path module that is much more robust against accidential misuse, as well as path encoding aware. It also supports allocation-less construction from a path's string representation, which results in some non-backwards-compatible changes. This PR makes the code compile with these changes in addition to the already supported combinations.