### PR TITLE
Better build reuse

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -656,7 +656,6 @@ class Dub {
 			tcinfo.targetType = TargetType.executable;
 			tcinfo.targetName = test_config;
 			// HACK for vibe.d's legacy main() behavior:
-			tcinfo.versions[""] ~= "VibeCustomMain";
 			m_project.rootPackage.recipe.buildSettings.versions[""] = m_project.rootPackage.recipe.buildSettings.versions.get("", null).remove!(v => v == "VibeDefaultMain");
 			// TODO: remove this ^ once vibe.d has removed the default main implementation
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -341,7 +341,7 @@ class BuildGenerator : ProjectGenerator {
 		addHashI(settings.platform.frontendVersion);
 		auto hashstr = hash.finish().toHexString().idup;
 
-		return format("%s-%s-%s-%s-%s_%s-%s", config, settings.buildType,
+		return format("%s-%s-%s-%s_%s-%s", config,
 			settings.platform.platform.join("."),
 			settings.platform.architecture.join("."),
 			settings.platform.compiler, settings.platform.frontendVersion, hashstr);


### PR DESCRIPTION
The fact that builds contain the buildType string means that every dependency has to be recompiled for all different build types, even when they cause no change in compiler options. It doesn't appear to be necessary as all that matters is that the compiler options are the same.

Seeing as VibeCustomMain doesn't actually do anything any more, I've stopped it being added.

The combination of these two changes means that - assuming no other differences with versions or optional dependencies - the same build can be used as a dependency of a unittest build as a normal build.