### PR TITLE
Reimplement dependency resolution as a recursive process

### DIFF
--- a/changelog/recursive_dependecy_resolution.dd
+++ b/changelog/recursive_dependecy_resolution.dd
@@ -1,0 +1,10 @@
+Dependency resolution has been reimplemented using a recursive algorithm
+
+The new algorithm minimizes the search space while descending the dependency
+graph. Compared to the old approach, it is now much less likely to run into
+pathological cases that result in exponential run time ("The dependency
+resolution algorithm is taking too long").
+
+Furthermore, the error message in case of unsatisfiable dependencies is more
+precise, usually making it straight forward to debug issues in the dependency
+graph of a failing package.

--- a/test/expected-issue1037-output
+++ b/test/expected-issue1037-output
@@ -1,4 +1,3 @@
-Root package issue1037-better-dependency-messages reference gitcompatibledubpackage 1.0.1 cannot be satisfied.
-Packages causing the conflict:
-	issue1037-better-dependency-messages depends on 1.0.1
-	b depends on ~>1.0.2
+Unresolvable dependencies to package gitcompatibledubpackage:
+  b >=0.0.0 @DIR/b depends on gitcompatibledubpackage ~>1.0.2
+  issue1037-better-dependency-messages ~master depends on gitcompatibledubpackage 1.0.1

--- a/test/issue1037-better-dependency-messages.sh
+++ b/test/issue1037-better-dependency-messages.sh
@@ -4,17 +4,21 @@ set -e -o pipefail
 cd ${CURR_DIR}/issue1037-better-dependency-messages
 
 temp_file=$(mktemp $(basename $0).XXXXXX)
+temp_file2=$(mktemp $(basename $0).XXXXXX)
 expected_file="$CURR_DIR/expected-issue1037-output"
 
 function cleanup {
-    rm $temp_file
+    rm -f $temp_file
+    rm -f $temp_file
 }
 
 trap cleanup EXIT
 
+sed "s#DIR#$CURR_DIR/issue1037-better-dependency-messages#" "$expected_file" > "$temp_file2"
+
 $DUB upgrade 2>$temp_file && exit 1 # dub upgrade should fail
 
-if ! diff "$expected_file" "$temp_file"; then
+if ! diff "$temp_file2" "$temp_file"; then
     die 'output not containing conflict information'
 fi
 


### PR DESCRIPTION
The new approach minimizes the dependency version graph while descending, making it *much* less likely to run into pathological cases. It also is a lot easier to understand and reason about than the previous iterative approach.

The downside is dynamic and stack memory use, where the latter could be optimized using a COW approach. If stack overflow should turn out to become an issue in large dependency graphs, the algorithm could be converted to use a heap based stack.

Fixes #1300.
Fixes #1508.

Looks related, but appears to be fixed already: #1484
#1001 appears to have been fixed already (gives a proper error message)
#1345 also appears to have been fixed, this time externally by fixing the faulty dependencies
