### PR TITLE
Use GDC from Semaphore and upgrade the minimally required host compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ jobs:
     - d: gdc
   include:
     - stage: test
-      d: dmd-2.078.0
+      d: dmd-2.081.1
+      env: [FRONTEND=2.081]
+    - d: dmd-2.080.1
+      env: [FRONTEND=2.080]
+    - d: dmd-2.079.1
+      env: [FRONTEND=2.078]
+    - d: dmd-2.078.1
       env: [FRONTEND=2.078]
     - d: dmd-2.077.1
       env: [FRONTEND=2.077, COVERAGE=true]
@@ -35,14 +41,12 @@ jobs:
       env: [FRONTEND=2.073]
     - d: dmd-2.072.2
       env: [FRONTEND=2.072]
-    - d: dmd-2.071.2
-      env: [FRONTEND=2.071]
-    - d: dmd-2.070.2
-      env: [FRONTEND=2.070]
-    - d: dmd-2.069.2
-      env: [FRONTEND=2.069]
-    - d: dmd-2.068.2
-      env: [FRONTEND=2.068]
+    - d: ldc-1.10.0
+      env: [FRONTEND=2.080]
+    - d: ldc-1.9.0
+      env: [FRONTEND=2.079]
+    - d: ldc-1.8.0
+      env: [FRONTEND=2.078]
     - d: ldc-1.7.0
       env: [FRONTEND=2.077]
     - d: ldc-1.6.0
@@ -53,16 +57,6 @@ jobs:
       env: [FRONTEND=2.074]
     - d: ldc-1.3.0
       env: [FRONTEND=2.073]
-    - d: ldc-1.2.0
-      env: [FRONTEND=2.072]
-    - d: ldc-1.1.0
-      env: [FRONTEND=2.071]
-    - d: ldc-1.0.0
-      env: [FRONTEND=2.070]
-    - d: gdc
-      env: [FRONTEND=2.068]
-    - d: gdc-4.8.5
-      env: [FRONTEND=2.068]
     - stage: deploy
       d: ldc
       os: osx

--- a/semaphore-ci.sh
+++ b/semaphore-ci.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+if  [ "${D_VERSION:-dmd}" == "gdc" ] ; then
+
+    # Use the dub-updating fork of the installer script until https://github.com/dlang/installer/pull/301 is merged
+    wget https://raw.githubusercontent.com/wilzbach/installer-dub/master/script/install.sh -O install.dub.sh
+    bash install.dub.sh -a dub
+    dub_path_activate="$(find $HOME/dlang/*/activate | head -1)"
+    rm "${dub_path_activate}"
+    dub_path="$(dirname "$dub_path_activate")"
+    sudo ln -s "${dub_path}/dub" /usr/bin/dub
+
+    export DMD=gdmd
+    export DC=gdc
+    # It's technically ~"2.076", but Ternary doesn't seem to have been ported and Vibe.d seems to depend on this.
+    # Ternary was added in 2.072: https://dlang.org/phobos/std_typecons.html#.Ternary
+    # However, the nonet tests is done only for > 2.072
+    export FRONTEND=2.072
+
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo apt-get update
+    sudo apt-get install -y gdc-8
+    # fetch the dmd-like wrapper
+    sudo wget https://raw.githubusercontent.com/D-Programming-GDC/GDMD/master/dmd-script -O /usr/bin/gdmd
+    sudo chmod +x /usr/bin/gdmd
+    # DUB requires gdmd
+    sudo ln -s /usr/bin/gdc-8 /usr/bin/gdc
+    # fake install script and create a fake 'activate' script
+    mkdir -p ~/dlang/gdc-8
+    echo "deactivate(){ echo;}" > ~/dlang/gdc-8/activate
+
+else
+    curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 1 --retry-max-time 60 https://dlang.org/install.sh | bash -s "$D_VERSION"
+fi
+
+./travis-ci.sh


### PR DESCRIPTION
Now that GDC on the latest Ubuntu 18.04 is built on top 2.076 (master is at 2.082 btw), we can upgrade it and thus finally increase the minimall required D version to build Dub (for DMD it's 2.079 btw, so we could increase a lot here, for now I wasn't so drastic though).

I used SemaphoreCI, because gdcdownloads.org still doesn't provide binaries for the newest GDC release.

See also: https://github.com/dlang/dmd/pull/8431