### PR TITLE
Allow to run single tests + output overview log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __dummy.html
 /bin/dub-*
 
 # Ignore files or directories created by the test suite.
+/test/test.log
 /test/custom-source-main-bug487/custom-source-main-bug487
 /test/3-copyFiles/bin/
 /test/ignore-hidden-1/ignore-hidden-1

--- a/test/common.sh
+++ b/test/common.sh
@@ -2,12 +2,17 @@ SOURCE_FILE=$_
 
 set -ueEo pipefail
 
+function log() {
+    echo -e "\033[0;33m[INFO] $@\033[0m"
+    echo "[INFO]  $@" >> $(dirname "${BASH_SOURCE[0]}")/test.log
+}
+
 # lineno[, msg]
 function die() {
     local line=$1
     local msg=${2:-command failed}
     local supplemental=${3:-}
-    >&2 echo "[ERROR] $SOURCE_FILE:$1 $msg"
+    echo "[ERROR] $SOURCE_FILE:$1 $msg" | tee -a $(dirname "${BASH_SOURCE[0]}")/test.log | cat 1>&2
     if [ ! -z "$supplemental" ]; then
         echo "$supplemental" | >&2 sed 's|^|        |g'
     fi


### PR DESCRIPTION
A modest PR to make testing easier.

The output of run-unittest.sh is quite verbose and lengthy. Difficult to come back to something that has failed in the middle.

This PR propose to log basic test info into a file, and to have the possibility to run a small subset of the test suite.

```sh
 $ ./run-unittest.sh
   # about 800 lines...
 $ cat test.log
   # one line per test
   [INFO]  Running /home/remi/dev/dlang/dub/test/issue103-single-file-package.sh...
   [INFO]  Running /home/remi/dev/dlang/dub/test/issue1091-bogus-rebuild.sh...
   [ERROR] Script failure.
   [INFO]  Running /home/remi/dev/dlang/dub/test/issue1194-warn-wrong-subconfig.sh...
   [INFO]  Running /home/remi/dev/dlang/dub/test/issue346-redundant-flags.sh...
   # ...
 $ ./run-unittest.sh bogus
   # only issue1091-bogus-rebuild related tests are run
```
Here `bogus` is a regex, so you can enter more subtile pattern