### PR TITLE
Move the package repository on Windows to LocalAppData

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -201,6 +201,9 @@ class Dub {
 			immutable appDataDir = environment.get("APPDATA");
 			m_dirs.userSettings = NativePath(appDataDir) ~ "dub/";
 			m_dirs.localRepository = NativePath(environment.get("LOCALAPPDATA", appDataDir)) ~ "dub";
+
+			migrateRepositoryFromRoaming(m_dirs.userSettings ~"\\packages", m_dirs.localRepository ~ "\\packages");
+
 		} else version(Posix){
 			m_dirs.systemSettings = NativePath("/var/lib/dub/");
 			m_dirs.userSettings = NativePath(environment.get("HOME")) ~ ".dub/";
@@ -217,6 +220,24 @@ class Dub {
 
 		determineDefaultCompiler();
 	}
+
+	version(Windows) 
+	private void migrateRepositoryFromRoaming(NativePath roamingDir, NativePath localDir)
+	{
+        immutable roamingDirPath = roamingDir.toNativeString();
+	    if (!existsDirectory(roamingDir)) return;
+        
+        immutable localDirPath = localDir.toNativeString();
+        logInfo("Detected a package cache in " ~ roamingDirPath ~ ". This will be migrated to " ~ localDirPath ~ ". Please wait...");
+        if (!existsDirectory(localDir))
+        {
+            mkdirRecurse(localDirPath);
+        }
+
+        runCommand("xcopy /s /e /y " ~ roamingDirPath ~ " " ~ localDirPath ~ " > NUL"); 
+        rmdirRecurse(roamingDirPath);
+	}
+
 
 	@property void dryRun(bool v) { m_dryRun = v; }
 


### PR DESCRIPTION
Move the package repository on Windows to LocalAppData to avoid bloat in the roaming data folder (speed up log-in/-off process). Keep the userSettings directory in AppData as this config data should roam.