### PR TITLE
GitHub's API + UI don't return 0.9.20 anymore

### DIFF
--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -2,30 +2,30 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
-$DUB fetch dub --version=0.9.20 && [ -d $HOME/.dub/packages/dub-0.9.20/dub ]
-$DUB fetch dub --version=0.9.21 && [ -d $HOME/.dub/packages/dub-0.9.21/dub ]
+$DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
+$DUB fetch dub --version=1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
 if $DUB remove dub --non-interactive 2>/dev/null; then
     die $LINENO 'Non-interactive remove should fail'
 fi
-echo 1 | $DUB remove dub | tr -d '\n' | grep --ignore-case 'select.*0\.9\.20.*0\.9\.21.*'
-if [ -d $HOME/.dub/packages/dub-0.9.20/dub ]; then
-    die $LINENO 'Failed to remove dub-0.9.20'
+echo 1 | $DUB remove dub | tr -d '\n' | grep --ignore-case 'select.*1\.9\.0.*1\.10\.0.*'
+if [ -d $HOME/.dub/packages/dub-1.9.0/dub ]; then
+    die $LINENO 'Failed to remove dub-1.9.0'
 fi
-$DUB fetch dub --version=0.9.20 && [ -d $HOME/.dub/packages/dub-0.9.20/dub ]
+$DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
 # EOF aborts remove
 echo -xn '' | $DUB remove dub
-if [ ! -d $HOME/.dub/packages/dub-0.9.20/dub ] || [ ! -d $HOME/.dub/packages/dub-0.9.21/dub ]; then
+if [ ! -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ ! -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Aborted dub still removed a package'
 fi
 # validates input
 echo -e 'abc\n4\n-1\n3' | $DUB remove dub
-if [ -d $HOME/.dub/packages/dub-0.9.20/dub ] || [ -d $HOME/.dub/packages/dub-0.9.21/dub ]; then
+if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Failed to remove all version of dub'
 fi
-$DUB fetch dub --version=0.9.20 && [ -d $HOME/.dub/packages/dub-0.9.20/dub ]
-$DUB fetch dub --version=0.9.21 && [ -d $HOME/.dub/packages/dub-0.9.21/dub ]
+$DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
+$DUB fetch dub --version=1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
 # is non-interactive with --version=
 $DUB remove dub --version=\*
-if [ -d $HOME/.dub/packages/dub-0.9.20/dub ] || [ -d $HOME/.dub/packages/dub-0.9.21/dub ]; then
+if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Failed to non-interactively remove specified versions'
 fi

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -10,6 +10,13 @@ if [ -z "$FRONTEND" -o "$FRONTEND" \> 2.072.z ]; then
     dub test --compiler=${DC} -c library-nonet
 fi
 
+function clean() {
+    # Hard reset of the DUB local folder is necessary as some tests
+    # currently don't properly clean themselves
+    rm -rf ~/.dub
+    git clean -dxf -- test
+}
+
 if [ "$COVERAGE" = true ]; then
     # library-nonet fails to build with coverage (Issue 13742)
     dub test --compiler=${DC} -b unittest-cov
@@ -18,12 +25,14 @@ if [ "$COVERAGE" = true ]; then
     # run tests with different compilers
     DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
     deactivate
-    git clean -dxf -- test
+    clean
+
     export FRONTEND=2.077
     source $(~/dlang/install.sh ldc-1.7.0 --activate)
     DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
     deactivate
-    git clean -dxf -- test
+    clean
+
     export FRONTEND=2.068
     source $(~/dlang/install.sh gdc-4.8.5 --activate)
     DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh


### PR DESCRIPTION
The 0.9.20 tag is still there, see e.g.

```
git ls-remote --tags https://github.com/dlang/dub
```

But not on the web UI nor API, e.g.

https://github.com/dlang/dub/tags?after=v0.9.22-beta.2

This is the pragmatic solution to fixing the test suite.