### PR TITLE
[WIP] Add --force-no-deps option to build command

### DIFF
--- a/changelog/forceNoDeps.dd
+++ b/changelog/forceNoDeps.dd
@@ -1,5 +1,5 @@
 build --force-no-deps
 
-The `-F`/`--force-no-deps` option to the `build` command forces a rebuild of the current package, excluding dependencies.
+The `--force-no-deps` option for the `build` command forces a rebuild of the current package, excluding dependencies.
 
 `--force-no-deps` does the same thing as `--force`, except that `--force-no-deps` does not rebuild dependencies.

--- a/changelog/forceNoDeps.dd
+++ b/changelog/forceNoDeps.dd
@@ -1,0 +1,5 @@
+build --force-no-deps
+
+The `-F`/`--force-no-deps` option to the `build` command forces a rebuild of the current package, excluding dependencies.
+
+`--force-no-deps` does the same thing as `--force`, except that `--force-no-deps` does not rebuild dependencies.


### PR DESCRIPTION
The `--force` option for `dub build` forces dependencies to be rebuilt, along with the actual package. There are some cases when it is useful to be able to force rebuild *only* the package, for example with [import expressions](https://dlang.org/spec/expression.html#import_expressions):
```
import std.stdio;

void main() {
    writeln( import("foo.txt") );
}
```

If the contents of `foo.txt` are updated and no changes to the package's actual source are made, dub won't trigger a rebuild. You have to use `dub build -f`, but then that also rebuilds dependencies, which is unnecessary.

This PR adds a `--force-no-deps` (shorthand `-F`) option to the `build` command.

fixes #1620
closes #606