### PR TITLE
Skip explicitly linking with libcurl for LDC on Windows.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,7 +15,6 @@ configuration "application" {
 
 configuration "library" {
 	targetType "library"
-	libs "curl"
 	excludedSourceFiles "source/app.d"
 	copyFiles "bin/libcurl.dll" "bin/libeay32.dll" "bin/ssleay32.dll" platform="windows"
 	versions "DubUseCurl"


### PR DESCRIPTION
Attempts to fix the failing AppVeyor build that currently ruins the PR overview page by making it see that all PRs are broken.