### PR TITLE
fix #1003 - Check empty ldflags

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -293,7 +293,7 @@ config    /etc/dmd.conf
 
 	string[] lflagsToDFlags(in string[] lflags) const
 	{
-		return  lflags.map!(f => "-L"~f)().array();
+        return map!(f => "-L"~f)(lflags.filter!(f => f != "")()).array();
 	}
 
 	private auto escapeArgs(in string[] args)

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -233,6 +233,9 @@ class GDCCompiler : Compiler {
 		string[] dflags;
 		foreach( f; lflags )
 		{
+            if ( f == "") {
+                continue;
+            }
 			dflags ~= "-Xlinker";
 			dflags ~= f;
 		}

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -236,7 +236,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 
 	string[] lflagsToDFlags(in string[] lflags) const
 	{
-		return  lflags.map!(s => "-L="~s)().array();
+        return map!(f => "-L"~f)(lflags.filter!(f => f != "")()).array();
 	}
 
 	private auto escapeArgs(in string[] args)

--- a/test/issue1003-check-empty-ld-flags.sh
+++ b/test/issue1003-check-empty-ld-flags.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+cd ${CURR_DIR}/issue1003-check-empty-ld-flags
+
+${DUB} build --compiler=${DC} --force

--- a/test/issue1003-check-empty-ld-flags/dub.json
+++ b/test/issue1003-check-empty-ld-flags/dub.json
@@ -1,0 +1,10 @@
+{
+	"authors": [
+		"--"
+	],
+	"copyright": "Copyright © 2019, --",
+	"description": "--",
+	"license": "--",
+	"name": "issue1003-empty-ld-flags",
+    "lflags": [""]
+}

--- a/test/issue1003-check-empty-ld-flags/source/app.d
+++ b/test/issue1003-check-empty-ld-flags/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+}


### PR DESCRIPTION
Project linking fails if `ldflags` contains an empty string in dub.json or dub.sdl.
Remove those strings before passing them to the linker.
This affects all 3 compilers.