### PR TITLE
Create "add" command to add a dependency

### DIFF
--- a/changelog/addcommand.dd
+++ b/changelog/addcommand.dd
@@ -1,0 +1,11 @@
+Add Command
+
+The `add` command adds a dependency to the dub.json/dub.sdl file.
+
+Running `dub add vibe-d` is equivalent to manually adding the following line to dub.sdl (X.Y.Z represents the latest version):
+dependency "vibe-d" version="~>X.Y.Z"
+
+Or the following in dub.json:
+"dependencies": {
+	"vibe-d": "~>X.Y.Z"
+}

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1147,6 +1147,7 @@ class AddCommand : Command {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		import dub.recipe.io : readPackageRecipe, writePackageRecipe;
+		import dub.internal.vibecompat.core.file : existsFile;
 		enforceUsage(free_args.length != 0, "Expected one or more arguments.");
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
@@ -1154,10 +1155,12 @@ class AddCommand : Command {
 			try {
 				auto ver = dub.getLatestVersion(depname);
 				auto dep = ver.isBranch ? Dependency(ver) : Dependency("~>" ~ ver.toString());
-				auto pkg = readPackageRecipe(dub.rootPath ~ "dub.json").clone();//TODO: detect if dub.json or dub.sdl
+
+				string filetype = existsFile(dub.rootPath ~ "dub.json") ? "json" : "sdl";
+				auto pkg = readPackageRecipe(dub.rootPath ~ ("dub." ~ filetype));
 
 				pkg.buildSettings.dependencies[depname] = dep;
-				writePackageRecipe(dub.rootPath ~ "dub.json", pkg);//TODO: detect if dub.json or dub.sdl
+				writePackageRecipe(dub.rootPath ~ ("dub." ~ filetype), pkg);
 
 				logInfo("Added dependency %s %s", depname, dep.versionSpec);
 			} catch (Exception e) {

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1151,12 +1151,11 @@ class AddCommand : Command {
 		enforceUsage(free_args.length != 0, "Expected one or more arguments.");
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
+		string filetype = existsFile(dub.rootPath ~ "dub.json") ? "json" : "sdl";
 		foreach (depname; free_args) {
 			try {
 				auto ver = dub.getLatestVersion(depname);
 				auto dep = ver.isBranch ? Dependency(ver) : Dependency("~>" ~ ver.toString());
-
-				string filetype = existsFile(dub.rootPath ~ "dub.json") ? "json" : "sdl";
 				auto pkg = readPackageRecipe(dub.rootPath ~ ("dub." ~ filetype));
 
 				pkg.buildSettings.dependencies[depname] = dep;

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1134,9 +1134,9 @@ class AddCommand : Command {
 	{
 		this.name = "add";
 		this.argumentsPattern = "<packages...>";
-		this.description = "Adds a package to the package file.";
+		this.description = "Adds dependencies to the package file.";
 		this.helpText = [
-			"Adds <packages> as dependencies to the package.",
+			"Adds <packages> as dependencies.",
 			"",
 			"Running \"dub add <package>\" is the same as adding <package> to the \"dependencies\" section in dub.json/dub.sdl."
 		];

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1260,7 +1260,7 @@ class FetchCommand : FetchRemoveCommand {
 		this.helpText = [
 			"Note: Use \"dub add <dependency>\" if you just want to use a certain package as a dependency, you don't have to explicitly fetch packages.",
 			"",
-			"Explicit retrieval/removal of packages is only needed when you want to put packages to a place where several applications can share these. If you just have an dependency to a package, just add it to your dub.json, dub will do the rest for you.",
+			"Explicit retrieval/removal of packages is only needed when you want to put packages in a place where several applications can share them. If you just have a dependency to add, use the `add` command. Dub will do the rest for you.",
 			"",
 			"Without specified options, placement/removal will default to a user wide shared location.",
 			"",

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1258,7 +1258,7 @@ class FetchCommand : FetchRemoveCommand {
 		this.argumentsPattern = "<name>";
 		this.description = "Manually retrieves and caches a package";
 		this.helpText = [
-			"Note: Use the \"dependencies\" field in the package description file (e.g. dub.json) if you just want to use a certain package as a dependency, you don't have to explicitly fetch packages.",
+			"Note: Use \"dub add <dependency>\" if you just want to use a certain package as a dependency, you don't have to explicitly fetch packages.",
 			"",
 			"Explicit retrieval/removal of packages is only needed when you want to put packages to a place where several applications can share these. If you just have an dependency to a package, just add it to your dub.json, dub will do the rest for you.",
 			"",

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.12.0-20-gbd67301";
+enum dubVersion = "v1.12.0-21-g1be7760";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.12.0";
+enum dubVersion = "v1.12.0-20-gbd67301";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.12.0-22-ga05d4e7";
+enum dubVersion = "v1.12.0";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.12.0-21-g1be7760";
+enum dubVersion = "v1.12.0-22-ga05d4e7";

--- a/test/issue1574-addcommand.sh
+++ b/test/issue1574-addcommand.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+tempDir="issue1574-addcommand"
+
+function cleanup {
+	cd ..
+	rm -rf $tempDir
+}
+trap cleanup EXIT
+
+
+$DUB init -n $tempDir
+cd $tempDir
+
+echo "import mir.math.common; void main(){}" > source/app.d
+
+$DUB add mir-core
+
+#if dub fails to compile, that means that the "import mir.math.common" did not work
+if ! $DUB build; then
+	die "Add command failed"
+fi


### PR DESCRIPTION
Usage: `dub add vibe-d` will add `dependency "vibe-d" version="~>X.Y.Z"`(X.Y.Z=latest version) to the dub.sdl file, or the equivalent to dub.json.
This command is a simpler alternative to manually editing the dub.json/dub.sdl file. It is also no longer necessary to check what the latest version of a package is before adding the dependency.

fixes #1574 