### PR TITLE
Only attempt to remove file with generate_binary

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -436,9 +436,11 @@ class BuildGenerator : ProjectGenerator {
 		NativePath target_file;
 		scope (failure) {
 			logDiagnostic("FAIL %s %s %s" , buildsettings.targetPath, buildsettings.targetName, buildsettings.targetType);
-			auto tpath = getTargetPath(buildsettings, settings);
-			if (generate_binary && existsFile(tpath))
-				removeFile(tpath);
+			if (generate_binary) {
+				auto tpath = getTargetPath(buildsettings, settings);
+				if (existsFile(tpath))
+					removeFile(tpath);
+			}
 		}
 		if (settings.buildMode == BuildMode.singleFile && generate_binary) {
 			import std.parallelism, std.range : walkLength;


### PR DESCRIPTION
Before it could assert fail on getTargetPath because
of an invalid target path. Fix #1564