### PR TITLE
Add support for DragonFlyBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.obj
+*~
 
 .dub
 .directory
@@ -26,6 +27,10 @@ __dummy.html
 /test/expected-issue616-output
 /test/describe-project/dummy.dat
 /test/describe-project/dummy-dep1.dat
+/test/*/main/main
+/test/*/*test-library
+/test/*/*test-application
+/test/*/exec-simple
 
 # Ignore coverage files
 cov/

--- a/build-gdc.sh
+++ b/build-gdc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 if [ "$GDC" = "" ]; then

--- a/scripts/rpm-package/make_installer.sh
+++ b/scripts/rpm-package/make_installer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 cd ../../
 DUB_PATH=`pwd`

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -349,6 +349,7 @@ class VisualDGenerator : ProjectGenerator {
 				ret.put("    <isWindows>0</isWindows>\n");
 				ret.put("    <isFreeBSD>0</isFreeBSD>\n");
 				ret.put("    <isSolaris>0</isSolaris>\n");
+				ret.put("    <isDragonFlyBSD>0</isDragonFlyBSD>\n");
 				ret.put("    <scheduler>0</scheduler>\n");
 				ret.put("    <useDeprecated>0</useDeprecated>\n");
 				ret.put("    <useAssert>0</useAssert>\n");

--- a/test/describe-dependency-1/dependency-postGenerateCommands.sh
+++ b/test/describe-dependency-1/dependency-postGenerateCommands.sh
@@ -1,1 +1,1 @@
-#!/bin/sh
+#!/usr/bin/env bash

--- a/test/describe-dependency-1/dependency-preGenerateCommands.sh
+++ b/test/describe-dependency-1/dependency-preGenerateCommands.sh
@@ -1,1 +1,1 @@
-#!/bin/sh
+#!/usr/bin/env bash

--- a/test/describe-project/do-postGenerateCommands.sh
+++ b/test/describe-project/do-postGenerateCommands.sh
@@ -1,1 +1,1 @@
-#!/bin/sh
+#!/usr/bin/env bash

--- a/test/describe-project/do-preGenerateCommands.sh
+++ b/test/describe-project/do-preGenerateCommands.sh
@@ -1,1 +1,1 @@
-#!/bin/sh
+#!/usr/bin/env bash

--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -7,7 +7,7 @@ $DUB fetch dub --version=0.9.21 && [ -d $HOME/.dub/packages/dub-0.9.21/dub ]
 if $DUB remove dub --non-interactive 2>/dev/null; then
     die $LINENO 'Non-interactive remove should fail'
 fi
-echo 1 | $DUB remove dub | tr --delete '\n' | grep --ignore-case 'select.*0\.9\.20.*0\.9\.21.*'
+echo 1 | $DUB remove dub | tr -d '\n' | grep --ignore-case 'select.*0\.9\.20.*0\.9\.21.*'
 if [ -d $HOME/.dub/packages/dub-0.9.20/dub ]; then
     die $LINENO 'Failed to remove dub-0.9.20'
 fi

--- a/test/issue616-describe-vs-generate-commands/do-preGenerateCommands.sh
+++ b/test/issue616-describe-vs-generate-commands/do-preGenerateCommands.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 if [ -n "${dub_issue616}" ]; then
     echo 'Fail! preGenerateCommands recursion detected!' >&2
     exit 0  # Don't return a non-zero error code here. This way the test gives a better diagnostic.

--- a/test/run-unittest.sh
+++ b/test/run-unittest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ueo pipefail
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
@@ -30,10 +31,11 @@ fi
 
 DC_BIN=$(basename "$DC")
 CURR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FRONTEND="${FRONTEND:-}"
 
 for script in $(ls $CURR_DIR/*.sh); do
     if [ "$script" = "$(readlink -f ${BASH_SOURCE[0]})" ] || [ "$(basename $script)" = "common.sh" ]; then continue; fi
-    if [ -e $script.min_frontend ] && [ ! -z ${FRONTEND:-} -a ${FRONTEND:-} \< $(cat $script.min_frontend) ]; then continue; fi
+    if [ -e $script.min_frontend ] && [ ! -z "$FRONTEND" ] && [ ${FRONTEND} \< $(cat $script.min_frontend) ]; then continue; fi
     log "Running $script..."
     DUB=$DUB DC=$DC CURR_DIR="$CURR_DIR" $script || logError "Script failure."
 done

--- a/test/single-file-sdl-default-name.sh
+++ b/test/single-file-sdl-default-name.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 cd ${CURR_DIR}
 rm -f single-file-sdl-default-name


### PR DESCRIPTION
Notes:
- Switch from /bin/sh to /usr/bin/env bash
- Ignore temporary and test-build files (gitignore)
- Untrack changes to source/dub/version_.d
- Handling 'isDragonflybsd'
- Use 'tr -d' instead of 'tr --deleted' which works on Linux and BSD based platforms
- Fix FRONTEND = unbound variable (test/run-unittest.sh)