### PR TITLE
fix #1099 - Empty settings.json causes exception

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -20,7 +20,7 @@ import std.array : appender, array;
 import std.conv : to;
 import std.exception : enforce;
 import std.file;
-import std.string : format;
+import std.string : format, empty;
 import std.process;
 import std.traits : isIntegral;
 version(DubUseCurl)
@@ -127,6 +127,8 @@ Json jsonFromFile(NativePath file, bool silent_fail = false) {
 	auto f = openFile(file.toNativeString(), FileMode.read);
 	scope(exit) f.close();
 	auto text = stripUTF8Bom(cast(string)f.readAll());
+	if (text.empty)
+		return Json.emptyObject;
 	return parseJsonString(text, file.toNativeString());
 }
 

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -37,9 +37,9 @@ struct RangeFile {
 	{
 		auto sz = this.size;
 		enforce(sz <= size_t.max, "File is too big to read to memory.");
-		if ( sz == 0 ) {
-			return new ubyte[cast(size_t)sz];
-		}
+
+		if ( sz == 0 ) return null;
+
 		() @trusted { file.seek(0, SEEK_SET); } ();
 		auto ret = new ubyte[cast(size_t)sz];
 		rawRead(ret);

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -37,6 +37,9 @@ struct RangeFile {
 	{
 		auto sz = this.size;
 		enforce(sz <= size_t.max, "File is too big to read to memory.");
+		if ( sz == 0 ) {
+			return new ubyte[cast(size_t)sz];
+		}
 		() @trusted { file.seek(0, SEEK_SET); } ();
 		auto ret = new ubyte[cast(size_t)sz];
 		rawRead(ret);

--- a/test/issue1099-empty-settings-json.sh
+++ b/test/issue1099-empty-settings-json.sh
@@ -18,6 +18,6 @@ touch $HOME/.dub/settings.json
 
 cd ${CURR_DIR}/issue1099-empty-settings-json
 
-if ! { ${DUB} build --force 2>&1 || true; } | grep -cF 'settings.json(1): Error: JSON string is empty.' ; then
-    die "Should have thrown with the message: '/settings.json(1): Error: JSON string is empty', but we threw something else"
+if ! ${DUB} build --force ; then
+    die "Dub failed to build with an empty settings.json"
 fi

--- a/test/issue1099-empty-settings-json.sh
+++ b/test/issue1099-empty-settings-json.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+mkdir issue1099_HOME_TEMP
+
+export HOME=$(pwd)/issue1099_HOME_TEMP
+
+function cleanup {
+    cd ../
+    rm -rf issue1099_HOME_TEMP
+}
+
+trap cleanup EXIT
+
+mkdir $HOME/.dub/
+touch $HOME/.dub/settings.json
+
+cd ${CURR_DIR}/issue1099-empty-settings-json
+
+if ! { ${DUB} build --force 2>&1 || true; } | grep -cF 'settings.json(1): Error: JSON string is empty.' ; then
+    die "Should have thrown with the message: '/settings.json(1): Error: JSON string is empty', but we threw something else"
+fi

--- a/test/issue1099-empty-settings-json.sh
+++ b/test/issue1099-empty-settings-json.sh
@@ -2,13 +2,16 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
-mkdir issue1099_HOME_TEMP
+postfix=$RANDOM
+HOME_STRING="issue1099_HOME_TEMP_${postfix}"
 
-export HOME=$(pwd)/issue1099_HOME_TEMP
+mkdir $HOME_STRING
+export HOME=$(pwd)/$HOME_STRING
+
 
 function cleanup {
     cd ../
-    rm -rf issue1099_HOME_TEMP
+    rm -rf $HOME
 }
 
 trap cleanup EXIT

--- a/test/issue1099-empty-settings-json/dub.json
+++ b/test/issue1099-empty-settings-json/dub.json
@@ -1,9 +1,3 @@
 {
-	"authors": [
-		"--"
-	],
-	"copyright": "Copyright © 2019, --",
-	"description": "A minimal D application.",
-	"license": "--",
 	"name": "issue1099-empty-settings-json"
 }

--- a/test/issue1099-empty-settings-json/dub.json
+++ b/test/issue1099-empty-settings-json/dub.json
@@ -1,0 +1,9 @@
+{
+	"authors": [
+		"--"
+	],
+	"copyright": "Copyright © 2019, --",
+	"description": "A minimal D application.",
+	"license": "--",
+	"name": "issue1099-empty-settings-json"
+}

--- a/test/issue1099-empty-settings-json/source/app.d
+++ b/test/issue1099-empty-settings-json/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+}


### PR DESCRIPTION
If the settings file is empty, just return an empty buffer.
rawRead throws if the buffer is 0.

Fixes the issue at hand.

I'd like to add a test for this but not really sure how thats done for everything around here seeing as the file this is in has no unittests. Additionally not sure how to test a thing which opens files without making an actual file on disk :woman_shrugging: Suggestions welcome!