### PR TITLE
Make deprecation warnings compile errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,8 @@ install:
                 $latestVersion = $latest.split("-")[0].split("~")[0];
                 $url = "http://downloads.dlang.org/pre-releases/2.x/$($latestVersion)/dmd.$($latest).windows.7z";
             }elseif($version -eq "nightly") {
-                $url = "http://nightlies.dlang.org/dmd-master-2017-05-20/dmd.master.windows.7z"
+                $latest = (Invoke-WebRequest "http://nightlies.dlang.org/dmd-nightly/LATEST").toString().replace("`n",", ").replace("`r",", ");
+                $url = "http://nightlies.dlang.org/dmd-$($latest)/dmd.master.windows.7z"
             }else {
                 $url = "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z";
             }

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.7
 
 echo Running $DMD...
-$DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -g -O -de -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo

--- a/dub.sdl
+++ b/dub.sdl
@@ -10,6 +10,13 @@ configuration "application" {
 	targetType "executable"
 	mainSourceFile "source/app.d"
 	libs "curl"
+	buildRequirements "disallowDeprecations"
+	versions "DubUseCurl"
+}
+
+configuration "unittest" {
+	buildRequirements "disallowDeprecations"
+	excludedSourceFiles "source/app.d"
 	versions "DubUseCurl"
 }
 


### PR DESCRIPTION
`-de` is also used at Phobos, Druntime and Tools.
See also: https://github.com/dlang/phobos/pull/5546
The idea is that whenever sth. gets deprecated in Druntime or Phobos a replacement needs to exists. By always building with `-de`, we can enforce that the replacement really exists and force the person who submits the deprecation to look after the fallout.