### PR TITLE
Use -dumpfullversion to determine GDC version

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -99,6 +99,13 @@ config    /etc/dmd.conf
 		assert(c && c.length > 1 && c[1] == "2.084.0-beta.1");
 	}
 
+	string determineVersion(string compiler_binary, string verboseOutput)
+	{
+		import std.regex : matchFirst, regex;
+		auto ver = matchFirst(verboseOutput, regex(dmdVersionRe, "m"));
+		return ver && ver.length > 1 ? ver[1] : null;
+	}
+
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{
 		string[] arch_flags;
@@ -121,8 +128,7 @@ config    /etc/dmd.conf
 		return probePlatform(
 			compiler_binary,
 			arch_flags ~ ["-quiet", "-c", "-o-", "-v"],
-			arch_override,
-			[ dmdVersionRe ]
+			arch_override
 		);
 	}
 

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -54,31 +54,15 @@ class GDCCompiler : Compiler {
 
 	@property string name() const { return "gdc"; }
 
-	enum gdcVersionRe1 = `GDC\s+(\d+\.\d+\.\d+[A-Za-z0-9.+-]*)`;
-	enum gdcVersionRe2 = `^GNU D \(.*?\) version (\d+\.\d+\.\d+[A-Za-z0-9.+-]*)`;
-	enum gdcVersionRe3 = `^gcc version (\d+\.\d+\.\d+[A-Za-z0-9.+-]*)`;
+	string determineVersion(string compiler_binary, string verboseOutput)
+	{
+		const result = execute([
+			compiler_binary,
+			"-dumpfullversion",
+			"-dumpversion"
+		]);
 
-	unittest {
-		import std.algorithm : equal, map;
-		import std.range : only;
-		import std.regex : matchFirst, regex;
-		auto probe = `
-Target: x86_64-pc-linux-gnu
-Thread model: posix
-gcc version 8.2.1 20180831 (GDC 8.2.1 based on D v2.068.2 built with ISL 0.20 for Arch Linux)
-GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
-GNU D (GDC 8.2.1 based on D v2.068.2 built with ISL 0.20 for Arch Linux) version 8.2.1 20180831 (x86_64-pc-linux-gnu)
-GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
-binary    /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.1/cc1d
-version   v2.068.2
-predefs   GNU D_Version2 LittleEndian GNU_DWARF2_Exceptions GNU_StackGrowsDown GNU_InlineAsm D_LP64 D_PIC assert all X86_64 D_HardFloat Posix linux CRuntime_Glibc
-`;
-		auto vers = only(gdcVersionRe1, gdcVersionRe2, gdcVersionRe3)
-			.map!(re => matchFirst(probe, regex(re, "m")))
-			.filter!(c => c && c.length > 1)
-			.map!(c => c[1]);
-
-		assert(vers.equal([ "8.2.1", "8.2.1", "8.2.1" ]));
+		return result.status == 0 ? result.output : null;
 	}
 
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
@@ -97,8 +81,7 @@ predefs   GNU D_Version2 LittleEndian GNU_DWARF2_Exceptions GNU_StackGrowsDown G
 		return probePlatform(
 			compiler_binary,
 			arch_flags ~ ["-S", "-v"],
-			arch_override,
-			[ gdcVersionRe1, gdcVersionRe2, gdcVersionRe3 ]
+			arch_override
 		);
 	}
 

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -69,6 +69,13 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		assert(c && c.length > 1 && c[1] == "1.11.0");
 	}
 
+	string determineVersion(string compiler_binary, string verboseOutput)
+	{
+		import std.regex : matchFirst, regex;
+		auto ver = matchFirst(verboseOutput, regex(ldcVersionRe, "m"));
+		return ver && ver.length > 1 ? ver[1] : null;
+	}
+
 	BuildPlatform determinePlatform(ref BuildSettings settings, string compiler_binary, string arch_override)
 	{
 		string[] arch_flags;
@@ -83,8 +90,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		return probePlatform(
 			compiler_binary,
 			arch_flags ~ ["-c", "-o-", "-v"],
-			arch_override,
-			[ ldcVersionRe ]
+			arch_override
 		);
 	}
 


### PR DESCRIPTION
Parsing `gdc -v` output is not reliable. On my machine it looks like:

```
Target: x86_64-slackware-linux
Configured with: ../gcc-8.2.0/configure --prefix=/opt/gdc --libdir=/opt/gdc/lib64 --mandir=/usr/man --infodir=/usr/info --enable-shared --enable-bootstrap --enable-languages=c,c++,d --enable-threads=posix --enable-checking=release --with-system-zlib --enable-libstdcxx-dual-abi --disable-libunwind-exceptions --enable-__cxa_atexit --enable-libssp --enable-lto --disable-install-libiberty --with-gnu-ld --verbose --with-arch-directory=amd64 --program-suffix=-8 --with-pkgversion='GDC 2.081.2' --disable-multilib --target=x86_64-slackware-linux --build=x86_64-slackware-linux --host=x86_64-slackware-linux
Thread model: posix
gcc version 8.2.0 (GDC 2.081.2) 
COLLECT_GCC_OPTIONS='-v' '-o' 'a.out' '-shared-libgcc' '-mtune=generic' '-march=x86-64'
 /opt/gdc/libexec/gcc/x86_64-slackware-linux/8.2.0/cc1d ../test.d -quiet -dumpbase test.d -mtune=generic -march=x86-64 -auxbase test -version -v -o /tmp/ccFfoCDi.s
GNU D (GDC 2.081.2) version 8.2.0 (x86_64-slackware-linux)
	compiled by GNU C version 8.2.0, GMP version 6.1.1, MPFR version 3.1.4, MPC version 1.0.3, isl version none
GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
GNU D (GDC 2.081.2) version 8.2.0 (x86_64-slackware-linux)
	compiled by GNU C version 8.2.0, GMP version 6.1.1, MPFR version 3.1.4, MPC version 1.0.3, isl version none
GGC heuristics: --param ggc-min-expand=100 --param ggc-min-heapsize=131072
binary    /opt/gdc/libexec/gcc/x86_64-slackware-linux/8.2.0/cc1d
version   v2.081.2
predefs   GNU D_Version2 LittleEndian GNU_DWARF2_Exceptions GNU_StackGrowsDown GNU_InlineAsm D_LP64 assert all X86_64 D_HardFloat Posix linux CRuntime_Glibc
```

The regular expressions prefers "GDC 2.081.2" and fails with "Invalid SemVer".

GCC/GDC has `-dumpfullversion` which outputs the compiler version as SemVer.

Two flags, `-dumpversion` and `-dumpfullversion`, are required for compatibility with elder GCC (`-dumpfullversion` is available since GCC 7, for GCC 6 and earlier `-dumpversion` does the same).

clang has `-dumpversion` as well, but it doesn't seem to work with ldc.

By the way https://github.com/dlang/dub/issues/1671 can be probably closed, it is fixed on the ldc side: https://github.com/ldc-developers/ldc/issues/3025