### PR TITLE
[WIP] support dependencies as git url (including with exact commit hash)

### DIFF
--- a/source/dub/packagesupplier.d
+++ b/source/dub/packagesupplier.d
@@ -146,6 +146,50 @@ class FileSystemPackageSupplier : PackageSupplier {
 	}
 }
 
+/**
+	Git based based package supplier.
+
+	This package supplier downloads directly from git.
+*/
+class GitPackageSupplier : PackageSupplier {
+	this() { }
+
+	override @property string description() { return typeof(this).stringof; }
+
+	Version[] getVersions(string package_id)
+	{
+		return null;
+	}
+
+	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	{
+		enforce(path.absolute);
+		logInfo("Storing package '"~packageId~"', version requirements: %s", dep);
+		auto gitDep=dep.gitDep;
+		assert(gitDep.valid);
+		URL url = gitDep.toURLZip;
+		logDiagnostic("Downloading from '%s'", url);
+		// TODO: foreach(i; 0..3)
+		download(url, path);
+	}
+
+	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	{
+		if(!dep.isGit)
+			return Json(null);
+		auto gitDep=dep.gitDep;
+		auto ret=Json.emptyObject;
+		ret["name"]=packageId;
+		ret["version"]=gitDep.toVersion;
+		return ret;
+	}
+
+	SearchResult[] searchPackages(string query)
+	{
+		assert(0);
+	}
+}
+
 
 /**
 	Online registry based package supplier.


### PR DESCRIPTION
[reviewers: please ignore whitespace issues]

this supports for eg:
```
{
	"fileVersion": 1,
	"versions": {
		"ae": "@https://github.com/timotheecour/ae/commit/64430549f0bad65caa47cef523e69004a2d41b62"
	}
}
```

this fixes https://github.com/dlang/dub/issues/51 (and is more general since allows that commit to come from a private fork)

also related to https://github.com/dlang/dub/issues/632

it works but I have some question to improve it, please contact me on slack

