### PR TITLE
Fix sublime text generator file regex

### DIFF
--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -85,7 +85,7 @@ private Json buildSystems(BuildPlatform buildPlatform, string workingDiretory = 
 	string fileRegex;
 
 	if (buildPlatform.frontendVersion >= 2066 && buildPlatform.compiler == "dmd")
-		fileRegex = r"^(.+)\(([0-9]+)\,([0-9]+)\)\:() (.*)$";
+		fileRegex = r"^(.+)\(([0-9]+)\,([0-9]+)\)\: (.*)$";
 	else
 		fileRegex = r"^(.+)\(([0-9]+)\)\:() (.*)$";
 


### PR DESCRIPTION
Errors were not displaying properly in sublime text before because of the extra empty group capture. 
That group was being interpreted as the error text when the one right after is actually the error text.