### PR TITLE
gen_man: Fix build with gdc-8

### DIFF
--- a/scripts/man/gen_man.d
+++ b/scripts/man/gen_man.d
@@ -106,8 +106,8 @@ dependencies \- both downloading them and linking them into the application.`);
 string highlightArguments(string args)
 {
 	import std.regex : regex, replaceAll;
-	static immutable re = regex("<([^>]*)>");
-	static immutable reReplacement = "<%s>".format(`$1`.italic);
+	static auto re = regex("<([^>]*)>");
+	static const reReplacement = "<%s>".format(`$1`.italic);
 	return args.replaceAll(re, reReplacement);
 }
 


### PR DESCRIPTION
Apparently, GDC 8 (or previous versions) don't have a Phobos that allows the regex or string to be immutable.
This patch allows the current gen_man to be built with GDC 8.

CC: @ibuclaw 