### PR TITLE
Bump versions to 2.078.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ sudo: false
 
 matrix:
   include:
-    - d: dmd-nightly
+    - d: dmd-2.078.0
       env: [FRONTEND=2.078]
-    - d: dmd-beta
-      env: [FRONTEND=2.078]
-    - d: dmd
+    - d: dmd-2.077.1
       env:
         - [FRONTEND=2.077]
         - [COVERAGE=true]
@@ -30,9 +28,9 @@ matrix:
       env: [FRONTEND=2.069]
     - d: dmd-2.068.2
       env: [FRONTEND=2.068]
-    - d: ldc-beta
-      env: [FRONTEND=2.073]
-    - d: ldc
+    - d: ldc-1.7.0
+      env: [FRONTEND=2.077]
+    - d: ldc-1.6.0
       env: [FRONTEND=2.076]
     - d: ldc-1.5.0
       env: [FRONTEND=2.075]

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -4,14 +4,15 @@
 		"botan": "1.12.9",
 		"botan-math": "1.0.3",
 		"diet-ng": "1.4.3",
-		"eventcore": "0.8.26",
+		"eventcore": "0.8.27",
 		"libasync": "0.8.3",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
 		"openssl": "1.1.6+1.0.1g",
+		"stdx-allocator": "2.77.0",
 		"taggedalgebraic": "0.10.8",
 		"vibe-core": "1.3.0",
-		"vibe-d": "0.8.3-alpha.1"
+		"vibe-d": "0.8.2"
 	}
 }


### PR DESCRIPTION
Removed `dmd-nightly` as we now have the Project-Tester and the `FRONTEND`
versions is very likely to be out of sync. The same motivation applies for
replacing `ldc` with `ldc-1.7.0`