### PR TITLE
Fix #1551: Escaping a variable ($$) is ignored

### DIFF
--- a/test/issue1551-var-escaping/dub.json
+++ b/test/issue1551-var-escaping/dub.json
@@ -1,0 +1,7 @@
+{
+	"name": "issue1551-var-escaping",
+    "preGenerateCommands": [
+        "echo $${DUB_PACKAGE_DIR}",
+        "echo $$DUB_PACKAGE_DIR"
+    ]
+}

--- a/test/issue1551-var-escaping/source/app.d
+++ b/test/issue1551-var-escaping/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+}


### PR DESCRIPTION
```
This was broken by the refactoring in #1392 (commit 14c00c49a9e756e93653b5e83e22fa05923cde67)
```