### PR TITLE
AppVeyor: remove failing Windows beta

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,6 @@ environment:
     DVersion: stable
     arch: x86
   - DC: ldc
-    DVersion: beta
-    arch: x64
-  - DC: ldc
     DVersion: stable
     arch: x64
   - DC: ldc


### PR DESCRIPTION
Apparently the URL changed. In lack of a Windows machine to test,

edit: let's do the simple fix, s.t. the CI is green again and upgrade to the new URL scheme later.