### PR TITLE
Auto-publishing Linux 32/64 + OSX binaries to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __dummy.html
 /bin/__test__library__
 /bin/dub-test-library
 /bin/libdub.a
+/bin/dub-*
 
 # Ignore files or directories created by the test suite.
 /test/custom-source-main-bug487/custom-source-main-bug487
@@ -35,3 +36,6 @@ __dummy.html
 
 # Ignore coverage files
 cov/
+
+# Ignore auto-generated docs
+/docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,20 @@ language: d
 dist: trusty
 sudo: false
 
-matrix:
+addons:
+  apt:
+    packages:
+      - libevent-dev
+
+script:
+  - ./travis-ci.sh
+
+jobs:
+  allow_failures:
+    - d: gdc
   include:
-    - d: dmd-2.078.0
+    - stage: test
+      d: dmd-2.078.0
       env: [FRONTEND=2.078]
     - d: dmd-2.077.1
       env: [FRONTEND=2.077, COVERAGE=true]
@@ -46,15 +57,61 @@ matrix:
       env: [FRONTEND=2.068]
     - d: gdc-4.8.5
       env: [FRONTEND=2.068]
-
-  allow_failures:
-    - d: gdc
-
-addons:
-  apt:
-    packages:
-      - libevent-dev
-
-script:
-  - deactivate # deactivate host compiler
-  - ./travis-ci.sh
+    - stage: deploy
+      d: ldc
+      os: osx
+      script: echo "Deploying to GitHub releases ..." && ./release.sh
+      deploy:
+        - provider: releases
+          file_glob: true
+          file: bin/dub-*.tar.gz
+          skip_cleanup: true
+          api_key: $GH_REPO_TOKEN
+          on:
+            branch: master
+            tags: true
+    - d: ldc
+      script: echo "Deploying to GitHub releases ..." && ./release.sh
+      env: [ARCH=32]
+      addons:
+        apt:
+          packages:
+          - g++-multilib
+          - libcurl4-openssl-dev:i386
+      deploy:
+        - provider: releases
+          file_glob: true
+          file: bin/dub-*.tar.gz
+          skip_cleanup: true
+          api_key: $GH_REPO_TOKEN
+          on:
+            branch: master
+            tags: true
+    - d: ldc
+      script: echo "Deploying to GitHub releases ..." && ./release.sh
+      deploy:
+        - provider: releases
+          file_glob: true
+          file: bin/dub-*.tar.gz
+          skip_cleanup: true
+          api_key: $GH_REPO_TOKEN
+          on:
+            branch: master
+            tags: true
+    - stage: update-latest
+      script: echo "Deploying to GitHub pages ..." && mkdir -p docs && git describe --abbrev=0 --tags > docs/LATEST
+      deploy:
+        - provider: pages
+          skip_cleanup: true
+          local_dir: docs
+          github_token: $GH_REPO_TOKEN
+          on:
+            branch: master
+            tags: true
+stages:
+  - name: test
+    if: type = pull_request or (type = push and branch = master)
+  - name: deploy
+    if: type = push and tag =~ ^v
+  - name: update-latest
+    if: type = push and tag =~ ^v

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     - d: gdc-4.8.5
       env: [FRONTEND=2.068]
     - stage: deploy
-      d: ldc
+      d: dmd
       os: osx
       script: echo "Deploying to GitHub releases ..." && ./release.sh
       deploy:
@@ -70,7 +70,7 @@ jobs:
           on:
             branch: master
             tags: true
-    - d: ldc
+    - d: dmd
       script: echo "Deploying to GitHub releases ..." && ./release.sh
       env: [ARCH=32]
       addons:
@@ -87,7 +87,7 @@ jobs:
           on:
             branch: master
             tags: true
-    - d: ldc
+    - d: dmd
       script: echo "Deploying to GitHub releases ..." && ./release.sh
       deploy:
         - provider: releases

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -v -e -o pipefail
+
+VERSION=$(git describe --abbrev=0 --tags)
+ARCH="${ARCH:-64}"
+
+unameOut="$(uname -s)"
+case "$unameOut" in
+    Linux*) OS=linux; ;;
+    Darwin*) OS=osx; ;;
+    *) echo "Unknown OS: $unameOut"; exit 1
+esac
+
+case "$ARCH" in
+    64) ARCH_SUFFIX="x86_64";;
+    32) ARCH_SUFFIX="x86";;
+    *) echo "Unknown ARCH: $ARCH"; exit 1
+esac
+
+archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
+
+echo "Building $archiveName"
+DFLAGS="-release -m$ARCH" DMD="$(command -v $DMD)" ./build.sh
+tar cvfz "bin/$archiveName" -C bin dub


### PR DESCRIPTION
(See also: https://github.com/dlang/dub/issues/1367)

Linux 32 and 64-bit + OSX already work. Only Windows is missing, but there isn't any script which currently uses `LATEST` anyhow (+ my Windows knowledge is quite limited).

It already works on my fork:
- https://github.com/wilzbach/dub/releases/tag/v1.7.17
- https://github.com/wilzbach/dub/blob/gh-pages/LATEST (and thus: http://wilzbach.github.io/dub/LATEST)

![image](https://user-images.githubusercontent.com/4370550/36065160-1de028fe-0e97-11e8-8b16-de9dbcc8a231.png)

Notes: 

1) I disabled the `test` stage for tag deployments, because there are still many random and spurious failures and if someone deliberately tags a new version, the deployment should succeed and not fail due to some tests depending on a host to be online.

2) I used build stages, s.t. `LATEST` is only updated after all three deployment jobs have run successfully. This avoids the case where `LATEST` is updated by the Linux job and the OSX job takes a few seconds/minutes longer or even fails.

3) Lastly, the normal PR/master is unaffected (see e.g. https://travis-ci.org/wilzbach/dub/builds/339909754)
If wanted we can also always run the `deploy` stage, but just skip the actual deployment step. Travis supports this out of the box.

Resources:
- https://docs.travis-ci.com/user/build-stages/
- https://docs.travis-ci.com/user/conditional-builds-stages-jobs/