### PR TITLE
Environment variable DUB_PACKAGE_VERSION added

### DIFF
--- a/changelog/env_var_package_version.dd
+++ b/changelog/env_var_package_version.dd
@@ -1,0 +1,3 @@
+Environment variable DUB_PACKAGE_VERSION added
+
+DUB now supports the environment variable DUB_PACKAGE_VERSION containing the version of the package

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -652,6 +652,7 @@ void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	env["DUB_PACKAGE_DIR"]       = pack.path.toNativeString();
 	env["DUB_ROOT_PACKAGE"]      = proj.rootPackage.name;
 	env["DUB_ROOT_PACKAGE_DIR"]  = proj.rootPackage.path.toNativeString();
+	env["DUB_PACKAGE_VERSION"]   = pack.version_.toString();
 
 	env["DUB_COMBINED"]          = settings.combined?      "TRUE" : "";
 	env["DUB_RUN"]               = settings.run?           "TRUE" : "";


### PR DESCRIPTION
The new environment variable DUB_PACKAGE_VERSION can be used in shell / batch scripts called from "preGenerateCommands". The version of the package can be written to module file.
This would simplify e.g. this logic https://github.com/dlang/dub/blob/master/build.cmd

Is a unit test needed for the new environment variable?