### PR TITLE
Fix misleading message when package description is invalid

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -245,7 +245,7 @@ int runDubCommandLine(string[] args)
 			// make the CWD package available so that for example sub packages can reference their
 			// parent package.
 			try dub.packageManager.getOrLoadPackage(NativePath(options.root_path));
-			catch (Exception e) { logDiagnostic("No package found in current working directory."); }
+			catch (Exception e) { logDiagnostic("No valid package found in current working directory: %s", e.msg); }
 		}
 	}
 


### PR DESCRIPTION
If the package description file is incomplete or contains errors, the produced error message can be misleading: "No package found in current working directory.", when in fact the package file is there but invalid.