### PR TITLE
Support targetType 'wasm'

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -171,9 +171,9 @@ private:
 	static bool pathMatch(string path, string pattern)
 	{
 		import std.functional : memoize;
-		
+
 		alias nativePath = memoize!((string stringPath) => NativePath(stringPath));
-			
+
 		return nativePath(path) == nativePath(pattern) || globMatch(path, pattern);
 	}
 
@@ -249,7 +249,8 @@ enum TargetType {
 	sourceLibrary,
 	dynamicLibrary,
 	staticLibrary,
-	object
+	object,
+	wasm
 }
 
 enum BuildRequirement {

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -167,6 +167,8 @@ class DMDCompiler : Compiler {
 				if (platform.platform.canFind("windows"))
 					return settings.targetName ~ ".obj";
 				else return settings.targetName ~ ".o";
+			case TargetType.wasm:
+				assert(false, "dub not support targetType: wasm");
 		}
 	}
 
@@ -189,6 +191,8 @@ class DMDCompiler : Compiler {
 			case TargetType.object:
 				settings.addDFlags("-c");
 				break;
+			case TargetType.wasm:
+				assert(false, "dub not support targetType: wasm");
 		}
 
 		if (tpath is null)

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -161,6 +161,8 @@ class GDCCompiler : Compiler {
 				if (platform.platform.canFind("windows"))
 					return settings.targetName ~ ".obj";
 				else return settings.targetName ~ ".o";
+			case TargetType.wasm:
+				assert(false, "gdc not support targetType: wasm");
 		}
 	}
 
@@ -179,6 +181,8 @@ class GDCCompiler : Compiler {
 			case TargetType.dynamicLibrary:
 				settings.addDFlags("-shared", "-fPIC");
 				break;
+			case TargetType.wasm:
+				assert(false, "gdc not support targetType: wasm");
 		}
 
 		if (tpath is null)

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -172,6 +172,8 @@ class LDCCompiler : Compiler {
 				if (platform.platform.canFind("windows"))
 					return settings.targetName ~ ".obj";
 				else return settings.targetName ~ ".o";
+			case TargetType.wasm:
+				return settings.targetName ~ ".wasm";
 		}
 	}
 
@@ -192,6 +194,9 @@ class LDCCompiler : Compiler {
 			case TargetType.object:
 				settings.addDFlags("-c");
 				break;
+			case TargetType.wasm:
+				settings.addDFlags("-mtriple=wasm32-unknown-unknown-wasm");
+				settings.addDFlags("-betterC");
 		}
 
 		if (tpath is null)

--- a/test/1-wasm-simple/dub.json
+++ b/test/1-wasm-simple/dub.json
@@ -1,0 +1,4 @@
+{
+    "name": "wasm-simple",
+    "targetType": "wasm"
+}

--- a/test/1-wasm-simple/source/app.d
+++ b/test/1-wasm-simple/source/app.d
@@ -1,0 +1,8 @@
+extern(C):
+
+double add(double a, double b)
+{
+	return a + b;
+}
+
+void _start() {}


### PR DESCRIPTION
WebAssembly is supported with LDC 1.11.0.
If wasm is added to the targetType, I think that development becomes easier.

```json
  "targetType": "wasm"
```

I wrote such a code. How about that?
