### PR TITLE
env var replacement not supporting `${VAR_NAME}` syntax

### DIFF
--- a/changelog/env-var-replacement.dd
+++ b/changelog/env-var-replacement.dd
@@ -1,0 +1,8 @@
+Enviroment variable expansion was improved
+
+Environment variable expansion now supports the braced `${MY_VAR}` expansion syntax: e.g. for `${PACKAGE_PATH}_suffix`.
+
+Moreover, `$PACKAGE_PATH`, `$ROOT_PACKAGE_PATH`, and `$DEP_PACKAGE_PATH` no longer end
+  with a `/` or `\` to support clean concatenation, e.g. `${PACKAGE_PATH}/subpath`.
+
+Learn more about the details at $(LINK2 https://github.com/dlang/dub/pull/1392, #1392).

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1183,9 +1183,9 @@ private void processVars(ref Appender!(string[]) dst, in Project project, in Pac
 
 private string processVars(Project, Package)(string var, in Project project, in Package pack,in GeneratorSettings gsettings, bool is_path)
 {
-	import std.regex : ctRegex, replaceAll;
+	import std.regex : regex, replaceAll;
 
-	enum varRE = ctRegex!`\$([\w_]+)|\$\{([\w_]+)\}`;
+	auto varRE = regex(`\$([\w_]+)|\$\{([\w_]+)\}`);
 	var = var.replaceAll!(m => getVariable(m[1].length ? m[1] : m[2], project, pack, gsettings))(varRE);
 	if (is_path) {
 		auto p = NativePath(var);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1205,7 +1205,7 @@ private string getVariable(Project, Package)(string name, in Project project, in
 {
 	import std.process : environment;
 	import std.uni : asUpperCase;
-	Path path;
+	NativePath path;
 	if (name == "PACKAGE_DIR")
 		path = pack.path;
 	else if (name == "ROOT_PACKAGE_DIR")

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1181,32 +1181,12 @@ private void processVars(ref Appender!(string[]) dst, in Project project, in Pac
 	foreach (var; vars) dst.put(processVars(var, project, pack, gsettings, are_paths));
 }
 
-private string processVars(string var, in Project project, in Package pack, in GeneratorSettings gsettings, bool is_path)
+private string processVars(Project, Package)(string var, in Project project, in Package pack,in GeneratorSettings gsettings, bool is_path)
 {
-	auto idx = std.string.indexOf(var, '$');
-	if (idx >= 0) {
-		auto vres = appender!string();
-		while (idx >= 0) {
-			if (idx+1 >= var.length) break;
-			if (var[idx+1] == '$') {
-				vres.put(var[0 .. idx+1]);
-				var = var[idx+2 .. $];
-			} else {
-				vres.put(var[0 .. idx]);
-				var = var[idx+1 .. $];
+	import std.regex : ctRegex, replaceAll;
 
-				size_t idx2 = 0;
-				while( idx2 < var.length && isIdentChar(var[idx2]) ) idx2++;
-				auto varname = var[0 .. idx2];
-				var = var[idx2 .. $];
-
-				vres.put(getVariable(varname, project, pack, gsettings));
-			}
-			idx = std.string.indexOf(var, '$');
-		}
-		vres.put(var);
-		var = vres.data;
-	}
+	enum varRE = ctRegex!`\$([\w_]+)|\$\{([\w_]+)\}`;
+	var = var.replaceAll!(m => getVariable(m[1].length ? m[1] : m[2], project, pack, gsettings))(varRE);
 	if (is_path) {
 		auto p = NativePath(var);
 		if (!p.absolute) {
@@ -1221,7 +1201,7 @@ package(dub) immutable buildSettingsVars = [
 	"ARCH", "PLATFORM", "PLATFORM_POSIX", "BUILD_TYPE"
 ];
 
-private string getVariable(string name, in Project project, in Package pack, in GeneratorSettings gsettings)
+private string getVariable(Project, Package)(string name, in Project project, in Package pack, in GeneratorSettings gsettings)
 {
 	import std.process : environment;
 	if (name == "PACKAGE_DIR") return pack.path.toNativeString();
@@ -1266,6 +1246,58 @@ private string getVariable(string name, in Project project, in Package pack, in 
 	throw new Exception("Invalid variable: "~name);
 }
 
+
+unittest
+{
+	static struct MockPackage
+	{
+		this(string name)
+		{
+			this.name = name;
+			version (Posix)
+				path = NativePath("/pkgs/"~name~"/");
+			else version (Windows)
+				path = NativePath(`C:\pkgs\`~name~`\`);
+		}
+		string name;
+		NativePath path;
+	}
+
+	static struct MockProject
+	{
+		MockPackage rootPackage;
+		inout(MockPackage)[] getTopologicalPackageList() inout
+		{
+			return _dependencies;
+		}
+	private:
+		MockPackage[] _dependencies;
+	}
+
+	MockProject proj = {
+		rootPackage: MockPackage("root"),
+		_dependencies: [MockPackage("dep1"), MockPackage("dep2")]
+	};
+	auto pack = MockPackage("test");
+	GeneratorSettings gsettings;
+	enum isPath = true;
+	// basic vars
+	assert(processVars("Hello $PACKAGE_DIR", proj, pack, gsettings, !isPath) == "Hello "~pack.path.toNativeString);
+	assert(processVars("Hello $ROOT_PACKAGE_DIR", proj, pack, gsettings, !isPath) == "Hello "~proj.rootPackage.path.toNativeString);
+	assert(processVars("Hello $DEP1_PACKAGE_DIR", proj, pack, gsettings, !isPath) == "Hello "~proj._dependencies[0].path.toNativeString);
+	// ${VAR} replacements, NOTE: PACKAGE_DIR et.al. end on /
+	assert(processVars("Hello ${PACKAGE_DIR}foobar", proj, pack, gsettings, !isPath) == "Hello "~(pack.path ~ "foobar").toNativeString);
+	// test with isPath
+	assert(processVars("local", proj, pack, gsettings, isPath) == (pack.path ~ "local").toNativeString);
+	// test other env variables
+	import std.process : environment;
+	environment["MY_ENV_VAR"] = "blablabla";
+	assert(processVars("$MY_ENV_VAR", proj, pack, gsettings, !isPath) == "blablabla");
+	assert(processVars("${MY_ENV_VAR}suffix", proj, pack, gsettings, !isPath) == "blablablasuffix");
+	assert(processVars("$MY_ENV_VAR-suffix", proj, pack, gsettings, !isPath) == "blablabla-suffix");
+	assert(processVars("$MY_ENV_VAR:suffix", proj, pack, gsettings, !isPath) == "blablabla:suffix");
+	environment.remove("MY_ENV_VAR");
+}
 
 /** Holds and stores a set of version selections for package dependencies.
 


### PR DESCRIPTION
This is commonly needed to join pathes or a suffix, e.g. `$PACKAGE_DIRmylib.a` (as unfortunately PACKAGE_DIR ends on `/`).
Expanding variables is straighforward, https://github.com/MartinNowak/alertd/blob/cbc4459bbdbcc8c799413f58a591f6d28205f147/src/alertd.d#L503.