### PR TITLE
[PoC] add ninja generator

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -120,7 +120,7 @@ int runDubCommandLine(string[] args)
 			args[1] = args[1].setExtension(".d");
 		}
 	}
-	
+
 	// special single-file package shebang syntax
 	if (args.length >= 2 && args[1].endsWith(".d")) {
 		args = args[0] ~ ["run", "-q", "--temp-build", "--single", args[1], "--"] ~ args[2 ..$];
@@ -757,6 +757,7 @@ class GenerateCommand : PackageBuildCommand {
 			"visuald - VisualD project files",
 			"sublimetext - SublimeText project file",
 			"cmake - CMake build scripts",
+			"ninja - Ninja build scripts",
 			"build - Builds the package directly",
 			"",
 			"An optional package name can be given to generate a different package than the root/CWD package."

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -86,6 +86,12 @@ interface Compiler {
 	/// Invokes the underlying linker directly
 	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback);
 
+	/// Get compiler flags for target type (e.g. -shared or -lib)
+	string[] targetTypeFlags(in TargetType tt) const;
+
+	/// Get compiler flags to set output file (e.g. -of=file.o)
+	string[] outFileFlags(string tpath) const;
+
 	/// Convert linker flags to compiler format
 	string[] lflagsToDFlags(in string[] lflags) const;
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -404,13 +404,13 @@ class BuildGenerator : ProjectGenerator {
 	/// Calls with path that resolve to the same file on the filesystem will return the same,
 	/// unless they include different symbolic links (which are not resolved).
 
-	static string pathToObjName(string path)
+	static string pathToObjName(string path, string base = getcwd())
 	{
 		import std.digest.crc : crc32Of;
-		import std.path : buildNormalizedPath, dirSeparator, relativePath, stripDrive;
+		import std.path : buildNormalizedPath, dirSeparator;
 		if (path.endsWith(".d")) path = path[0 .. $-2];
-		auto ret = buildNormalizedPath(getcwd(), path).replace(dirSeparator, ".");
-		auto idx = ret.lastIndexOf('.');
+		auto ret = buildNormalizedPath(base, path);
+		auto idx = ret.lastIndexOf(dirSeparator);
 		return idx < 0 ? ret ~ objSuffix : format("%s_%(%02x%)%s", ret[idx+1 .. $], crc32Of(ret[0 .. idx]), objSuffix);
 	}
 

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -8,8 +8,9 @@
 module dub.generators.generator;
 
 import dub.compilers.compiler;
-import dub.generators.cmake;
 import dub.generators.build;
+import dub.generators.cmake;
+import dub.generators.ninja;
 import dub.generators.sublimetext;
 import dub.generators.visuald;
 import dub.internal.vibecompat.core.file;
@@ -615,6 +616,9 @@ ProjectGenerator createProjectGenerator(string generator_type, Project project)
 		case "cmake":
 			logDebug("Creating CMake generator.");
 			return new CMakeGenerator(project);
+		case "ninja":
+			logDebug("Creating Ninja generator.");
+			return new NinjaGenerator(project);
 	}
 }
 

--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -1,0 +1,117 @@
+/**
+    Generator for Ninja build scripts
+
+    Copyright: © 2018 Martin Nowak
+    License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+    Authors: Martin Nowak
+*/
+module dub.generators.ninja;
+
+import dub.compilers.buildsettings;
+import dub.generators.generator;
+import dub.internal.vibecompat.core.log;
+import dub.internal.vibecompat.core.file;
+import dub.internal.vibecompat.inet.path;
+import dub.package_ : Package;
+import dub.project;
+
+import std.algorithm: endsWith, filter, map, startsWith;
+import std.array: replace;
+import std.format : formattedWrite;
+import std.stdio: File, write;
+import std.string: format;
+
+class NinjaGenerator: ProjectGenerator
+{
+    this(Project project)
+    {
+        super(project);
+    }
+
+    override void generateTargets(GeneratorSettings settings, in TargetInfo[string] targets)
+    {
+		auto path = (m_project.rootPackage.path ~ "build.ninja").toNativeString;
+		auto script = File(path, "w").lockingTextWriter();
+
+		script.formattedWrite(`
+dc = %1$s
+
+rule dc
+     depfile = $out.deps
+     command = $dc -c %2$s $dflags %3$-(%s %) $in; echo $out: $$(sed 's|.*(\(.*\)).*|\1|' $out.deps.tmp | sort | uniq | tr '\n' ' ') > $out.deps; rm $out.deps.tmp
+     description = DC $in
+rule link
+     command = $dc %3$-(%s %) @$out.rsp $lflags
+     rspfile = $out.rsp
+     rspfile_content = $in
+     description = LINK $out
+rule ar
+     command = rm -f $out && ar rcs $out $in
+     description = AR $out
+`,
+			settings.platform.compilerBinary,
+			settings.compiler.name == "gdc" ? "-fdeps=$out.deps.tmp" : "-deps=$out.deps.tmp",
+			settings.compiler.outFileFlags("$out"));
+
+		immutable rootPackageDir = m_project.rootPackage.path.toNativeString;
+		string[string] targetPaths;
+		foreach (name, ti; targets)
+		{
+			import std.path : buildPath;
+
+			auto bs = &ti.buildSettings;
+			targetPaths[name] = buildPath(bs.targetPath, settings.compiler.getTargetFileName(*bs, settings.platform));
+		}
+		foreach (name, ti; targets)
+		{
+			auto bs = ti.buildSettings.dup;
+			assert(bs.targetType != TargetType.sourceLibrary && bs.targetType != TargetType.none);
+			name = name.replace(":", "_");
+			settings.compiler.prepareBuildSettings(bs, BuildSetting.commandLineSeparate|BuildSetting.sourceFiles);
+			writeBuildScript(rootPackageDir, ti, settings, bs, targetPaths);
+			script.formattedWrite("subninja build_%s.ninja\n", name);
+		}
+    }
+}
+
+void writeBuildScript(string rootPackageDir, in ref ProjectGenerator.TargetInfo ti, in ref GeneratorSettings settings, in ref BuildSettings bs, in string[string] targetPaths)
+{
+	import std.array : array;
+	import std.algorithm : splitter;
+	import std.conv : to;
+	import std.path : absolutePath, buildPath, dirName, relativePath, setExtension;
+	import std.range : zip;
+	import dub.generators.build : BuildGenerator;
+
+	auto scriptPath = buildPath(rootPackageDir, "build_%-(%s_%).ninja".format(ti.pack.name.splitter(":")));
+	auto script = File(scriptPath, "w").lockingTextWriter;
+
+	/// Objects are written relative to .dub/obj/ninja/<pkg> of the
+	/// root package, this reflects the semantic of ninja, where the
+	/// generator tool is rerun to build different configurations.
+	auto packageName = ti.pack.basePackage is null ? ti.pack.name : ti.pack.basePackage.name;
+	auto objDir = format(".dub/ninja/%s/", packageName);
+	auto packDir = ti.pack.path.toNativeString;
+
+	string shrinkPath(string path)
+	{
+		if (path.startsWith(rootPackageDir))
+			return path[rootPackageDir.length .. $];
+		return path;
+	}
+	auto srcs = bs.sourceFiles.filter!(s => s.endsWith(".d")).map!absolutePath.map!shrinkPath.array;
+	auto objs = srcs.map!(src => buildPath(objDir, BuildGenerator.pathToObjName(src))).array;
+
+	script.formattedWrite("dflags = %-(%s %)\n", bs.dflags);
+	foreach (src, obj; zip(srcs, objs))
+		script.formattedWrite("build %s: dc %s\n", obj, src);
+
+	if (bs.targetType == TargetType.staticLibrary)
+		script.formattedWrite("build %s: ar %-(%s %)\n", targetPaths[ti.pack.name], objs);
+	else
+	{
+		script.formattedWrite("lflags = %-(%s %)\n", settings.compiler.targetTypeFlags(bs.targetType) ~ settings.compiler.lflagsToDFlags(bs.lflags));
+		script.formattedWrite("build %s: link %-(%s %) %-(%s %)\n", targetPaths[ti.pack.name], objs,
+			ti.linkDependencies.map!(ldep => buildPath(ldep.replace(":", "_"), targetPaths[ldep])));
+	}
+}


### PR DESCRIPTION
- based on parallel single file compilation
- writes object files to local .dub/ninja/<package> folder
  (use `ninja -t clean` to cleanup)
- different build types require regeneration of .ninja files
  (see https://ninja-build.org/manual.html#_philosophical_overview)
- requires dlang/dmd#9122 for non-segfaulting `-deps`