### PR TITLE
Fix Issue #1504

### DIFF
--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -20,6 +20,7 @@ import std.array : join, split;
 import std.exception : enforce;
 import std.file;
 import std.range;
+import std.process : environment;
 
 
 /**
@@ -179,6 +180,9 @@ struct BuildSettingsTemplate {
 		{
 			auto files = appender!(string[]);
 
+			import dub.project : buildSettingsVars;
+			auto envVars = environment.toAA();
+
 			foreach (suffix, paths; paths_map) {
 				if (!platform.matchesSpecification(suffix))
 					continue;
@@ -188,9 +192,8 @@ struct BuildSettingsTemplate {
 					auto path = NativePath(spath);
 					if (!path.absolute) path = base_path ~ path;
 					if (!existsFile(path) || !isDir(path.toNativeString())) {
-						import dub.project : buildSettingsVars;
 						import std.algorithm : any, find;
-						const hasVar = buildSettingsVars.any!((string var) {
+						const hasVar = chain(buildSettingsVars, envVars.byKey).any!((string var) {
 							return spath.find("$"~var).length > 0 || spath.find("${"~var~"}").length > 0;
 						});
 						if (!hasVar)

--- a/test/issue1504-envvar-in-path.sh
+++ b/test/issue1504-envvar-in-path.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+rm -rf ${CURR_DIR}/issue1504-envvar-in-path/.dub
+rm -rf ${CURR_DIR}/issue1504-envvar-in-path/test
+rm -rf ${CURR_DIR}/output-1504.txt
+
+
+export MY_VARIABLE=teststrings 
+# pragma(msg) outputs to stderr
+${DUB} build --force --root ${CURR_DIR}/issue1504-envvar-in-path 2> ${CURR_DIR}/output-1504.txt
+
+grep "env_variables_work" < ${CURR_DIR}/output-1504.txt
+
+# Don't manage to make it work
+#grep "Invalid source" < ${CURR_DIR}/output-1504.txt && true
+

--- a/test/issue1504-envvar-in-path/dub.json
+++ b/test/issue1504-envvar-in-path/dub.json
@@ -1,0 +1,5 @@
+{
+    "name": "test",
+    "stringImportPaths": ["$MY_VARIABLE"]
+}
+

--- a/test/issue1504-envvar-in-path/source/app.d
+++ b/test/issue1504-envvar-in-path/source/app.d
@@ -1,0 +1,5 @@
+pragma(msg, import("message.txt"));
+
+void main()
+{    
+}

--- a/test/issue1504-envvar-in-path/teststrings/message.txt
+++ b/test/issue1504-envvar-in-path/teststrings/message.txt
@@ -1,0 +1,1 @@
+env_variables_work


### PR DESCRIPTION
This also checks environment variable $ENV_VAR or ${ENV_VAR} in `importPaths`, `stringImportPaths`, etc.
