### PR TITLE
AppVeyor CI: Temporary disable DMD nightly testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 platform: x64
 environment:
  matrix:
-  - DC: dmd
-    DVersion: nightly
-    arch: x64
-  - DC: dmd
-    DVersion: nightly
-    arch: x86
+  #- DC: dmd
+  #  DVersion: nightly
+  #  arch: x64
+  #- DC: dmd
+  #  DVersion: nightly
+  #  arch: x86
   - DC: dmd
     DVersion: beta
     arch: x64


### PR DESCRIPTION
Until the dmd nightlies server is back online