### PR TITLE
Use shortened object file names in single-file build mode.

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -401,7 +401,7 @@ class BuildGenerator : ProjectGenerator {
 
 	static string pathToObjName(string path)
 	{
-		import std.digest.crc;
+		import std.digest.crc : crc32Of;
 		import std.path : buildNormalizedPath, dirSeparator, relativePath, stripDrive;
 		if (path.endsWith(".d")) path = path[0 .. $-2];
 		auto ret = buildNormalizedPath(getcwd(), path).replace(dirSeparator, ".");

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -401,8 +401,12 @@ class BuildGenerator : ProjectGenerator {
 
 	static string pathToObjName(string path)
 	{
-		import std.path : buildNormalizedPath, dirSeparator, stripDrive;
-		return stripDrive(buildNormalizedPath(getcwd(), path~objSuffix))[1..$].replace(dirSeparator, ".");
+		import std.digest.crc;
+		import std.path : buildNormalizedPath, dirSeparator, relativePath, stripDrive;
+		if (path.endsWith(".d")) path = path[0 .. $-2];
+		auto ret = buildNormalizedPath(getcwd(), path).replace(dirSeparator, ".");
+		auto idx = ret.lastIndexOf('.');
+		return idx < 0 ? ret ~ objSuffix : format("%s_%(%02x%)%s", ret[idx+1 .. $], crc32Of(ret[0 .. idx]), objSuffix);
 	}
 
 	/// Compile a single source file (srcFile), and write the object to objName.


### PR DESCRIPTION
The full path was repeated twice in the object file path, resulting in excessively long paths (and failures on Windows). This change uses just the module name part (i.e. just the file *name* of the D file) and combines the path part as a single crc32 value (e.g. "somemod_0a56fb23.o").