### PR TITLE
Bump vibe-d to 0.8.3-alpha.1

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -4,14 +4,14 @@
 		"botan": "1.12.9",
 		"botan-math": "1.0.3",
 		"diet-ng": "1.4.3",
-		"eventcore": "0.8.21",
+		"eventcore": "0.8.26",
 		"libasync": "0.8.3",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
 		"openssl": "1.1.6+1.0.1g",
-		"taggedalgebraic": "0.10.7",
-		"vibe-core": "1.2.0",
-		"vibe-d": "0.8.1"
+		"taggedalgebraic": "0.10.8",
+		"vibe-core": "1.3.0",
+		"vibe-d": "0.8.3-alpha.1"
 	}
 }

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -4,7 +4,7 @@ set -v -e -o pipefail
 
 source ~/dlang/*/activate # activate host compiler
 
-if [ -z "$FRONTEND" -o "$FRONTEND" \> 2.068.z ]; then
+if [ -z "$FRONTEND" -o "$FRONTEND" \> 2.071.z ]; then
     vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
     dub fetch vibe-d --version=$vibe_ver # get optional dependency
     dub test --compiler=${DC} -c library-nonet


### PR DESCRIPTION
Vibe.d 0.8.3 won't include `std.experimental.allocator` anymore.

See also: https://github.com/vibe-d/vibe.d/pull/1983

Needed for https://github.com/dlang/phobos/pull/5921