### PR TITLE
Fix temp copy files

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -34,7 +34,6 @@ class BuildGenerator : ProjectGenerator {
 	private {
 		PackageManager m_packageMan;
 		NativePath[] m_temporaryFiles;
-		NativePath m_targetExecutablePath;
 	}
 
 	this(Project project)
@@ -108,10 +107,10 @@ class BuildGenerator : ProjectGenerator {
 		auto buildsettings = targets[m_project.rootPackage.name].buildSettings.dup;
 		if (settings.run && !(buildsettings.options & BuildOption.syntaxOnly)) {
 			NativePath exe_file_path;
-			if (m_targetExecutablePath.empty)
+			if (m_tempTargetExecutablePath.empty)
 				exe_file_path = getTargetPath(buildsettings, settings);
 			else
-				exe_file_path = m_targetExecutablePath ~ settings.compiler.getTargetFileName(buildsettings, settings.platform);
+				exe_file_path = m_tempTargetExecutablePath ~ settings.compiler.getTargetFileName(buildsettings, settings.platform);
 			runTarget(exe_file_path, buildsettings, settings.runArgs, settings);
 		}
 	}
@@ -161,7 +160,7 @@ class BuildGenerator : ProjectGenerator {
 		NativePath target_path;
 		if (settings.tempBuild) {
 			string packageName = pack.basePackage is null ? pack.name : pack.basePackage.name;
-			m_targetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
+			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
 		}
 		else target_path = pack.path ~ format(".dub/build/%s/", build_id);
 

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -74,6 +74,7 @@ class ProjectGenerator
 
 	protected {
 		Project m_project;
+		NativePath m_tempTargetExecutablePath;
 	}
 
 	this(Project project)
@@ -109,12 +110,13 @@ class ProjectGenerator
 		if (bs.targetType == TargetType.executable) bs.addSourceFiles(mainfiles);
 
 		generateTargets(settings, targets);
+		auto targetPath = (m_tempTargetExecutablePath.empty) ? NativePath(bs.targetPath) : m_tempTargetExecutablePath;
 
 		foreach (pack; m_project.getTopologicalPackageList(true, null, configs)) {
 			BuildSettings buildsettings;
 			buildsettings.processVars(m_project, pack, pack.getBuildSettings(settings.platform, configs[pack.name]), settings, true);
 			bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
-			finalizeGeneration(pack, m_project, settings, buildsettings, NativePath(bs.targetPath), generate_binary);
+			finalizeGeneration(pack, m_project, settings, buildsettings, targetPath, generate_binary);
 		}
 
 		performPostGenerateActions(settings, targets);

--- a/test/issue1136-temp-copy-files.sh
+++ b/test/issue1136-temp-copy-files.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+cd ${CURR_DIR}/issue1136-temp-copy-files
+
+"$DUB" app.d

--- a/test/issue1136-temp-copy-files/app.d
+++ b/test/issue1136-temp-copy-files/app.d
@@ -1,0 +1,15 @@
+/+ dub.sdl:
+
+name "app"
+dependency "mylib" path="./mylib"
++/
+
+import std.exception: enforce;
+import std.file: exists, thisExePath;
+import std.path: dirName, buildPath;
+
+void main()
+{
+    string filePath = buildPath(thisExePath.dirName, "helloworld.txt");
+    enforce(filePath.exists);
+}

--- a/test/issue1136-temp-copy-files/mylib/dub.sdl
+++ b/test/issue1136-temp-copy-files/mylib/dub.sdl
@@ -1,0 +1,3 @@
+name "mylib"
+copyFiles "./helloworld.txt"
+targetType "none"

--- a/test/issue1136-temp-copy-files/mylib/helloworld.txt
+++ b/test/issue1136-temp-copy-files/mylib/helloworld.txt
@@ -1,0 +1,1 @@
+hello world!


### PR DESCRIPTION
Executing app.d
```
/+ dub.sdl:

name "app"
dependency "vibe-d" version=">=0.8.0-beta.5"
+/
void main(){}
```
with command ```dub app.d``` which is similiar to ```dub run --temp-build --single app.d```
fails on windows because the OpenSSL dlls are copied to the location of app.d instead of
the location of the executable.

The actual location of the executable ```getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id)``` is only known to BuildGenerator but not to ProjectGenerator. This is an issue as
copying the files is triggered from ProjectGenerator. I solved this issue by introducing protected variable ```m_tempTargetExecutablePath``` within ProjectGenerator. BuildGenerator will fill this variable.



