### PR TITLE
[PoC] Regenerate buildSettings after preGenerateCommands

### DIFF
--- a/examples/generated-sources/dub.json
+++ b/examples/generated-sources/dub.json
@@ -2,6 +2,6 @@
 	"name": "generated-sources",
 	"description": "Example of using pre generate commands to generate source code.",
 	"preGenerateCommands": [
-		"echo int fun() { return 42; } > source/test.d"
+		"echo 'int fun() { return 42; }' > source/test.d"
 	]
 }

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -100,6 +100,11 @@ class ProjectGenerator
 			targets[pack.name] = TargetInfo(pack, [pack], config, buildSettings);
 
 			prepareGeneration(pack, m_project, settings, buildSettings);
+			// Dub might have generated new files, so we need to regenerate at
+			// least buildSettings.sourceFiles
+			if (buildSettings.preGenerateCommands.length) {
+				buildSettings = pack.getBuildSettings(settings.platform, config);
+			}
 		}
 
 		configurePackages(m_project.rootPackage, targets, settings);


### PR DESCRIPTION
Fixes https://github.com/dlang/dub/issues/1474

This fixes the problem, but obviously we should be smarter 

TODO:
- [ ] add test case (or add the the examples to the CI)
- [x] check whether there actually was a preGenerateCommand run and only do the regeneration then
- [ ] try to find a better solution than this

FWIW it looks like even with the simple hello world example the buildSettings regeneration is already regenerated 4 times before.