### PR TITLE
Fix broken link in changelog

### DIFF
--- a/changelog/addcommand.dd
+++ b/changelog/addcommand.dd
@@ -18,7 +18,7 @@ dependency "vibe-d" version="~>X.Y.Z"
 ------
 
 It is also possible to add multiple packages at once and explicitly add a
-simple $(LINK2 version specification,http://code.dlang.org/package-format?lang=json#version-specs)
+simple $(LINK2 https://code.dlang.org/package-format?lang=json#version-specs,version specification)
 for some of them.
 
 For example the command `dub add vibe-d='~>0.8.2' mir-algorithm=3.1.21` would


### PR DESCRIPTION
The [changelog for the AddCommand](https://dlang.org/changelog/2.084.0.html#addcommand) has a broken link.

The link text and link location must have been mixed up, because the link shows as
> It is also possible to add multiple packages at once and explicitly add a simple [http://code.dlang.org/package-format?lang=json#version-specs](https://dlang.org/changelog/version%20specification) for some of them. 

(link href is `version specification`)

Instead of
> It is also possible to add multiple packages at once and explicitly add a simple [version specification](https://code.dlang.org/package-format?lang=json#version-specs) for some of them. 

(link href is `https://code.dlang.org/package-format?lang=json#version-specs`)