### PR TITLE
when running `dub build :<subpackage>`, explicitly load subpackage in current folder.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -697,11 +697,16 @@ abstract class PackageBuildCommand : Command {
 			return true;
 		}
 
+		bool from_cwd = package_name.length == 0 || package_name.startsWith(":");
 		// load package in root_path to enable searching for sub packages
-		if (loadCwdPackage(dub, package_name.length == 0)) {
+		if (loadCwdPackage(dub, from_cwd)) {
 			if (package_name.startsWith(":"))
-				package_name = dub.projectName ~ package_name;
-			if (!package_name.length) return true;
+			{
+				auto pack = dub.packageManager.getSubPackage(dub.project.rootPackage, package_name[1 .. $], false);
+				dub.loadPackage(pack);
+				return true;
+			}
+			if (from_cwd) return true;
 		}
 
 		enforce(package_name.length, "No valid root package found - aborting.");


### PR DESCRIPTION
To reproduce the problem that prompted this:

```
cd $HOME
rm -rf .dub
dub fetch unit-threaded --version 0.7.52
dub fetch unit-threaded --version 0.7.53
cd .dub/packages/unit-threaded-0.7.52/unit-threaded
dub build :runner
```
Observe that what is built is unit-threaded-0.7.**53**:runner!

This is because dub handles :runner by building "unit-threaded:runner", but it uses the normal lookup logic to find what "unit-threaded:runner" is. Normally the current path would be in `m_temporaryPackages`, but since the current path is already in the search path, it is not added again. As a result, `unit-threaded-0.7.53` is found first.

The attached commit explicitly looks up subpackages specified as ":<package>" in the project loaded from the cwd.