### PR TITLE
fix #1372 - Ignore files in hidden directories.

### DIFF
--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -247,8 +247,11 @@ struct BuildSettingsTemplate {
 					}
 
 					foreach (d; dirEntries(path.toNativeString(), pattern, SpanMode.depth)) {
-						import std.path : baseName;
-						if (baseName(d.name)[0] == '.' || d.isDir) continue;
+						import std.path : baseName, pathSplitter;
+						import std.algorithm.searching: canFind;
+						if (baseName(d.name)[0] == '.' || d.isDir ||
+							pathSplitter(d).canFind!(name => name[0] == '.'))
+							continue;
 						auto src = NativePath(d.name).relativeTo(base_path);
 						files ~= src.toNativeString();
 					}

--- a/test/issue1372-ignore-files-in-hidden-dirs.sh
+++ b/test/issue1372-ignore-files-in-hidden-dirs.sh
@@ -2,4 +2,15 @@
 
 cd ${CURR_DIR}/issue1372-ignore-files-in-hidden-dirs/
 
+echo "Compile and ignore hidden directories"
+rm dub.json
+ln -s dub_json_no_hidden.json dub.json
 ${DUB} build --force
+
+rm dub.json
+
+echo "Compile and explcitly include file in hidden directories"
+ln -s dub_json_hidden.json dub.json
+${DUB} build --force
+
+rm dub.json

--- a/test/issue1372-ignore-files-in-hidden-dirs.sh
+++ b/test/issue1372-ignore-files-in-hidden-dirs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd ${CURR_DIR}/issue1372-ignore-files-in-hidden-dirs/
+
+${DUB} build --force

--- a/test/issue1372-ignore-files-in-hidden-dirs/dub.json
+++ b/test/issue1372-ignore-files-in-hidden-dirs/dub.json
@@ -1,9 +1,0 @@
-{
-	"authors": [
-		"--"
-	],
-	"copyright": "Copyright © 2019, --",
-	"description": "--",
-	"license": "--",
-	"name": "issue1372-ignore-files-in-hidden-dirs"
-}

--- a/test/issue1372-ignore-files-in-hidden-dirs/dub.json
+++ b/test/issue1372-ignore-files-in-hidden-dirs/dub.json
@@ -1,0 +1,9 @@
+{
+	"authors": [
+		"--"
+	],
+	"copyright": "Copyright © 2019, --",
+	"description": "--",
+	"license": "--",
+	"name": "issue1372-ignore-files-in-hidden-dirs"
+}

--- a/test/issue1372-ignore-files-in-hidden-dirs/dub_json_hidden.json
+++ b/test/issue1372-ignore-files-in-hidden-dirs/dub_json_hidden.json
@@ -1,0 +1,5 @@
+{
+	"name": "issue1372-ignore-files-in-hidden-dirs",
+    "sourceFiles":["source/.compileMe/hello.d"]
+    
+}

--- a/test/issue1372-ignore-files-in-hidden-dirs/dub_json_no_hidden.json
+++ b/test/issue1372-ignore-files-in-hidden-dirs/dub_json_no_hidden.json
@@ -1,0 +1,3 @@
+{
+	"name": "issue1372-ignore-files-in-hidden-dirs"
+}

--- a/test/issue1372-ignore-files-in-hidden-dirs/source/.AppleDouble/app.d
+++ b/test/issue1372-ignore-files-in-hidden-dirs/source/.AppleDouble/app.d
@@ -1,0 +1,2 @@
+This file needs to contain something to show the issue up.
+If it's empty, it'll get ignored.

--- a/test/issue1372-ignore-files-in-hidden-dirs/source/app.d
+++ b/test/issue1372-ignore-files-in-hidden-dirs/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+}


### PR DESCRIPTION
I can't see a reason why dub would need to detect files in hidden folders, so we should be okay to ignore them outright.

The modified file `packagerecipe.d` is using tabs, I have followed this convention.