### PR TITLE
Build {32,64}-bit Windows binaries on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,27 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
+    - d: dmd
+      #if: tag IS present
+      os: linux
+      language: generic
+      sudo: yes
+      script: echo "Deploying to GitHub releases ..." && ./release-windows.sh && ARCH=64 ./release-windows.sh
+      addons:
+        apt:
+          packages:
+            - p7zip-full
+            - wine
+        deploy:
+          provider: releases
+          api_key: $GH_REPO_TOKEN
+          file_glob: true
+          file: bin/dub-.*.zip
+          skip_cleanup: true
+          on:
+            repo: dlang/dub
+            tags: true
+
     - stage: update-latest
       script: echo "Deploying to GitHub pages ..." && mkdir -p docs && git describe --abbrev=0 --tags > docs/LATEST
       deploy:

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build the Windows binaries under Linux (requires wine)
+set -eux -o pipefail
+VERSION=$(git describe --abbrev=0 --tags)
+OS=windows
+if [ "${ARCH:-32}" == "64" ] ; then
+	ARCH_SUFFIX="x86_64"
+	export MFLAGS="-m64"
+else
+	ARCH_SUFFIX="x86"
+	export MFLAGS="-m32"
+fi
+
+
+# Allow the script to be run from anywhere
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+# Step 1: download the DMD binaries
+if [ ! -d dmd2 ] ; then
+	wget http://downloads.dlang.org/releases/2.x/2.080.0/dmd.2.080.0.windows.7z
+	7z x dmd.2.080.0.windows.7z > /dev/null
+fi
+
+# Step 2: Run DMD via wineconsole
+archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.zip"
+echo "Building $archiveName"
+mkdir -p bin
+DC="$DIR/dmd2/windows/bin/dmd.exe" wine cmd /C build.cmd
+
+cd bin
+zip "$archiveName" dub.exe


### PR DESCRIPTION
Similar to how we build the binaries at Dscanner, DCD and dfmt, e.g.

https://github.com/dlang-community/DCD/blob/master/release-windows.sh
https://github.com/dlang-community/DCD/releases/tag/v0.9.7

I guess generating the setup.exe is a bit more tricky (@s-ludwig: do you have a script for it?), but this should already bring us a lot further down the road.