### PR TITLE
Avoid creation of a temporary probe file for newer compilers

### DIFF
--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -255,7 +255,21 @@ NativePath generatePlatformProbeFile()
 		fil.close();
 	}
 
-	fil.write(q{
+	fil.write(platformProbeFile);
+	fil.close();
+
+	return path;
+}
+
+
+/**
+	Platform probe file that will give, at compile time, information about the compiler (architecture, frontend version...)
+
+	See_Also: `generatePlatformProbeFile`, `readPlatformProbe`
+*/
+string platformProbeFile()
+{
+	return q{
 		module dub_platform_probe;
 		import std.array;
 
@@ -279,11 +293,7 @@ NativePath generatePlatformProbeFile()
 		string determineArchitecture() } ~ '{' ~ archCheck ~
 		`	return '"' ~ ret.data.join("\", \"") ~ "\", "; }` ~ q{
 
-		string determineCompiler() } ~ '{' ~ compilerCheck ~ "	}");
-
-	fil.close();
-
-	return path;
+		string determineCompiler() } ~ '{' ~ compilerCheck ~ "	}";
 }
 
 /**


### PR DESCRIPTION
When I chatred with @RazvanN7 today, he complained about DUB creating a lot of temporary probing files in his current working directory.
A quick look at the code revealed that DUB uses this probing hack to extract information
from DMD. Since https://github.com/dlang/dmd/pull/6880 (2.076.0), it's possible
to avoid the need of creating a temporary file for this hack.
Of course, it would be better to read this file from the compiler directly...