### PR TITLE
Fix wrong cast

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -396,7 +396,7 @@ class ProjectGenerator
 	{
 		child.addVersions(parent.versions);
 		child.addDebugVersions(parent.debugVersions);
-		child.addOptions(BuildOptions(cast(BuildOptions)parent.options & inheritedBuildOptions));
+		child.addOptions(BuildOptions(parent.options & inheritedBuildOptions));
 	}
 
 	private static void mergeFromDependency(in ref BuildSettings child, ref BuildSettings parent)


### PR DESCRIPTION
This is currently blocking [1]. The cast to BuildOption is useless since parent.options is already a BuildOption object. What happened before the patch in [1]: parent.options.values (the alias this member)
was being  wrongfully cast to BuildOptions (and opCast from std.typecons.Bitflags was called); now the opCast is no longer called directly on the alias this member.

[1] https://github.com/dlang/dmd/pull/9017