### PR TITLE
remove regular upgrade check

### DIFF
--- a/changelog/upgrade_check.dd
+++ b/changelog/upgrade_check.dd
@@ -1,0 +1,8 @@
+The regular upgrade check has been removed
+
+Previously dub would regularly (once a day) check for possible package upgrades before building a packages.
+This lead to unexpected build failures, e.g. when internet connectivity was down or dependency resolution failed, and caused unnecessary delays.
+
+The build flag `--nodeps` now only suppresses resolution of missing dependencies.
+
+The new upgrade flag `--dry-run` was added to explicitly check for upgradable packages without actually upgrading anything.

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1067,41 +1067,14 @@ class Project {
 			m_selections.save(path);
 	}
 
-	/** Checks if the cached upgrade information is still considered up to date.
-
-		The cache will be considered out of date after 24 hours after the last
-		online check.
-	*/
-	bool isUpgradeCacheUpToDate()
+	deprecated bool isUpgradeCacheUpToDate()
 	{
-		try {
-			auto datestr = m_packageSettings["dub"].opt!(Json[string]).get("lastUpgrade", Json("")).get!string;
-			if (!datestr.length) return false;
-			auto date = SysTime.fromISOExtString(datestr);
-			if ((Clock.currTime() - date) > 1.days) return false;
-			return true;
-		} catch (Exception t) {
-			logDebug("Failed to get the last upgrade time: %s", t.msg);
-			return false;
-		}
+		return false;
 	}
 
-	/** Returns the currently cached upgrade information.
-
-		The returned dictionary maps from dependency package name to the latest
-		available version that matches the dependency specifications.
-	*/
-	Dependency[string] getUpgradeCache()
+	deprecated Dependency[string] getUpgradeCache()
 	{
-		try {
-			Dependency[string] ret;
-			foreach (string p, d; m_packageSettings["dub"].opt!(Json[string]).get("cachedUpgrades", Json.emptyObject))
-				ret[p] = SelectedVersions.dependencyFromJson(d);
-			return ret;
-		} catch (Exception t) {
-			logDebug("Failed to get cached upgrades: %s", t.msg);
-			return null;
-		}
+		return null;
 	}
 
 	/** Sets a new set of versions for the upgrade cache.
@@ -1446,4 +1419,3 @@ final class SelectedVersions {
 			m_selections[p] = Selected(dependencyFromJson(v));
 	}
 }
-


### PR DESCRIPTION
- avoids "build" failures due to connectivity issues or pending dependency conflicts
- `dub build --nodeps` now only suppresses resolution of missing dependencies
- add an explicit `dub upgrade --dry-run` to check for new packages