### PR TITLE
allow absolute paths in sourcePaths (useful for local development)

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -646,7 +646,12 @@ class Package {
 		string app_main_file;
 		auto pkg_name = m_info.name.length ? m_info.name : "unknown";
 		foreach(sf; bs.sourcePaths.get("", null)){
-			auto p = m_path ~ sf;
+			NativePath p;
+			import std.path:isAbsolute;
+			if(sf.isAbsolute)
+				p=sf.NativePath;
+			else
+				p = m_path ~ sf;
 			if( !existsFile(p) ) continue;
 			foreach(fil; ["app.d", "main.d", pkg_name ~ "/main.d", pkg_name ~ "/" ~ "app.d"]){
 				if( existsFile(p ~ fil) ) {


### PR DESCRIPTION
this useful for local development (workarounds are painful), but we probably shouldn't use this feature for published dub packages.

Is there a way to prevent pushing a dub package to official dub repository that would rely on this feature? Likewise if a fix for https://github.com/dlang/dub/issues/1378 were implemented, we'd want to prevent pushing to official dub package repository pacakges using that override feature.


