### PR TITLE
Use the more generic 0.8 version for Vibe.d in 'dub init' to avoid it getting outdated too fast

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -111,7 +111,7 @@ void main()
 private void initVibeDPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
 	if ("vibe-d" !in p.buildSettings.dependencies)
-		p.buildSettings.dependencies["vibe-d"] = Dependency("~>0.8.2");
+		p.buildSettings.dependencies["vibe-d"] = Dependency("~>0.8");
 	p.description = "A simple vibe.d server application.";
 	pre_write_callback();
 


### PR DESCRIPTION
A quick fix that should push the problem of having an outdated Vibe.d version when running `dub init`  a bit more into the future.

At some point a proper `init` template system / bootstrapping system would be great though.