### PR TITLE
Report failed external commands explicitly

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -198,7 +198,8 @@ void runCommands(in string[] commands, string[string] env = null)
 		Pid pid;
 		pid = spawnShell(cmd, stdin, childStdout, childStderr, env, config);
 		auto exitcode = pid.wait();
-		enforce(exitcode == 0, "Command failed with exit code "~to!string(exitcode));
+		enforce(exitcode == 0, "Command failed with exit code "
+			~ to!string(exitcode) ~ ": " ~ cmd);
 	}
 }
 


### PR DESCRIPTION
Improve the error on failed external commands: dub will now print the exact command that failed.

This was useful to troubleshoot #1478.

Before:
```
object.Exception@source\dub\internal\utils.d(201): Command failed with exit code 4
```
After:
```
object.Exception@source\dub\internal\utils.d(201): Command ``xcopy /s /e /y C:\users\simon\Application Data\dub\packages C:\users\simon\Local Settings\Application Data\dub\packages > NUL'' failed with exit code 4
```