### PR TITLE
Git version resolution for path-based dependecy

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -756,7 +756,7 @@ private string determineVersionWithGIT(NativePath path)
 	import dub.semver;
 
 	auto git_dir = path ~ ".git";
-	if (!existsFile(git_dir) || !isDir(git_dir.toNativeString)) return null;
+	if (!existsFile(git_dir)) return null;
 	auto git_dir_param = "--git-dir=" ~ git_dir.toNativeString();
 
 	static string exec(scope string[] params...) {


### PR DESCRIPTION
It is fairly legal in case of a git submodule that _.git_ is a regular file. Git accepts this file in its _--git-dir_ parameter in `git describe`. Thus rendering the `isDir()` check in `determineVersionWithGIT(NativePath path)` being counter-effective.