### PR TITLE
fix unix executables gitignore

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -182,7 +182,7 @@ q"{.dub
 docs.json
 __dummy.html
 docs/
-%1$s
+/%1$s
 %1$s.so
 %1$s.dylib
 %1$s.dll


### PR DESCRIPTION
I recently merged #1594, but it turns out that putting `{project-name}` in the gitignore also ignores the directory `source/{project-name}`. I added a leading `/` to only ignore the executable in the root project directory, and nothing from the `source/` directory.