### PR TITLE
Windows: Don't use Optlink by default

### DIFF
--- a/changelog/dmd-mscoff-default.dd
+++ b/changelog/dmd-mscoff-default.dd
@@ -1,0 +1,16 @@
+DUB will no longer use OPTLINK as default on Windows
+
+DMD's $(LINK2 https://digitalmars.com/ctg/optlink.html, OPTLINK) has many limitations. Apart from long-standing issues in the underlying DigitalMars runtime,
+the maximum number of symbols is limited as well, which is why most big DUB
+libraries can't be compiled with OPTLINK for years. This has been a cause of
+grief and pain for many users and impacted the newcomer experience severly.
+
+With this release, `dub` will no longer use `OPTLINK` as default on Windows, but
+use `-m32mscoff` (MSCOFF) on 32-bit Windows systems and `-m64` (MSCOFF) on 64-bit
+Windows.
+
+Users can still manually instruct `dub` to use OPTLINK with the `--arch=x86` switch of `dub`:
+
+$(CONSOLE
+> dub --arch=x86
+)

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -35,8 +35,8 @@ private Nullable!bool isWow64() {
 	if (!result.isNull)
 		return result;
 
-	//SYSTEM_INFO systemInfo;
-	//GetNativeSystemInfo(&systemInfo);
+	SYSTEM_INFO systemInfo;
+	GetNativeSystemInfo(&systemInfo);
 	result = systemInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64;
 	return result;
 }


### PR DESCRIPTION
There's __a lot__ of evidence that the Windows experience of D is frustrating as almost every big Dub package doesn't compile with Optlink and the user manually needs to figure out to switch to COFF.

This PR proposes to use COFF by default on Windows.

Evidence collection:
--------------------------

- https://github.com/vibe-d/vibe.d/issues/2243
- https://forum.dlang.org/thread/bobqtoesasjlwvdiisih@forum.dlang.org
- https://forum.dlang.org/post/wpxsfavlgqtfqplwizme@forum.dlang.org
- https://forum.dlang.org/post/hoyaqzytksiuvdlsitaw@forum.dlang.org
- https://forum.dlang.org/post/uaprrobsefqhaqahcthu@forum.dlang.org
- https://forum.dlang.org/post/xbhsbhepqcnfbcveuduw@forum.dlang.org
- https://forum.dlang.org/post/xbzqqhzjrjxndzgqogyk@forum.dlang.org
- https://issues.dlang.org/show_bug.cgi?id=17508
- https://github.com/vibe-d/vibe.d/issues/2122
- https://github.com/vibe-d/vibe.d/issues/1910
- https://github.com/vibe-d/vibe.d/issues/1771
- https://github.com/vibe-d/vibe.d/issues/1439
- https://forum.dlang.org/post/owoazhliszwqcqvsnifl@forum.dlang.org
- https://forum.dlang.org/post/abxmmjwpwmelxyicuzip@forum.dlang.org
- https://forum.dlang.org/post/zjhvufwmratwxcpywjsg@forum.dlang.org
- https://forum.dlang.org/post/ybufckdvasbnehwbdnec@forum.dlang.org
- https://forum.dlang.org/post/gemkzmxsdyilziloorqv@forum.dlang.org
- https://forum.dlang.org/post/yawsuwxbzkdlboniyyio@forum.dlang.org
- https://forum.dlang.org/post/ryzmhycnzowbyurvnlsu@forum.dlang.org
...

TODO:
- [x] changelog entry
- [x] Test on Windows

I don't have a Windows box at the moment, so if one of the many devs who actually run into this issue would step to test this, this would be awesome.