### PR TITLE
Update compiler support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ sudo: false
 matrix:
   include:
     - d: dmd-nightly
-      env: [FRONTEND=2.076]
+      env: [FRONTEND=2.078]
     - d: dmd-beta
-      env: [FRONTEND=2.076]
+      env: [FRONTEND=2.078]
     - d: dmd
       env:
-        - [FRONTEND=2.075]
+        - [FRONTEND=2.077]
         - [COVERAGE=true]
+    - d: dmd-2.076.1
+      env: [FRONTEND=2.076]
     - d: dmd-2.075.1
       env: [FRONTEND=2.075]
     - d: dmd-2.074.1
@@ -28,12 +30,14 @@ matrix:
       env: [FRONTEND=2.069]
     - d: dmd-2.068.2
       env: [FRONTEND=2.068]
-    - d: dmd-2.067.1
-      env: [FRONTEND=2.067]
     - d: ldc-beta
       env: [FRONTEND=2.073]
     - d: ldc
-      env: [FRONTEND=2.073]
+      env: [FRONTEND=2.076]
+    - d: ldc-1.5.0
+      env: [FRONTEND=2.075]
+    - d: ldc-1.4.0
+      env: [FRONTEND=2.074]
     - d: ldc-1.3.0
       env: [FRONTEND=2.073]
     - d: ldc-1.2.0
@@ -42,8 +46,6 @@ matrix:
       env: [FRONTEND=2.071]
     - d: ldc-1.0.0
       env: [FRONTEND=2.070]
-    - d: ldc-0.17.2
-      env: [FRONTEND=2.068]
     - d: gdc
       env: [FRONTEND=2.068]
     - d: gdc-4.8.5


### PR DESCRIPTION
- Add testing for DMD 2.076.1
- Update frontend versions for dmd-beta and dmd-nightly
- Test on LDC 1.4.0 and 1.5.0
- Stop testing on LDC 0.17.2
- Stop testing on DMD 2.067.1