### PR TITLE
Force CodeCov to be informational only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,6 +29,6 @@ coverage:
     changes: off
     patch:
       default:
-        threshold: 5
+        informational: true
 
 comment: false


### PR DESCRIPTION
Let's stop these non-sense errors like on https://github.com/dlang/dub/pull/1509.
CodeCov is nice for looking at the diff and seeing what lines are covered, but it's not nice to fail the PR for that.