### PR TITLE
Always set CodeCov notifications to green/passing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,14 +1,34 @@
 # Documentation: https://docs.codecov.io/docs/codecov-yaml
+# Validate with: `curl --data-binary @.codecov.yml https://codecov.io/validate`
+
+codecov:
+  notify:
+    # We don't want to wait for the CodeCov report
+    # See https://github.com/codecov/support/issues/312
+    require_ci_to_pass: false
+    after_n_builds: 1  # send notifications after the first upload
+    wait_for_ci: false
+
+  bot: dlang-bot
+
+  # At Travis, the PR is merged into `master` before the testsuite is run.
+  # This allows CodeCov to adjust the resulting coverage diff, s.t. it matches
+  # with the GitHub diff.
+  # https://github.com/codecov/support/issues/363
+  # https://docs.codecov.io/v4.3.6/docs/comparing-commits
+  allow_coverage_offsets: true
 
 coverage:
   precision: 3
   round: down
   range: "80...100"
 
+  # Learn more at https://docs.codecov.io/docs/commit-status
   status:
-    # Learn more at https://docs.codecov.io/docs/commit-status
-    project: true
-    patch: true
-    changes: true
+    project: off
+    changes: off
+    patch:
+      default:
+        threshold: 5
 
 comment: false


### PR DESCRIPTION
As the dlang-bot now won't merge a PR when there's one failure [1], it makes sense
to force CodeCov to be `informational`. The interesting bit - coverage of the diff -
is still displayed in the CI tab and more importantly the browser extension still
works too and will continue to highlight the uncovered parts in red.

See also: https://github.com/dlang/dmd/blob/master/.codecov.yml

[1] https://github.com/dlang-bots/dlang-bot/pull/69