### PR TITLE
Use default architecture for ddox

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1254,7 +1254,7 @@ class Dub {
 		GeneratorSettings settings;
 		settings.config = "application";
 		settings.compiler = getCompiler(compiler_binary); // TODO: not using --compiler ???
-		settings.platform = settings.compiler.determinePlatform(settings.buildSettings, compiler_binary);
+		settings.platform = settings.compiler.determinePlatform(settings.buildSettings, compiler_binary, m_defaultArchitecture);
 		settings.buildType = "debug";
 		settings.run = true;
 


### PR DESCRIPTION
This solves the OPTLINK Termination error while executing
```
dub build -b ddox
```
on windows. At the moment there is no possibility to set the architecture for the ddox build.
Therefore x86 is always used. But this results in this error message

![image](https://user-images.githubusercontent.com/1451047/48024976-6e55ad80-e142-11e8-8ede-bc2f9e986dfe.png)

With this pull request the architecture is no longer fixed to x86 but the architecture defined in the settings.json can be used to override the architecture. 