### PR TITLE
Fix syntax inconsistency in toolchainRequirements

### DIFF
--- a/changelog/toolchain_requirements.dd
+++ b/changelog/toolchain_requirements.dd
@@ -28,7 +28,7 @@ $(UL
 )
 
 Each can contain a
-$(LINK2 https://dub.pm/package-format-sdl.html#version-specs version specification),
+$(LINK2 https://dub.pm/package-format-sdl.html#version-specs, version specification),
 where DMD-like versions are supported in addition to SemVer versions. For
 compilers, instead of a version specification, the keyword `no` can also be used
 to indicate that the compiler should not be used for this package.

--- a/changelog/toolchain_requirements.dd
+++ b/changelog/toolchain_requirements.dd
@@ -8,7 +8,7 @@ dub.json:
 {
     "toolchainRequirements": {
         "dub": "~>1.10",
-        "frontend": ">=2.068|<2.083"
+        "frontend": ">=2.068 <2.083"
     }
 }
 ---
@@ -27,9 +27,11 @@ $(UL
     $(LI gdc)
 )
 
-Each can be assigned to one or more version specifications, separated by `|`.
-For compilers, instead of a version specification, the keyword `no` can also be
-used to indicate that the compiler should not be used for this package.
+Each can contain a
+$(LINK2 https://dub.pm/package-format-sdl.html#version-specs version specification),
+where DMD-like versions are supported in addition to SemVer versions. For
+compilers, instead of a version specification, the keyword `no` can also be used
+to indicate that the compiler should not be used for this package.
 
 Example scenario:$(BR)
 Package that needs DUB>=1.12, and that will only build with LDC>=1.10:

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -8,6 +8,7 @@
 module dub.compilers.compiler;
 
 public import dub.compilers.buildsettings;
+public import dub.dependency : Dependency;
 public import dub.platform : BuildPlatform, matchesSpecification;
 
 import dub.internal.vibecompat.core.file;
@@ -92,46 +93,11 @@ interface Compiler {
 	string[] lflagsToDFlags(in string[] lflags) const;
 
 	/// Get the dependency requirement string for this compiler
-	string toolchainRequirementString(const ref ToolchainRequirements tr);
+	Dependency toolchainRequirement(const ref ToolchainRequirements tr);
 
 	/// Check whether the compiler meet the compiler requirement specified
 	/// in the recipe.
 	bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr);
-
-	/// Check if the compiler is supported by the recipe
-	final bool checkCompilerSupported(const ref ToolchainRequirements tr)
-	{
-		const str = toolchainRequirementString(tr);
-		return str != ToolchainRequirements.noKwd;
-	}
-
-	/// Check whether the compiler meet the frontend requirement specified
-	/// in the recipe.
-	final bool checkFrontendRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
-	{
-		import std.typecons : Yes;
-
-		return checkRequirement(tr.frontend, platform.frontendVersionString, Yes.dmdVer);
-	}
-
-	/// Check that a particular tool version matches with a given requirement
-	final bool checkRequirement(const string requirement, const string toolVer, const Flag!"dmdVer" dmdVer)
-	{
-		import dub.compilers.utils : dmdLikeVersionToSemverLike;
-		import dub.dependency : Dependency, Version;
-		import std.algorithm : all, map, splitter;
-
-		if (!requirement.length) return true; // no requirement
-
-		const ver = Version(dmdVer ? dmdLikeVersionToSemverLike(toolVer) : toolVer);
-
-		return requirement
-			.splitter(' ')
-			.map!(r => dmdVer ? dmdLikeVersionToSemverLike(r) : r)
-			.join(' ')
-			.Dependency
-			.matches(ver);
-	}
 
 	/** Runs a tool and provides common boilerplate code.
 

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -126,9 +126,11 @@ interface Compiler {
 		const ver = Version(dmdVer ? dmdLikeVersionToSemverLike(toolVer) : toolVer);
 
 		return requirement
-			.splitter('|')
-			.map!(r => Dependency(dmdVer ? dmdLikeVersionToSemverLike(r) : r))
-			.all!(r => r.matches(ver));
+			.splitter(' ')
+			.map!(r => dmdVer ? dmdLikeVersionToSemverLike(r) : r)
+			.join(' ')
+			.Dependency
+			.matches(ver);
 	}
 
 	/** Runs a tool and provides common boilerplate code.

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -92,13 +92,6 @@ interface Compiler {
 	/// Convert linker flags to compiler format
 	string[] lflagsToDFlags(in string[] lflags) const;
 
-	/// Get the dependency requirement string for this compiler
-	Dependency toolchainRequirement(const ref ToolchainRequirements tr);
-
-	/// Check whether the compiler meet the compiler requirement specified
-	/// in the recipe.
-	bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr);
-
 	/** Runs a tool and provides common boilerplate code.
 
 		This method should be used by `Compiler` implementations to invoke the

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -265,19 +265,6 @@ config    /etc/dmd.conf
 		return  lflags.map!(f => "-L"~f)().array();
 	}
 
-	Dependency toolchainRequirement(const ref ToolchainRequirements tr)
-	{
-		return tr.dmd;
-	}
-
-	bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
-	{
-		auto ver = platform.compilerVersion.length
-			? dmdLikeVersionToSemverLike(platform.compilerVersion)
-			: "0.0.0";
-		return tr.dmd.matches(ver);
-	}
-
 	private auto escapeArgs(in string[] args)
 	{
 		return args.map!(s => s.canFind(' ') ? "\""~s~"\"" : s);

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -265,16 +265,17 @@ config    /etc/dmd.conf
 		return  lflags.map!(f => "-L"~f)().array();
 	}
 
-	string toolchainRequirementString(const ref ToolchainRequirements tr)
+	Dependency toolchainRequirement(const ref ToolchainRequirements tr)
 	{
 		return tr.dmd;
 	}
 
 	bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
 	{
-		import std.typecons : Yes;
-
-		return checkRequirement(tr.dmd, platform.compilerVersion, Yes.dmdVer);
+		auto ver = platform.compilerVersion.length
+			? dmdLikeVersionToSemverLike(platform.compilerVersion)
+			: "0.0.0";
+		return tr.dmd.matches(ver);
 	}
 
 	private auto escapeArgs(in string[] args)

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -256,18 +256,6 @@ predefs   GNU D_Version2 LittleEndian GNU_DWARF2_Exceptions GNU_StackGrowsDown G
 
 		return  dflags;
 	}
-
-	final Dependency toolchainRequirement(const ref ToolchainRequirements tr)
-	{
-		return tr.gdc;
-	}
-
-	final bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
-	{
-		auto ver = platform.compilerVersion.length
-			? platform.compilerVersion : "0.0.0";
-		return tr.gdc.matches(ver);
-	}
 }
 
 private string extractTarget(const string[] args) { auto i = args.countUntil("-o"); return i >= 0 ? args[i+1] : null; }

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -257,16 +257,16 @@ predefs   GNU D_Version2 LittleEndian GNU_DWARF2_Exceptions GNU_StackGrowsDown G
 		return  dflags;
 	}
 
-	final string toolchainRequirementString(const ref ToolchainRequirements tr)
+	final Dependency toolchainRequirement(const ref ToolchainRequirements tr)
 	{
 		return tr.gdc;
 	}
 
 	final bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
 	{
-		import std.typecons : No;
-
-		return checkRequirement(tr.gdc, platform.compilerVersion, No.dmdVer);
+		auto ver = platform.compilerVersion.length
+			? platform.compilerVersion : "0.0.0";
+		return tr.gdc.matches(ver);
 	}
 }
 

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -233,18 +233,6 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		return  lflags.map!(s => "-L="~s)().array();
 	}
 
-	final Dependency toolchainRequirement(const ref ToolchainRequirements tr)
-	{
-		return tr.ldc;
-	}
-
-	final bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
-	{
-		auto ver = platform.compilerVersion.length
-			? platform.compilerVersion : "0.0.0";
-		return tr.ldc.matches(ver);
-	}
-
 	private auto escapeArgs(in string[] args)
 	{
 		return args.map!(s => s.canFind(' ') ? "\""~s~"\"" : s);

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -233,16 +233,16 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		return  lflags.map!(s => "-L="~s)().array();
 	}
 
-	final string toolchainRequirementString(const ref ToolchainRequirements tr)
+	final Dependency toolchainRequirement(const ref ToolchainRequirements tr)
 	{
 		return tr.ldc;
 	}
 
 	final bool checkCompilerRequirement(const ref BuildPlatform platform, const ref ToolchainRequirements tr)
 	{
-		import std.typecons : No;
-
-		return checkRequirement(tr.ldc, platform.compilerVersion, No.dmdVer);
+		auto ver = platform.compilerVersion.length
+			? platform.compilerVersion : "0.0.0";
+		return tr.ldc.matches(ver);
 	}
 
 	private auto escapeArgs(in string[] args)

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -247,7 +247,7 @@ void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, s
 	Returns:
 		A Semver compliant string
 */
-string dmdLikeVersionToSemverLike(string ver)
+package(dub) string dmdLikeVersionToSemverLike(string ver)
 {
 	import std.algorithm : countUntil, joiner, map, skipOver, splitter;
 	import std.array : join, split;

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -138,6 +138,8 @@ struct Dependency {
 	*/
 	@property void versionSpec(string ves)
 	{
+		static import std.string;
+
 		enforce(ves.length > 0);
 		string orig = ves;
 
@@ -200,6 +202,8 @@ struct Dependency {
 	/// ditto
 	@property string versionSpec()
 	const {
+		static import std.string;
+
 		string r;
 
 		if (this == invalid) return "invalid";

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -50,46 +50,13 @@ class BuildGenerator : ProjectGenerator {
 
 		void checkPkgRequirements(const(Package) pkg)
 		{
-			import std.format : format;
-
 			const tr = pkg.recipe.toolchainRequirements;
-
-			if (dcl.toolchainRequirement(tr) == Dependency.invalid)
-				throw new Exception(format(
-					"Installed %s-%s is not supported by %s. Supported compiler(s):\n%s",
-					dcl.name, settings.platform.compilerVersion, pkg.name,
-					tr.supportedCompilers.map!((cs) {
-						auto str = "  - " ~ cs[0];
-						if (cs[1] != Dependency.any) str ~= ": " ~ cs[1].toString();
-						return str;
-					}).join("\n")
-				));
-
-			enforce(
-				dcl.checkCompilerRequirement(settings.platform, tr),
-				format(
-					"Installed %s-%s does not comply with %s compiler requirement: %s %s\n" ~
-					"Please consider upgrading your installation.",
-					dcl.name, settings.platform.compilerVersion,
-					pkg.name, dcl.name, dcl.toolchainRequirement(tr)
-				)
-			);
-
-			enforce(
-				tr.matchesFrontendVersion(settings.platform),
-				format(
-					"Installed %s-%s with frontend %s does not comply with %s frontend requirement: %s\n" ~
-					"Please consider upgrading your installation.",
-					dcl.name, settings.platform.compilerVersion,
-					settings.platform.frontendVersionString, pkg.name, tr.frontend
-				)
-			);
+			tr.checkPlatform(settings.platform, pkg.name);
 		}
 
 		checkPkgRequirements(m_project.rootPackage);
-		foreach (pkg; m_project.dependencies) {
+		foreach (pkg; m_project.dependencies)
 			checkPkgRequirements(pkg);
-		}
 
 		auto root_ti = targets[m_project.rootPackage.name];
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -54,18 +54,16 @@ class BuildGenerator : ProjectGenerator {
 
 			const tr = pkg.recipe.toolchainRequirements;
 
-			enforce (
-				dcl.checkCompilerSupported(tr),
-				format(
+			if (dcl.toolchainRequirement(tr) == Dependency.invalid)
+				throw new Exception(format(
 					"Installed %s-%s is not supported by %s. Supported compiler(s):\n%s",
 					dcl.name, settings.platform.compilerVersion, pkg.name,
-					tr.supportedCompilers.map!((string[2] cs) {
+					tr.supportedCompilers.map!((cs) {
 						auto str = "  - " ~ cs[0];
-						if (cs[1].length) str ~= ": "~cs[1];
+						if (cs[1] != Dependency.any) str ~= ": " ~ cs[1].toString();
 						return str;
 					}).join("\n")
-				)
-			);
+				));
 
 			enforce(
 				dcl.checkCompilerRequirement(settings.platform, tr),
@@ -73,11 +71,12 @@ class BuildGenerator : ProjectGenerator {
 					"Installed %s-%s does not comply with %s compiler requirement: %s %s\n" ~
 					"Please consider upgrading your installation.",
 					dcl.name, settings.platform.compilerVersion,
-					pkg.name, dcl.name, dcl.toolchainRequirementString( tr )
+					pkg.name, dcl.name, dcl.toolchainRequirement(tr)
 				)
 			);
+
 			enforce(
-				dcl.checkFrontendRequirement(settings.platform, tr),
+				tr.matchesFrontendVersion(settings.platform),
 				format(
 					"Installed %s-%s with frontend %s does not comply with %s frontend requirement: %s\n" ~
 					"Please consider upgrading your installation.",

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -641,23 +641,21 @@ class Package {
 		import dub.version_ : dubVersion;
 		import std.exception : enforce;
 
-		if (m_info.toolchainRequirements.dub.length) {
-			const dep = Dependency(m_info.toolchainRequirements.dub);
+		const dep = m_info.toolchainRequirements.dub;
 
-			static assert(dubVersion.length);
-			static if (dubVersion[0] == 'v') {
-				enum dv = dubVersion[1 .. $];
-			}
-			else {
-				enum dv = dubVersion;
-			}
-			static assert(isValidVersion(dv));
-
-			enforce(dep.matches(dv),
-				"dub-"~dv~" does not comply with toolchainRequirements.dub " ~
-				"specification: "~m_info.toolchainRequirements.dub~
-				"\nPlease consider upgrading your DUB installation");
+		static assert(dubVersion.length);
+		static if (dubVersion[0] == 'v') {
+			enum dv = dubVersion[1 .. $];
 		}
+		else {
+			enum dv = dubVersion;
+		}
+		static assert(isValidVersion(dv));
+
+		enforce(dep.matches(dv),
+			"dub-" ~ dv ~ " does not comply with toolchainRequirements.dub "
+			~ "specification: " ~ m_info.toolchainRequirements.dub.toString()
+			~ "\nPlease consider upgrading your DUB installation");
 	}
 
 	private void fillWithDefaults()

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -551,15 +551,13 @@ class Package {
 	// Left as package until the final API for this has been found
 	package auto getAllDependenciesRange()
 	const {
-		return this.recipe.buildSettings.dependencies.byKeyValue
-			.map!(bs => PackageDependency(bs.key, bs.value))
-			.chain(
-				this.recipe.configurations
-					.map!(c => c.buildSettings.dependencies.byKeyValue
-						.map!(bs => PackageDependency(bs.key, bs.value))
-					)
-					.joiner()
-			);
+		return
+			chain(
+				only(this.recipe.buildSettings.dependencies.byKeyValue),
+				this.recipe.configurations.map!(c => c.buildSettings.dependencies.byKeyValue)
+			)
+			.joiner()
+			.map!(d => PackageDependency(d.key, d.value));
 	}
 
 

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -106,7 +106,7 @@ Json toJson(in ref PackageRecipe recipe)
 			types[name] = settings.toJson();
 		ret["buildTypes"] = types;
 	}
-	if (recipe.hasToolchainRequirements) {
+	if (!recipe.toolchainRequirements.empty) {
 		ret["toolchainRequirements"] = recipe.toolchainRequirements.toJson();
 	}
 	if (!recipe.ddoxFilterArgs.empty) ret["-ddoxFilterArgs"] = recipe.ddoxFilterArgs.serializeToJson();
@@ -300,46 +300,17 @@ private Json toJson(in ref BuildSettingsTemplate bs)
 
 private void parseJson(ref ToolchainRequirements tr, Json json)
 {
-	foreach (string name, value; json) {
-		switch (name) {
-		case "dub":
-			tr.dub = value.get!string();
-			break;
-		case "frontend":
-			tr.frontend = value.get!string();
-			break;
-		case "dmd":
-			tr.dmd = value.get!string();
-			break;
-		case "ldc":
-			tr.ldc = value.get!string();
-			break;
-		case "gdc":
-			tr.gdc = value.get!string();
-			break;
-		default:
-			break;
-		}
-	}
+	foreach (string name, value; json)
+		tr.addRequirement(name, value.get!string);
 }
 
 private Json toJson(in ref ToolchainRequirements tr)
 {
 	auto ret = Json.emptyObject;
-	if (tr.dub.length) {
-		ret["dub"] = serializeToJson(tr.dub);
-	}
-	if (tr.frontend.length) {
-		ret["frontend"] = serializeToJson(tr.frontend);
-	}
-	if (tr.dmd.length) {
-		ret["dmd"] = serializeToJson(tr.dmd);
-	}
-	if (tr.ldc.length) {
-		ret["ldc"] = serializeToJson(tr.ldc);
-	}
-	if (tr.gdc.length) {
-		ret["gdc"] = serializeToJson(tr.gdc);
-	}
+	if (tr.dub != Dependency.any) ret["dub"] = serializeToJson(tr.dub);
+	if (tr.frontend != Dependency.any) ret["frontend"] = serializeToJson(tr.frontend);
+	if (tr.dmd != Dependency.any) ret["dmd"] = serializeToJson(tr.dmd);
+	if (tr.ldc != Dependency.any) ret["ldc"] = serializeToJson(tr.ldc);
+	if (tr.gdc != Dependency.any) ret["gdc"] = serializeToJson(tr.gdc);
 	return ret;
 }

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -104,7 +104,7 @@ Tag toSDL(in ref PackageRecipe recipe)
 		t.add(settings.toSDL());
 		ret.add(t);
 	}
-	if (recipe.hasToolchainRequirements) {
+	if (!recipe.toolchainRequirements.empty) {
 		ret.add(toSDL(recipe.toolchainRequirements));
 	}
 	if (recipe.ddoxFilterArgs.length)
@@ -280,47 +280,18 @@ private Tag[] toSDL(in ref BuildSettingsTemplate bs)
 
 private void parseToolchainRequirements(ref ToolchainRequirements tr, Tag tag)
 {
-	foreach (attr; tag.attributes) {
-		switch (attr.name) {
-		case "dub":
-			tr.dub = attr.value.get!string();
-			break;
-		case "frontend":
-			tr.frontend = attr.value.get!string();
-			break;
-		case "dmd":
-			tr.dmd = attr.value.get!string();
-			break;
-		case "ldc":
-			tr.ldc = attr.value.get!string();
-			break;
-		case "gdc":
-			tr.gdc = attr.value.get!string();
-			break;
-		default:
-			break;
-		}
-	}
+	foreach (attr; tag.attributes)
+		tr.addRequirement(attr.name, attr.value.get!string);
 }
 
 private Tag toSDL(const ref ToolchainRequirements tr)
 {
 	Attribute[] attrs;
-	if (tr.dub.length) {
-		attrs ~= new Attribute("dub", Value(tr.dub));
-	}
-	if (tr.frontend.length) {
-		attrs ~= new Attribute("frontend", Value(tr.frontend));
-	}
-	if (tr.dmd.length) {
-		attrs ~= new Attribute("dmd", Value(tr.dmd));
-	}
-	if (tr.ldc.length) {
-		attrs ~= new Attribute("ldc", Value(tr.ldc));
-	}
-	if (tr.gdc.length) {
-		attrs ~= new Attribute("gdc", Value(tr.gdc));
-	}
+	if (tr.dub != Dependency.any) attrs ~= new Attribute("dub", Value(tr.dub.toString()));
+	if (tr.frontend != Dependency.any) attrs ~= new Attribute("frontend", Value(tr.frontend.toString()));
+	if (tr.dmd != Dependency.any) attrs ~= new Attribute("dmd", Value(tr.dmd.toString()));
+	if (tr.ldc != Dependency.any) attrs ~= new Attribute("ldc", Value(tr.ldc.toString()));
+	if (tr.gdc != Dependency.any) attrs ~= new Attribute("gdc", Value(tr.gdc.toString()));
 	return new Tag(null, "toolchainRequirements", null, attrs);
 }
 
@@ -510,11 +481,11 @@ lflags "lf3"
 	assert(rec.buildTypes.length == 2);
 	assert(rec.buildTypes["debug"].dflags == ["": ["-g", "-debug"]]);
 	assert(rec.buildTypes["release"].dflags == ["": ["-release", "-O"]]);
-	assert(rec.toolchainRequirements.dub == "~>1.11.0");
-	assert(rec.toolchainRequirements.frontend is null);
-	assert(rec.toolchainRequirements.dmd == "~>2.082");
-	assert(rec.toolchainRequirements.ldc is null);
-	assert(rec.toolchainRequirements.gdc is null);
+	assert(rec.toolchainRequirements.dub == Dependency("~>1.11.0"));
+	assert(rec.toolchainRequirements.frontend == Dependency.any);
+	assert(rec.toolchainRequirements.dmd == Dependency("~>2.82.0"));
+	assert(rec.toolchainRequirements.ldc == Dependency.any);
+	assert(rec.toolchainRequirements.gdc == Dependency.any);
 	assert(rec.ddoxFilterArgs == ["-arg1", "-arg2", "-arg3"], rec.ddoxFilterArgs.to!string);
 	assert(rec.ddoxTool == "ddoxtool");
 	assert(rec.buildSettings.dependencies.length == 2);

--- a/test/issue1531-toolchain-requirements.sh
+++ b/test/issue1531-toolchain-requirements.sh
@@ -91,7 +91,7 @@ test_cl_req_pass ">=$DC_VER"
 test_cl_req_fail ">$DC_VER"
 test_cl_req_pass "<=$DC_VER"
 test_cl_req_fail "<$DC_VER"
-test_cl_req_pass ">=$DC_VER|<$(($DC_VER_MAJ + 1))$DC_VER_REM"
+test_cl_req_pass ">=$DC_VER <$(($DC_VER_MAJ + 1))$DC_VER_REM"
 test_cl_req_pass "~>$DC_VER"
 test_cl_req_fail "~>$(($DC_VER_MAJ + 1))$DC_VER_REM"
 test_cl_req_fail no


### PR DESCRIPTION
Removes the additional '|' syntax for toolchain requirements from #1571.

- '|' seems confusing, given that it is used as a logical AND
- Dependency already supports specifying an arbitrary range and this is the only meaningful use for '|'
- Keeps the possibility open to use '|' as a logical OR in a later version
- Rewords the change log entry and adds a link to the DUB documentation

Another thing that seems a bit off is the fact that the dependency specifications for tool chain requirements are stored as strings whereas the usual ones are stored as `Dependency`. Changing this later on will require a new major version, so this should better be right from the start.