### PR TITLE
Add defaultArchitecture field to dub configuration

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -620,6 +620,7 @@ abstract class PackageBuildCommand : Command {
 	protected void setupPackage(Dub dub, string package_name, string default_build_type = "debug")
 	{
 		if (!m_compilerName.length) m_compilerName = dub.defaultCompiler;
+		if (!m_arch.length) m_arch = dub.defaultArchitecture;
 		m_compiler = getCompiler(m_compilerName);
 		m_buildPlatform = m_compiler.determinePlatform(m_buildSettings, m_compilerName, m_arch);
 		m_buildSettings.addDebugVersions(m_debugVersions);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -106,6 +106,7 @@ class Dub {
 		Project m_project;
 		NativePath m_overrideSearchPath;
 		string m_defaultCompiler;
+		string m_defaultArchitecture;
 	}
 
 	/** The default placement location of fetched packages.
@@ -213,6 +214,8 @@ class Dub {
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		determineDefaultCompiler();
+
+		m_defaultArchitecture = m_config.defaultArchitecture;
 	}
 
 	@property void dryRun(bool v) { m_dryRun = v; }
@@ -249,6 +252,13 @@ class Dub {
 		will be used.
 	*/
 	@property string defaultCompiler() const { return m_defaultCompiler; }
+
+	/** Returns the default architecture to use for building D code.
+
+		If set, the "defaultArchitecture" field of the DUB user or system
+		configuration file will be used. Otherwise null will be returned.
+	*/
+	@property string defaultArchitecture() const { return m_defaultArchitecture; }
 
 	/** Loads the package that resides within the configured `rootPath`.
 	*/
@@ -1582,6 +1592,14 @@ private class DubConfig {
 		if (auto pv = "defaultCompiler" in m_data)
 			return pv.get!string;
 		if (m_parentConfig) return m_parentConfig.defaultCompiler;
+		return null;
+	}
+
+	@property string defaultArchitecture()
+	const {
+		if(auto pv = "defaultArchitecture" in m_data)
+			return (*pv).get!string;
+		if (m_parentConfig) return m_parentConfig.defaultArchitecture;
 		return null;
 	}
 }


### PR DESCRIPTION
This is especially useful on Windows where, if the MSVC tools have been installed, x86_64 is usually the preferred target arch.