### PR TITLE
Fix random stall of issue884 test

### DIFF
--- a/test/issue884-init-defer-file-creation.sh
+++ b/test/issue884-init-defer-file-creation.sh
@@ -9,8 +9,11 @@ mkdir ${TMPDIR}
 cd ${TMPDIR}
 
 # kill dub init during interactive mode
-${DUB} init <(while :; do sleep 1; done) &
+mkfifo in
+${DUB} init < in &
+sleep 1
 kill $!
+rm in
 
 # ensure that no files are left behind
 NFILES_PLUS_ONE=`ls -la | wc -l`


### PR DESCRIPTION
This is a continuation of https://github.com/dlang/dub/pull/1227.

From time to time I experienced a stall when running the dub tests in the package build of NixOS.
Maybe it's just on Mac OSX machines, I don't know but it happend again on my Mac and I saw that the build could not finish.
It was stalled because of issue884 test was still running. I killed the process manually and the build could finish.

I looked at my fix https://github.com/dlang/dub/commit/66e16f4f2dbff21bd0393dcdad5287aec00d461f#diff-5d90b75ad0c20c53fbbfe98b572ac8d3 and suspected that sometimes it can happen that kill $! isn't working properly because the previously started background process wasn't started properly yet.
So I added the sleep after dub init again and found that the problem now was reproducible all the time for me.
I still don't understand what exactly happens but the kill is obviously not working because it somehow doesn't find the proper pid via $!.
So I tried to replace the ugly loop with something nicer and came up with this solution.
