### PR TITLE
Ensure mainSourceFile is deduplicated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ v1.8.1 - 2018-
 -------------------
 
 - Fixed a regression in 1.8.0 that caused linker files specified as `sourceFiles` to not get inherited properly - [issue #1408][issue1408], [pull #1409][issue1409]
+- Fixed a regression in 1.8.0 that caused `mainSourceFile` to be passed twice to the compiler on Windows - [issue #1407][issue1407], [pull #1410][issue1410]
 
+[issue1407]: https://github.com/dlang/dub/issues/1407
 [issue1408]: https://github.com/dlang/dub/issues/1408
 [issue1409]: https://github.com/dlang/dub/issues/1409
+[issue1410]: https://github.com/dlang/dub/issues/1410
 
 
 v1.8.0 - 2018-03-01


### PR DESCRIPTION
This forces the mainSourceFile to be normalized and converted to the native path format before being added to sourceFiles, so that when adding files later on with collectFiles matches up properly.

Fixes #1407.