### PR TITLE
Remove both temporary files in cleanup of test script

### DIFF
--- a/test/issue1037-better-dependency-messages.sh
+++ b/test/issue1037-better-dependency-messages.sh
@@ -9,7 +9,7 @@ expected_file="$CURR_DIR/expected-issue1037-output"
 
 function cleanup {
     rm -f $temp_file
-    rm -f $temp_file
+    rm -f $temp_file2
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
In the previous version, the same file was attempted to remove twice, and the second would be untouched.