### PR TITLE
Optimize dependency resolution and add a hard execution limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       env: [FRONTEND=2.068]
     - d: dmd-2.067.1
       env: [FRONTEND=2.067]
-    - d: dmd-2.066.1
-      env: [FRONTEND=2.066]
     - d: ldc-beta
       env: [FRONTEND=2.073]
     - d: ldc
@@ -48,10 +46,8 @@ matrix:
       env: [FRONTEND=2.068]
     - d: gdc
       env: [FRONTEND=2.068]
-    - d: gdc-5.2.0
-      env: [FRONTEND=2.066]
-    - d: gdc-4.9.2
-      env: [FRONTEND=2.066]
+    - d: gdc-4.8.5
+      env: [FRONTEND=2.068]
 
   allow_failures:
     - d: gdc

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -14,6 +14,7 @@ import std.algorithm : all, canFind, filter, map, sort;
 import std.array : appender, array;
 import std.conv : to;
 import std.exception : enforce;
+import std.typecons : Nullable;
 import std.string : format, indexOf, lastIndexOf;
 
 
@@ -41,7 +42,8 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		CONFIG config;
 
 		hash_t toHash() const nothrow @trusted {
-			size_t ret = typeid(string).getHash(&pack);
+			size_t ret = pack.hashOf();
+			//size_t ret = typeid(string).getHash(&pack);
 			ret ^= typeid(CONFIG).getHash(&config);
 			return ret;
 		}
@@ -123,7 +125,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		config_indices[] = 0;
 
 		visited = null;
-		sizediff_t validateConfigs(TreeNode parent, ref string error)
+		sizediff_t validateConfigs(TreeNode parent, ref ConflictError error)
 		{
 			import std.algorithm : max;
 
@@ -160,7 +162,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 					}
 					// choose another parent config to avoid the invalid child
 					if (parentidx > maxcpi) {
-						error = format("Package %s contains invalid dependency %s (no version candidates)", parent.pack, ch.pack);
+						error = ConflictError(ConflictError.Kind.invalidDependency, parent, ch, CONFIG.invalid);
 						logDiagnostic("%s (ci=%s)", error, parentidx);
 						maxcpi = parentidx;
 					}
@@ -175,13 +177,13 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 						// if we are at the root level, we can safely skip the maxcpi computation and instead choose another childidx config
 						if (parentbase == root_base_pack) {
-							error = format("No match for dependency %s %s of %s", ch.pack, ch.configs, parent.pack);
+							error = ConflictError(ConflictError.Kind.noRootMatch, parent, ch, config);
 							return childidx;
 						}
 
 						if (childidx > maxcpi) {
 							maxcpi = max(childidx, parentidx);
-							error = format("Dependency %s -> %s %s mismatches with selected version %s", parent.pack, ch.pack, ch.configs, config);
+							error = ConflictError(ConflictError.Kind.childMismatch, parent, ch, config);
 							logDebug("%s (ci=%s)", error, maxcpi);
 						}
 
@@ -196,7 +198,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 			return maxcpi;
 		}
 
-		string first_error;
+		Nullable!ConflictError first_error;
 		size_t loop_counter = 0;
 
 		// Leave the possibility to opt-out from the loop limit
@@ -213,9 +215,9 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 			// check if the current combination of configurations works out
 			visited = null;
-			string error;
+			ConflictError error;
 			auto conflict_index = validateConfigs(root, error);
-			if (first_error is null) first_error = error;
+			if (first_error.isNull) first_error = error;
 
 			// print out current iteration state
 			logDebug("Interation (ci=%s) %s", conflict_index, {
@@ -249,7 +251,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 				else break;
 			}
 			if (config_indices.all!"a==0") {
-				if (throw_on_failure) throw new Exception("Could not find a valid dependency tree configuration: "~first_error);
+				if (throw_on_failure) throw new Exception(format("Could not find a valid dependency tree configuration: %s", first_error.get));
 				else return null;
 			}
 		}
@@ -282,6 +284,36 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		foreach (p; configs.keys.dup)
 			if (p !in required)
 				configs.remove(p);
+	}
+
+	private struct ConflictError {
+		enum Kind {
+			none,
+			noRootMatch,
+			childMismatch,
+			invalidDependency
+		}
+
+		Kind kind;
+		TreeNode parent;
+		TreeNodes child;
+		CONFIG config;
+
+		string toString()
+		const {
+			final switch (kind) {
+				case Kind.none: return "no error";
+				case Kind.noRootMatch:
+					return "No match for dependency %s %s of %s"
+						.format(child.pack, child.configs, parent.pack);
+				case Kind.childMismatch:
+					return "Dependency %s -> %s %s mismatches with selected version %s"
+						.format(parent.pack, child.pack, child.configs, config);
+				case Kind.invalidDependency:
+					return "Package %s contains invalid dependency %s (no version candidates)"
+						.format(parent.pack, child.pack);
+			}
+		}
 	}
 }
 

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -197,8 +197,20 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		}
 
 		string first_error;
+		size_t loop_counter = 0;
+
+		// Leave the possibility to opt-out from the loop limit
+		import std.process : environment;
+		bool no_loop_limit = environment.get("DUB_NO_RESOLVE_LIMIT") !is null;
 
 		while (true) {
+			assert(no_loop_limit || loop_counter++ < 1_000_000,
+				"The dependency resolution process is taking too long. The"
+				~ " dependency graph is likely hitting a pathological case in"
+				~ " the resolution algorithm. Please file a bug report at"
+				~ " https://github.com/dlang/dub/issues and mention the package"
+				~ " recipe that reproduces this error.");
+
 			// check if the current combination of configurations works out
 			visited = null;
 			string error;

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -141,7 +141,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 				// get the current config/version of the current dependency
 				sizediff_t childidx = package_indices[basepack];
-				if (all_configs[childidx] == [CONFIG.invalid]) {
+				if (all_configs[childidx].length == 1 && all_configs[childidx][0] == CONFIG.invalid) {
 					// ignore invalid optional dependencies
 					if (ch.depType != DependencyType.required)
 						continue;
@@ -281,7 +281,7 @@ enum DependencyType {
 
 private string basePackage(string p)
 {
-	auto idx = indexOf(p, ":");
+	auto idx = indexOf(p, ':');
 	if (idx < 0) return p;
 	return p[0 .. idx];
 }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1243,6 +1243,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		SelectedVersions m_selectedVersions;
 		Package m_rootPackage;
 		bool[string] m_packagesToUpgrade;
+		Package[PackageDependency] m_packages;
 	}
 
 
@@ -1344,7 +1345,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		}
 		auto basepack = pack.basePackage;
 
-		foreach (d; pack.getAllDependencies()) {
+		foreach (d; pack.getAllDependenciesRange()) {
 			auto dbasename = getBasePackageName(d.name);
 
 			// detect dependencies to the root package (or sub packages thereof)
@@ -1395,6 +1396,16 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 	}
 
 	private Package getPackage(string name, Dependency dep)
+	{
+		auto key = PackageDependency(name, dep);
+		if (auto pp = key in m_packages)
+			return *pp;
+		auto p = getPackageRaw(name, dep);
+		m_packages[key] = p;
+		return p;
+	}
+
+	private Package getPackageRaw(string name, Dependency dep)
 	{
 		auto basename = getBasePackageName(name);
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1244,6 +1244,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		Package m_rootPackage;
 		bool[string] m_packagesToUpgrade;
 		Package[PackageDependency] m_packages;
+		TreeNodes[][TreeNode] m_children;
 	}
 
 
@@ -1334,6 +1335,15 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 
 	protected override TreeNodes[] getChildren(TreeNode node)
+	{
+		if (auto pc = node in m_children)
+			return *pc;
+		auto ret = getChildrenRaw(node);
+		m_children[node] = ret;
+		return ret;
+	}
+
+	private final TreeNodes[] getChildrenRaw(TreeNode node)
 	{
 		import std.array : appender;
 		auto ret = appender!(TreeNodes[]);

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -526,12 +526,22 @@ class Package {
 	PackageDependency[] getAllDependencies()
 	const {
 		auto ret = appender!(PackageDependency[]);
-		foreach (n, d; this.recipe.buildSettings.dependencies)
-			ret ~= PackageDependency(n, d);
-		foreach (ref c; this.recipe.configurations)
-			foreach (n, d; c.buildSettings.dependencies)
-				ret ~= PackageDependency(n, d);
+		getAllDependenciesRange().copy(ret);
 		return ret.data;
+	}
+
+	// Left as package until the final API for this has been found
+	package auto getAllDependenciesRange()
+	const {
+		return this.recipe.buildSettings.dependencies.byKeyValue
+			.map!(bs => PackageDependency(bs.key, bs.value))
+			.chain(
+				this.recipe.configurations
+					.map!(c => c.buildSettings.dependencies.byKeyValue
+						.map!(bs => PackageDependency(bs.key, bs.value))
+					)
+					.joiner()
+			);
 	}
 
 

--- a/source/dub/semver.d
+++ b/source/dub/semver.d
@@ -140,10 +140,10 @@ int compareVersions(string a, string b)
 	// compare a.b.c numerically
 	if (auto ret = compareNumber(a, b)) return ret;
 	assert(a[0] == '.' && b[0] == '.');
-	a.popFront(); b.popFront();
+	a = a[1 .. $]; b = b[1 .. $];
 	if (auto ret = compareNumber(a, b)) return ret;
 	assert(a[0] == '.' && b[0] == '.');
-	a.popFront(); b.popFront();
+	a = a[1 .. $]; b = b[1 .. $];
 	if (auto ret = compareNumber(a, b)) return ret;
 
 	// give precedence to non-prerelease versions
@@ -154,7 +154,7 @@ int compareVersions(string a, string b)
 
 	// compare the prerelease tail lexicographically
 	do {
-		a.popFront(); b.popFront();
+		a = a[1 .. $]; b = b[1 .. $];
 		if (auto ret = compareIdentifier(a, b)) return ret;
 	} while (a.length > 0 && b.length > 0 && a[0] != '+' && b[0] != '+');
 
@@ -288,12 +288,12 @@ private int compareIdentifier(ref string a, ref string b)
 	bool aempty = true, bempty = true;
 	int res = 0;
 	while (true) {
-		if (a.front != b.front && res == 0) res = a.front - b.front;
-		if (anumber && (a.front < '0' || a.front > '9')) anumber = false;
-		if (bnumber && (b.front < '0' || b.front > '9')) bnumber = false;
-		a.popFront(); b.popFront();
-		aempty = a.empty || a.front == '.' || a.front == '+';
-		bempty = b.empty || b.front == '.' || b.front == '+';
+		if (a[0] != b[0] && res == 0) res = a[0] - b[0];
+		if (anumber && (a[0] < '0' || a[0] > '9')) anumber = false;
+		if (bnumber && (b[0] < '0' || b[0] > '9')) bnumber = false;
+		a = a[1 .. $]; b = b[1 .. $];
+		aempty = !a.length || a[0] == '.' || a[0] == '+';
+		bempty = !b.length || b[0] == '.' || b[0] == '+';
 		if (aempty || bempty) break;
 	}
 
@@ -315,10 +315,10 @@ private int compareNumber(ref string a, ref string b)
 {
 	int res = 0;
 	while (true) {
-		if (a.front != b.front && res == 0) res = a.front - b.front;
-		a.popFront(); b.popFront();
-		auto aempty = a.empty || (a.front < '0' || a.front > '9');
-		auto bempty = b.empty || (b.front < '0' || b.front > '9');
+		if (a[0] != b[0] && res == 0) res = a[0] - b[0];
+		a = a[1 .. $]; b = b[1 .. $];
+		auto aempty = !a.length || (a[0] < '0' || a[0] > '9');
+		auto bempty = !b.length || (b[0] < '0' || b[0] > '9');
 		if (aempty != bempty) return bempty - aempty;
 		if (aempty) return res;
 	}

--- a/source/dub/semver.d
+++ b/source/dub/semver.d
@@ -26,7 +26,7 @@ import std.conv;
 	Validates a version string according to the SemVer specification.
 */
 bool isValidVersion(string ver)
-{
+pure @nogc {
 	// NOTE: this is not by spec, but to ensure sane input
 	if (ver.length > 256) return false;
 
@@ -102,7 +102,7 @@ unittest {
 /**
 	Determines if a given valid SemVer version has a pre-release suffix.
 */
-bool isPreReleaseVersion(string ver)
+bool isPreReleaseVersion(string ver) pure @nogc
 in { assert(isValidVersion(ver)); }
 body {
 	foreach (i; 0 .. 2) {
@@ -136,7 +136,7 @@ unittest {
 		equal, and a positive number otherwise.
 */
 int compareVersions(string a, string b)
-{
+pure @nogc {
 	// compare a.b.c numerically
 	if (auto ret = compareNumber(a, b)) return ret;
 	assert(a[0] == '.' && b[0] == '.');
@@ -225,7 +225,8 @@ unittest {
 
 	See_Also: `expandVersion`
 */
-string bumpVersion(string ver) {
+string bumpVersion(string ver)
+pure {
 	// Cut off metadata and prerelease information.
 	auto mi = ver.indexOfAny("+-");
 	if (mi > 0) ver = ver[0..mi];
@@ -258,7 +259,8 @@ unittest {
 
 	See_Also: `bumpVersion`
 */
-string expandVersion(string ver) {
+string expandVersion(string ver)
+pure {
 	auto mi = ver.indexOfAny("+-");
 	auto sub = "";
 	if (mi > 0) {
@@ -282,7 +284,7 @@ unittest {
 }
 
 private int compareIdentifier(ref string a, ref string b)
-{
+pure @nogc {
 	bool anumber = true;
 	bool bnumber = true;
 	bool aempty = true, bempty = true;
@@ -312,7 +314,7 @@ private int compareIdentifier(ref string a, ref string b)
 }
 
 private int compareNumber(ref string a, ref string b)
-{
+pure @nogc {
 	int res = 0;
 	while (true) {
 		if (a[0] != b[0] && res == 0) res = a[0] - b[0];
@@ -325,7 +327,7 @@ private int compareNumber(ref string a, ref string b)
 }
 
 private bool isValidIdentifierChain(string str, bool allow_leading_zeros = false)
-{
+pure @nogc {
 	if (str.length == 0) return false;
 	while (str.length) {
 		auto end = str.indexOf('.');
@@ -338,7 +340,7 @@ private bool isValidIdentifierChain(string str, bool allow_leading_zeros = false
 }
 
 private bool isValidIdentifier(string str, bool allow_leading_zeros = false)
-{
+pure @nogc {
 	if (str.length < 1) return false;
 
 	bool numeric = true;
@@ -361,7 +363,7 @@ private bool isValidIdentifier(string str, bool allow_leading_zeros = false)
 }
 
 private bool isValidNumber(string str)
-{
+pure @nogc {
 	if (str.length < 1) return false;
 	foreach (ch; str)
 		if (ch < '0' || ch > '9')
@@ -374,7 +376,7 @@ private bool isValidNumber(string str)
 }
 
 private sizediff_t indexOfAny(string str, in char[] chars)
-{
+pure @nogc {
 	sizediff_t ret = -1;
 	foreach (ch; chars) {
 		auto idx = str.indexOf(ch);


### PR DESCRIPTION
This speeds up the dependency resolution process by a factor of around 20x (without exact measurements). On top of that, there is now an execution cap of 1 million iterations (which previously would have easily taken an hour) to avoid CI processed getting stuck and to be able to print a helpful error message pointing to the bug tracker.