### PR TITLE
Add dub fetch <package>@<version> shortcut

### DIFF
--- a/changelog/dub-fetch-shortcut.dd
+++ b/changelog/dub-fetch-shortcut.dd
@@ -1,0 +1,9 @@
+`dub fetch` now supports `<package>@<version>` as a shortcut
+
+`dub fetch <package>@<version>` is a shortcut for
+`dub fetch <package> --version=<version>`:
+
+$(CONSOLE
+> dub fetch gitcompatibledubpackage@1.0.4
+Fetching gitcompatibledubpackage 1.0.4...
+)

--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -23,7 +23,7 @@ if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10
     die $LINENO 'Failed to remove all version of dub'
 fi
 $DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
-$DUB fetch dub --version=1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
+$DUB fetch dub@1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
 # is non-interactive with --version=
 $DUB remove dub --version=\*
 if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10.0/dub ]; then

--- a/test/issue1574-addcommand.sh
+++ b/test/issue1574-addcommand.sh
@@ -28,7 +28,7 @@ grep -q '"gitcompatibledubpackage"\s*:\s*"~>1\.0\.4"' dub.json
 $DUB add gitcompatibledubpackage=1.0.2 non-existing-issue1574-pkg='~>9.8.7' --skip-registry=all
 grep -q '"gitcompatibledubpackage"\s*:\s*"1\.0\.2"' dub.json
 grep -q '"non-existing-issue1574-pkg"\s*:\s*"~>9\.8\.7"' dub.json
-if $DUB add foo=1.2.3 gitcompatibledubpackage='~>a.b.c' --skip-registry=all; then
+if $DUB add foo@1.2.3 gitcompatibledubpackage='~>a.b.c' --skip-registry=all; then
     die $LINENO 'Adding non-semver spec should error'
 fi
 if grep -q '"foo"' dub.json; then


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dub/pull/1428#discussion_r252577400

FWIW the recently added `dub add` uses `=`, but as both `=` and `:` can't be part
of a valid version we can just support both as valid splitting symbols to avoid any potential confusion.

edit: now changed to `@` instead of `:`