### PR TITLE
Central build cache

### DIFF
--- a/changelog/central_build_cache.dd
+++ b/changelog/central_build_cache.dd
@@ -1,0 +1,6 @@
+Added support for using central build cache directory
+
+Instead of putting intermediate build files into the ".dub" sub folder of each
+package, settings.json now supports a new field "buildCacheDirectory". The
+configured directory will be used to store the build artefacts of all packages
+as sub directories.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1214,6 +1214,11 @@ class GenerateCommand : PackageBuildCommand {
 		if (!gensettings.config.length)
 			gensettings.config = m_defaultConfig;
 		gensettings.runArgs = app_args;
+		gensettings.force = m_force;
+		gensettings.rdmd = m_rdmd;
+		gensettings.tempBuild = m_tempBuild;
+		gensettings.parallelBuild = m_parallel;
+		gensettings.buildCacheDirectory = dub.buildCacheDirectory;
 
 		logDiagnostic("Generating using %s", m_generator);
 		dub.generateProject(m_generator, gensettings);
@@ -1432,6 +1437,7 @@ class TestCommand : PackageBuildCommand {
 		settings.compiler = getCompiler(this.baseSettings.platform.compilerBinary);
 		settings.run = true;
 		settings.runArgs = app_args;
+		settings.buildCacheDirectory = dub.buildCacheDirectory;
 
 		dub.testProject(settings, this.baseSettings.config, NativePath(m_mainFile));
 		return 0;
@@ -2386,6 +2392,7 @@ class DustmiteCommand : PackageBuildCommand {
 			gensettings.compileCallback = check(m_compilerStatusCode, m_compilerRegex);
 			gensettings.linkCallback = check(m_linkerStatusCode, m_linkerRegex);
 			gensettings.runCallback = check(m_programStatusCode, m_programRegex);
+			gensettings.buildCacheDirectory = dub.buildCacheDirectory;
 			try dub.generateProject("build", gensettings);
 			catch (DustmiteMismatchException) {
 				logInfoNoTag("Dustmite test doesn't match.");

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1214,10 +1214,6 @@ class GenerateCommand : PackageBuildCommand {
 		if (!gensettings.config.length)
 			gensettings.config = m_defaultConfig;
 		gensettings.runArgs = app_args;
-		gensettings.force = m_force;
-		gensettings.rdmd = m_rdmd;
-		gensettings.tempBuild = m_tempBuild;
-		gensettings.parallelBuild = m_parallel;
 		gensettings.buildCacheDirectory = dub.buildCacheDirectory;
 
 		logDiagnostic("Generating using %s", m_generator);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -417,6 +417,14 @@ class Dub {
 	@property const(string[string]) defaultPreRunEnvironments() const { return this.m_config.defaultPreRunEnvironments; }
 	@property const(string[string]) defaultPostRunEnvironments() const { return this.m_config.defaultPostRunEnvironments; }
 
+	/** An optional directory that is used for storing cached build artefacts.
+
+		This is used by `BuildGenerator` to store intermediate object files
+		for reuse in incremental builds. The value of this proprerty may be
+		an empty path, in which case no directory is configured.
+	*/
+	@property NativePath buildCacheDirectory() const { return m_config.buildCacheDirectory; }
+
 	/** Loads the package that resides within the configured `rootPath`.
 	*/
 	void loadPackage()
@@ -1346,6 +1354,7 @@ class Dub {
 		if (this.defaultPostRunEnvironments)
 			settings.buildSettings.addPostRunEnvironments(this.defaultPostRunEnvironments);
 		settings.run = true;
+		settings.buildCacheDirectory = m_config.buildCacheDirectory;
 
 		return settings;
 	}
@@ -1884,6 +1893,7 @@ private struct UserConfiguration {
 
 	@Optional string[] registryUrls;
 	@Optional NativePath[] customCachePaths;
+	@Optional NativePath buildCacheDirectory;
 
 	SetInfo!(SkipPackageSuppliers) skipRegistry;
 	SetInfo!(string) defaultCompiler;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1893,7 +1893,7 @@ private struct UserConfiguration {
 
 	@Optional string[] registryUrls;
 	@Optional NativePath[] customCachePaths;
-	@Optional NativePath buildCacheDirectory;
+	SetInfo!(NativePath) buildCacheDirectory;
 
 	SetInfo!(SkipPackageSuppliers) skipRegistry;
 	SetInfo!(string) defaultCompiler;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -780,6 +780,7 @@ struct GeneratorSettings {
 	bool single;
 
 	string[] runArgs;
+	NativePath buildCacheDirectory;
 	void delegate(int status, string output) compileCallback;
 	void delegate(int status, string output) linkCallback;
 	void delegate(int status, string output) runCallback;


### PR DESCRIPTION
Add support for storing cached build artefacts in a central directory instead of in each package's ".dub" directory.