### PR TITLE
Ignore unix executables in generated .gitignore

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -182,7 +182,7 @@ q"{.dub
 docs.json
 __dummy.html
 docs/
-/%1$s
+%1$s
 %1$s.so
 %1$s.dylib
 %1$s.dll


### PR DESCRIPTION
Dub's generated .gitignore file does not ignore unix executables. It ignores `{project-name}.exe`, which works for windows executables, but linux/macOS executables are just named `{project-name}`, which is not currently in the generated gitignore file.