### PR TITLE
[auto-deploy] search for 32-bit DMD executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ jobs:
           on:
             tags: true
     - d: dmd
-      script: echo "Deploying to GitHub releases ..." && ./release.sh
+      # DMD 32-bit is needed for 32-bit compilation
+      script: echo "Deploying to GitHub releases ..." && DMD=$(find $HOME/dlang | grep "dmd-.*/linux/bin32/dmd") ./release.sh
       env: [ARCH=32]
       addons:
         apt:


### PR DESCRIPTION
See also: https://github.com/dlang/dub/issues/1367

This wasn't detected before, because I used `ldc` in my testing and only changed to DMD at the end (see https://github.com/dlang/dub/pull/1369) and the release steps are only executed on new tags.