### PR TITLE
Use full Link-Time Optimization (LTO) for the release binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,8 @@ jobs:
 stages:
   - name: test
     if: type = pull_request or (type = push and branch = master)
-  - name: deploy
-    if: type = push and tag =~ ^v
+  # Until deployment of the release binaries is fixed, always build them
+  #- name: deploy
+    #if: type = push and tag =~ ^v
   - name: update-latest
     if: type = push and tag =~ ^v

--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,8 @@ else
 	echo Using existing version file.
 fi
 
-# For OSX compatibility >= 10.7
-MACOSX_DEPLOYMENT_TARGET=10.7
+# For OSX compatibility >= 10.8
+MACOSX_DEPLOYMENT_TARGET=10.8
 
 echo Running $DMD...
 $DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt


### PR DESCRIPTION
Without LTO
-----------

```
~/dlang/avgtime/avgtime -q -r1000 ~/dlang/dub-repo/bin/dub.stable describe

------------------------
Total time (ms): 110249
Repetitions    : 1000
Sample mode    : 100 (586 occurrences)
Median time    : 108.899
Avg time       : 110.249
Std dev.       : 6.25044
Minimum        : 100.357
Maximum        : 142.289
95% conf.int.  : [97.9979, 122.499]  e = 12.2506
99% conf.int.  : [94.1484, 126.349]  e = 16.1001
EstimatedAvg95%: [109.861, 110.636]  e = 0.387399
EstimatedAvg99%: [109.739, 110.758]  e = 0.509129
```

With LTO
--------

```
~/dlang/avgtime/avgtime -q -r1000 ~/dlang/dub-repo/bin/dub.lto describe

------------------------
Total time (ms): 97952.6
Repetitions    : 1000
Sample mode    : 93 (117 occurrences)
Median time    : 96.2915
Avg time       : 97.9526
Std dev.       : 5.86976
Minimum        : 89.173
Maximum        : 146.487
95% conf.int.  : [86.4481, 109.457]  e = 11.5045
99% conf.int.  : [82.8331, 113.072]  e = 15.1195
EstimatedAvg95%: [97.5888, 98.3164]  e = 0.363805
EstimatedAvg99%: [97.4745, 98.4307]  e = 0.478121
```

Note that the binary size goes up from 17M to 22M.
(Compressed from 3.8M to 5.2M), but imho space is cheap compared to this huge speed-up.

Learn more about LTO -> http://johanengelen.github.io/ldc/2016/11/10/Link-Time-Optimization-LDC.html