### PR TITLE
improve package supplier fallback logic

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -254,8 +254,7 @@ int runDubCommandLine(string[] args)
 					PackageSupplier ps = getRegistryPackageSupplier(urls.front);
 					urls.popFront;
 					if (!urls.empty)
-						ps = new FallbackPackageSupplier(ps,
-							urls.map!(u => getRegistryPackageSupplier(u)).array);
+						ps = new FallbackPackageSupplier(ps ~ urls.map!getRegistryPackageSupplier.array);
 					return ps;
 				})
 				.array;
@@ -309,7 +308,7 @@ struct CommonOptions {
 		args.getopt("skip-registry", &skipRegistry, [
 			"Sets a mode for skipping the search on certain package registry types:",
 			"  none: Search all configured or default registries (default)",
-			"  standard: Don't search the main registry (e.g. "~defaultRegistryURL~")",
+			"  standard: Don't search the main registry (e.g. "~defaultRegistryURLs[0]~")",
 			"  configured: Skip all default and user configured registries",
 			"  all: Only search registries specified with --registry",
 			]);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -65,7 +65,6 @@ deprecated("use defaultRegistryURLs") enum defaultRegistryURL = defaultRegistryU
 enum defaultRegistryURLs = [
 	"https://code.dlang.org/",
 	"https://code-mirror.dlang.io/",
-	"https://code-mirror2.dlang.io/",
 	"https://dub-registry.herokuapp.com/",
 ];
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -59,9 +59,11 @@ static this()
 	registerCompiler(new LDCCompiler);
 }
 
-/// The URL to the official package registry.
-enum defaultRegistryURL = "https://code.dlang.org/";
-enum fallbackRegistryURLs = [
+deprecated("use defaultRegistryURLs") enum defaultRegistryURL = defaultRegistryURLs[0];
+
+/// The URL to the official package registry and it's default fallback registries.
+enum defaultRegistryURLs = [
+	"https://code.dlang.org/",
 	// fallback in case of HTTPS problems
 	"http://code.dlang.org/",
 	"https://code-mirror.dlang.io/",
@@ -74,17 +76,12 @@ enum fallbackRegistryURLs = [
 	This will contain a single package supplier that points to the official
 	package registry.
 
-	See_Also: `defaultRegistryURL`
+	See_Also: `defaultRegistryURLs`
 */
 PackageSupplier[] defaultPackageSuppliers()
 {
-	logDiagnostic("Using dub registry url '%s'", defaultRegistryURL);
-	return [
-		new FallbackPackageSupplier(
-			new RegistryPackageSupplier(URL(defaultRegistryURL)),
-			fallbackRegistryURLs.map!(x => cast(PackageSupplier) new RegistryPackageSupplier(URL(x))).array
-		)
-	];
+	logDiagnostic("Using dub registry url '%s'", defaultRegistryURLs[0]);
+	return [new FallbackPackageSupplier(defaultRegistryURLs.map!getRegistryPackageSupplier.array)];
 }
 
 /** Returns a registry package supplier according to protocol.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -64,8 +64,6 @@ deprecated("use defaultRegistryURLs") enum defaultRegistryURL = defaultRegistryU
 /// The URL to the official package registry and it's default fallback registries.
 enum defaultRegistryURLs = [
 	"https://code.dlang.org/",
-	// fallback in case of HTTPS problems
-	"http://code.dlang.org/",
 	"https://code-mirror.dlang.io/",
 	"https://code-mirror2.dlang.io/",
 	"https://dub-registry.herokuapp.com/",

--- a/source/dub/packagesuppliers/fallback.d
+++ b/source/dub/packagesuppliers/fallback.d
@@ -5,19 +5,26 @@ import std.typecons : AutoImplement;
 
 package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 {
-	protected PackageSupplier[] m_suppliers;
+	protected import core.time : minutes;
+	protected import std.datetime : Clock, SysTime;
+
+	static struct Pair { PackageSupplier ps; SysTime failTime; }
+	protected Pair[] m_suppliers;
 
 	this(PackageSupplier[] suppliers)
 	{
 		assert(suppliers.length);
-		m_suppliers = suppliers;
+		m_suppliers.length = suppliers.length;
+		foreach (i, ps; suppliers)
+			m_suppliers[i].ps = ps;
 	}
 
 	override @property string description()
 	{
 		import std.algorithm.iteration : map;
 		import std.format : format;
-		return format("%s (fallbacks %-(%s, %))", m_suppliers[0].description, m_suppliers[1 .. $].map!(x => x.description));
+		return format("%s (fallbacks %-(%s, %))", m_suppliers[0].ps.description,
+			m_suppliers[1 .. $].map!(pair => pair.ps.description));
 	}
 
 	// Workaround https://issues.dlang.org/show_bug.cgi?id=2525
@@ -43,27 +50,29 @@ private template fallback(T, alias func)
 
 		Exception firstEx;
 		try
-			return m_suppliers[0].%1$s(args);
+			return m_suppliers[0].ps.%1$s(args);
 		catch (Exception e)
 		{
 			logDiagnostic("Package supplier %%s failed with '%%s', trying fallbacks.",
-				m_suppliers[0].description, e.msg);
-			m_suppliers = m_suppliers[1 .. $];
+				m_suppliers[0].ps.description, e.msg);
 			firstEx = e;
 		}
 
-		foreach (fallback; m_suppliers)
+		immutable now = Clock.currTime;
+		foreach (ref pair; m_suppliers[1 .. $])
 		{
+			if (pair.failTime > now - 10.minutes)
+				continue;
 			try
 			{
-				scope (success) logDiagnostic("Fallback %%s succeeded", fallback.description);
-				return fallback.%1$s(args);
+				scope (success) logDiagnostic("Fallback %%s succeeded", pair.ps.description);
+				return pair.ps.%1$s(args);
 			}
-			catch(Exception e)
+			catch (Exception e)
 			{
+				pair.failTime = now;
 				logDiagnostic("Fallback package supplier %%s failed with '%%s'.",
-					fallback.description, e.msg);
-				m_suppliers = m_suppliers[1 .. $];
+					pair.ps.description, e.msg);
 			}
 		}
 		throw firstEx;

--- a/test/feat663-search.sh
+++ b/test/feat663-search.sh
@@ -7,9 +7,9 @@ fi
 if ${DUB} search nonexistent123456789package 2>/dev/null; then
     die $LINENO '`dub search nonexistent123456789package` succeeded'
 fi
-if ! OUTPUT=$(${DUB} search dub -v 2>&1); then
-    die $LINENO '`dub search dub` failed' "$OUTPUT"
+if ! OUTPUT=$(${DUB} search '"dub-registry"' -v 2>&1); then
+    die $LINENO '`dub search "dub-registry"` failed' "$OUTPUT"
 fi
-if ! grep -q '^dub (.*)\s'<<<"$OUTPUT"; then
-    die $LINENO '`grep -q '"'"'^dub (.*)\s'"'"'` failed' "$OUTPUT"
+if ! grep -q '^dub-registry (.*)\s'<<<"$OUTPUT"; then
+    die $LINENO '`grep -q '"'"'^dub-registry (.*)\s'"'"'` failed' "$OUTPUT"
 fi


### PR DESCRIPTION
- scope (failure) did swallow fatal errors
- improve logging of failures and successes
- rethrow failure of default registry instead of from the last one
- remove failing package suppliers, so we don't keep beating dead horses

Note that some retry logic is already done interally by package suppliers,
so a failing one is unlikely to recover on the next usage.