### PR TITLE
Retry download for registry search packages

### DIFF
--- a/source/dub/packagesuppliers/registry.d
+++ b/source/dub/packagesuppliers/registry.d
@@ -116,7 +116,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		auto url = m_registryUrl;
 		url.localURI = "/api/packages/search?q="~encodeComponent(query);
 		string data;
-		data = cast(string)download(url);
+		data = cast(string)retryDownload(url);
 		return data.parseJson.opt!(Json[])
 			.map!(j => SearchResult(j["name"].opt!string, j["description"].opt!string, j["version"].opt!string))
 			.array;


### PR DESCRIPTION
Retry was missing for search packages.
Maybe this also solves the master build (https://travis-ci.org/dlang/dub/jobs/452114936)

```
[INFO] Running /home/travis/build/dlang/dub/test/feat663-search.sh...
[ERROR] /home/travis/build/dlang/dub/test/feat663-search.sh:11 `dub search dub` failed
        Using dub registry url 'https://code.dlang.org/'
        Refreshing local packages (refresh existing: true)...
        Looking for local package map at /var/lib/dub/packages/local-packages.json
        Looking for local package map at /home/travis/.dub/packages/local-packages.json
        Try to load local package map at /home/travis/.dub/packages/local-packages.json
        Determined package version using GIT: dub 1.12.0+commit.24.g7b909c3
        Searching registry at https://code.dlang.org/ (fallback ["registry at http://code.dlang.org/", "registry at https://code-mirror.dlang.io/", "registry at https://code-mirror2.dlang.io/", "registry at https://dub-registry.herokuapp.com/"]) for 'dub' failed: Timeout was reached on handle 2AD7780
        No matches found.
[ERROR] Script failure.
```