### PR TITLE
Add build type syntax

### DIFF
--- a/changelog/buildTypeSyntax.dd
+++ b/changelog/buildTypeSyntax.dd
@@ -1,0 +1,3 @@
+DUB supports build type "syntax" 
+
+With this release new build type "syntax" is added. This build type is useful for IDEs to check the syntax of D coding without generating binaries.

--- a/scripts/fish-completion/dub.fish
+++ b/scripts/fish-completion/dub.fish
@@ -49,7 +49,7 @@ for cmd in run build test generate describe dustmite
 	complete -c dub -n "contains '$cmd' (commandline -poc)" -s a -l arch               -r -d "Force architecture"
 	complete -c dub -n "contains '$cmd' (commandline -poc)" -s d -l debug              -r -d "Debug identifier"
 	complete -c dub -n "contains '$cmd' (commandline -poc)"      -l nodeps                -d "No dependency check"
-	complete -c dub -n "contains '$cmd' (commandline -poc)" -s b -l build           -u -x -d "Build type"                        -a "debug plain release release-debug release-nobounds unittest profile profile-gc docs ddox cov unittest-cov"
+	complete -c dub -n "contains '$cmd' (commandline -poc)" -s b -l build           -u -x -d "Build type"                        -a "debug plain release release-debug release-nobounds unittest profile profile-gc docs ddox cov unittest-cov syntax"
 	complete -c dub -n "contains '$cmd' (commandline -poc)"      -l build-mode         -x -d "How compiler & linker are invoked" -a "separate allAtOnce singleFile"
 	complete -c dub -n "contains '$cmd' (commandline -poc)"      -l compiler           -x -d "Compiler binary"                   -a "dmd gdc ldc gdmd ldmd"
 end

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -599,7 +599,7 @@ abstract class PackageBuildCommand : Command {
 		args.getopt("b|build", &m_buildType, [
 			"Specifies the type of build to perform. Note that setting the DFLAGS environment variable will override the build type with custom flags.",
 			"Possible names:",
-			"  debug (default), plain, release, release-debug, release-nobounds, unittest, profile, profile-gc, docs, ddox, cov, unittest-cov and custom types"
+			"  debug (default), plain, release, release-debug, release-nobounds, unittest, profile, profile-gc, docs, ddox, cov, unittest-cov, syntax and custom types"
 		]);
 		args.getopt("c|config", &m_buildConfig, [
 			"Builds the specified configuration. Configurations can be defined in dub.json"

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -192,6 +192,7 @@ void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, s
 		{[BuildOption.optimize], "Call DUB with --build=release"},
 		{[BuildOption.profile], "Call DUB with --build=profile"},
 		{[BuildOption.unittests], "Call DUB with --build=unittest"},
+		{[BuildOption.syntaxOnly], "Call DUB with --build=syntax"},
 		{[BuildOption.warnings, BuildOption.warningsAsErrors], "Use \"buildRequirements\" to control the warning level"},
 		{[BuildOption.ignoreDeprecations, BuildOption.deprecationWarnings, BuildOption.deprecationErrors], "Use \"buildRequirements\" to control the deprecation warning level"},
 		{[BuildOption.property], "This flag is deprecated and has no effect"}

--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -80,6 +80,7 @@ private Json buildSystems(BuildPlatform buildPlatform, string workingDiretory = 
 		"profile-gc",
 		"cov",
 		"unittest-cov",
+		"syntax"
 		];
 
 	string fileRegex;

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -409,6 +409,7 @@ class Package {
 				case "profile-gc": settings.addOptions(profileGC, debugInfo); break;
 				case "cov": settings.addOptions(coverage, debugInfo); break;
 				case "unittest-cov": settings.addOptions(unittests, coverage, debugMode, debugInfo); break;
+				case "syntax": settings.addOptions(syntaxOnly); break;
 			}
 		}
 	}


### PR DESCRIPTION
The build type "syntax" should be highly valuable for IDEs like IntelliJ (D plugin).
At the moment the syntax check in IntelliJ D plugin compiles on every code change a new binary leading to several issues (performance, file locked errors).

Using build type "syntax" (will cause -o-) these issues will be gone. 