### PR TITLE
Fix #1478 - Quote paths passed to xcopy

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -311,7 +311,7 @@ class Dub {
             mkdirRecurse(localDirPath);
         }
 
-        runCommand("xcopy /s /e /y " ~ roamingDirPath ~ " " ~ localDirPath ~ " > NUL");
+        runCommand(`xcopy /s /e /y "` ~ roamingDirPath ~ `" "` ~ localDirPath ~ `" > NUL`);
         rmdirRecurse(roamingDirPath);
 	}
 
@@ -1278,7 +1278,7 @@ class Dub {
 
 		if (!run) {
 			// TODO: ddox should copy those files itself
-			version(Windows) runCommand("xcopy /S /D "~tool_path~"public\\* docs\\");
+			version(Windows) runCommand(`xcopy /S /D "`~tool_path~`public\*" docs\`);
 			else runCommand("rsync -ru '"~tool_path~"public/' docs/");
 		}
 	}


### PR DESCRIPTION
This fixes two lines:
**(1)** migrate dub package dir,
**(2)** copy DDoc files.

I have tested (1) on Wine and on a friend's native Windows 8.1. Both times, the fix works as expected: `xcopy` finds and copies the old package directory even when source or target dir contain spaces.

**Reviewers:** I have not tested (2), neither on Wine nor on Windows. Please test (2)!

---

On Windows, `cd` accepts unquoted paths, but for any calls to `xcopy`,
paths arguments must be double-quoted. This patch surrounds all paths
with double-quotes before passing them to `xcopy`.

This fixes #1478: On Wine (and presumably Windows XP), migrating the dub
package directory from dub 1.7 to dub 1.8/1.9 via `xcopy` failed an
enforce in dub (because `xcopy` quit with nonzero exit code) and thus
prevented even the most simple dub projects from being built.

D WYSIWYG strings (backtick-surrounded strings) allow all characters
unescaped, including double quotes and backslashes.