### PR TITLE
gen_man: Add missing "-lz" linker flag to link against zlib

### DIFF
--- a/scripts/man/gen_man.d
+++ b/scripts/man/gen_man.d
@@ -1,6 +1,7 @@
 #!/usr/bin/env dub
 /+dub.sdl:
 dependency "dub" path="../.."
+lflags "-lz"
 +/
 
 import std.algorithm, std.conv, std.format, std.path, std.range, std.stdio;


### PR DESCRIPTION
We add this patch on Debian, to ensure the resulting binary is correctly linked against ZLib.