### PR TITLE
Adding support for $DUB variable

### DIFF
--- a/build-gdc.sh
+++ b/build-gdc.sh
@@ -17,7 +17,7 @@ echo "module dub.version_;" > source/dub/version_.d
 echo "enum dubVersion = \"$GITVER\";" >> source/dub/version_.d
 
 echo Running $GDC...
-$GDC -obin/dub -lcurl -w -fversion=DubUseCurl -Isource $* $LIBS @build-files.txt
+$GDC -obin/dub -lcurl -w -fversion=DubUseCurl -fversion=DubApplication -Isource $* $LIBS @build-files.txt
 echo DUB has been built as bin/dub.
 echo
 echo You may want to run

--- a/build.cmd
+++ b/build.cmd
@@ -7,7 +7,7 @@
 @echo enum dubVersion = "%GITVER%"; >> source\dub\version_.d
 
 @echo Executing %DC%...
-@%DC% -ofbin\dub.exe -g -debug -w -version=DubUseCurl -Isource curl.lib %* @build-files.txt
+@%DC% -ofbin\dub.exe -g -debug -w -version=DubUseCurl -version=DubApplication -Isource curl.lib %* @build-files.txt
 @if errorlevel 1 exit /b 1
 
 @echo DUB has been built. You probably also want to add the following entry to your

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.8
 
 echo Running $DMD...
-$DMD -ofbin/dub -g -O -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt
+$DMD -ofbin/dub -g -O -w -version=DubUseCurl -version=DubApplication -Isource $* $LIBS @build-files.txt
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo

--- a/changelog/dubEnvVar.dd
+++ b/changelog/dubEnvVar.dd
@@ -1,0 +1,13 @@
+dub now supports `$DUB` variable
+
+With this release, one can call dub from build commands in the following way:
+------
+    // dub.sdl:
+    preBuildCommands "$DUB run --single somebuildscript.d"
+-----
+This is useful if dub is not in the `$PATH`, or if several versions of dub are installed.
+
+`$DUB` is also accessible as environment variable in the build commands processes.
+
+`$DUB` points to the running executable, unless it is used as a library.
+In such case, `$DUB` will resolve to the first dub executable found in `$PATH`.

--- a/dub.sdl
+++ b/dub.sdl
@@ -11,7 +11,7 @@ configuration "application" {
 	targetType "executable"
 	mainSourceFile "source/app.d"
 	libs "curl"
-	versions "DubUseCurl"
+	versions "DubUseCurl" "DubApplication"
 }
 
 configuration "library" {

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -621,9 +621,9 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	in GeneratorSettings settings, in BuildSettings build_settings)
 {
-	import std.conv;
-	import std.process;
-	import dub.internal.utils;
+	import dub.internal.utils : getDUBExePath, runCommands;
+	import std.conv : to, text;
+	import std.process : environment, escapeShellFileName;
 
 	string[string] env = environment.toAA();
 	// TODO: do more elaborate things here
@@ -639,6 +639,7 @@ void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	env["DC_BASE"]               = settings.platform.compiler;
 	env["D_FRONTEND_VER"]        = to!string(settings.platform.frontendVersion);
 
+	env["DUB_EXE"]               = getDUBExePath(settings.platform.compilerBinary);
 	env["DUB_PLATFORM"]          = join(cast(string[])settings.platform.platform," ");
 	env["DUB_ARCH"]              = join(cast(string[])settings.platform.architecture," ");
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1213,8 +1213,10 @@ package(dub) immutable buildSettingsVars = [
 
 private string getVariable(Project, Package)(string name, in Project project, in Package pack, in GeneratorSettings gsettings)
 {
-	import std.process : environment;
+	import dub.internal.utils : getDUBExePath;
+	import std.process : environment, escapeShellFileName;
 	import std.uni : asUpperCase;
+
 	NativePath path;
 	if (name == "PACKAGE_DIR")
 		path = pack.path;
@@ -1236,6 +1238,10 @@ private string getVariable(Project, Package)(string name, in Project project, in
 		// no trailing slash for clean path concatenation (see #1392)
 		path.endsWithSlash = false;
 		return path.toNativeString();
+	}
+
+	if (name == "DUB") {
+		return getDUBExePath(gsettings.platform.compilerBinary);
 	}
 
 	if (name == "ARCH") {

--- a/test/pr1549-dub-exe-var.sh
+++ b/test/pr1549-dub-exe-var.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+set -e
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+PR1549=$CURR_DIR/pr1549-dub-exe-var
+
+${DUB} build --root ${PR1549}
+OUTPUT=$(${PR1549}/test-application)
+
+if [[ "$OUTPUT" != "modified code" ]]; then die "\$DUB build variable was (likely) not evaluated correctly"; fi

--- a/test/pr1549-dub-exe-var/.gitignore
+++ b/test/pr1549-dub-exe-var/.gitignore
@@ -1,0 +1,2 @@
+setmsg
+setmsg.exe

--- a/test/pr1549-dub-exe-var/dub.sdl
+++ b/test/pr1549-dub-exe-var/dub.sdl
@@ -1,0 +1,4 @@
+name "test-application"
+targetType "executable"
+preBuildCommands "$DUB run --single $PACKAGE_DIR/setmsg.d -- \"modified code\""
+postBuildCommands "$DUB run --single $PACKAGE_DIR/setmsg.d -- \"unmodified code\""

--- a/test/pr1549-dub-exe-var/setmsg.d
+++ b/test/pr1549-dub-exe-var/setmsg.d
@@ -1,0 +1,21 @@
+/+ dub.sdl:
++/
+
+import std.exception;
+import std.path;
+import std.process;
+import std.stdio;
+
+void main(in string[] args)
+{
+    enforce(args.length > 1);
+    const string msg = args[1];
+
+    const path = buildPath(environment["DUB_PACKAGE_DIR"], "source", "app.d");
+    auto file = File(path, "w");
+    file.writeln(`import std.stdio;`);
+    file.writeln();
+    file.writeln(`void main() {`);
+    file.writefln(`    writeln("%s");`, msg);
+    file.writeln(`}`);
+}

--- a/test/pr1549-dub-exe-var/source/app.d
+++ b/test/pr1549-dub-exe-var/source/app.d
@@ -1,0 +1,5 @@
+import std.stdio;
+
+void main() {
+    writeln("unmodified code");
+}


### PR DESCRIPTION
Adding support for `$DUB` variable in build scripts.
```sdl
preBuildCommands "$DUB run --single somescript.d"
```
Resolves to `thisExePath`, unless `dub` was built as a library. In such case, it searches for the first dub application in `$PATH`.
This is useful if dub is not in the `$PATH` (really seldom i guess), or if several versions of dub are installed (that's more for devs than users).
$DUB env var is also set within build command processes.