### PR TITLE
 Fix #1419 - Use LDC by default for the released binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     - d: gdc-4.8.5
       env: [FRONTEND=2.068]
     - stage: deploy
-      d: dmd
+      d: ldc
       os: osx
       script: echo "Deploying to GitHub releases ..." && ./release.sh
       deploy:
@@ -69,9 +69,8 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: dmd
-      # DMD 32-bit is needed for 32-bit compilation
-      script: echo "Deploying to GitHub releases ..." && DMD=$(find $HOME/dlang | grep "dmd-.*/linux/bin32/dmd") ./release.sh
+    - d: ldc
+      script: echo "Deploying to GitHub releases ..." && ./release.sh
       env: [ARCH=32]
       addons:
         apt:
@@ -86,7 +85,7 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: dmd
+    - d: ldc
       script: echo "Deploying to GitHub releases ..." && ./release.sh
       deploy:
         - provider: releases

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.7
 
 echo Running $DMD...
-$DMD -ofbin/dub -L--export-dynamic -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.7
 
 echo Running $DMD...
-$DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -L--export-dynamic -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo

--- a/release.sh
+++ b/release.sh
@@ -4,11 +4,17 @@ set -v -e -o pipefail
 
 VERSION=$(git describe --abbrev=0 --tags)
 ARCH="${ARCH:-64}"
+CUSTOM_FLAGS=""
 
 unameOut="$(uname -s)"
 case "$unameOut" in
-    Linux*) OS=linux; ;;
-    Darwin*) OS=osx; ;;
+    Linux*)
+        OS=linux
+        CUSTOM_FLAGS="-L--export-dynamic"
+        ;;
+    Darwin*)
+        OS=osx
+        ;;
     *) echo "Unknown OS: $unameOut"; exit 1
 esac
 
@@ -21,5 +27,5 @@ esac
 archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
 
 echo "Building $archiveName"
-DFLAGS="-release -m$ARCH" DMD="$(command -v $DMD)" ./build.sh
+DFLAGS="-release -m$ARCH ${CUSTOM_FLAGS}" DMD="$(command -v $DMD)" ./build.sh
 tar cvfz "bin/$archiveName" -C bin dub


### PR DESCRIPTION
See https://github.com/dlang/dub/issues/1419

Travis release build: https://travis-ci.org/wilzbach/dub/builds/357736472

https://github.com/wilzbach/dub/releases/tag/v1.8.4 (<- release tag is arbitrary and just needed to kickoff a Travis build on my fork)

(for comparison: https://github.com/dlang/dub/releases/tag/v1.8.0)