### PR TITLE
Increased maven http timeout

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -366,13 +366,20 @@ ubyte[] download(URL url, uint timeout = 8)
 	on "unrecoverable failures" such as 404 not found
 	Otherwise might throw anything else that `download` throws.
 	See_Also: download
+
+	The download times out if a connection cannot be established within
+	`timeout` ms, or if the average transfer rate drops below 10 bytes / s for
+	more than `timeout` seconds.  Pass `0` as `timeout` to disable both timeout
+	mechanisms.
+
+	Note: Timeouts are only implemented when curl is used (DubUseCurl).
 **/
-void retryDownload(URL url, NativePath filename, size_t retryCount = 3)
+void retryDownload(URL url, NativePath filename, size_t retryCount = 3, uint timeout = 8)
 {
 	foreach(i; 0..retryCount) {
 		version(DubUseCurl) {
 			try {
-				download(url, filename);
+				download(url, filename, timeout);
 				return;
 			}
 			catch(HTTPStatusException e) {
@@ -408,12 +415,12 @@ void retryDownload(URL url, NativePath filename, size_t retryCount = 3)
 }
 
 ///ditto
-ubyte[] retryDownload(URL url, size_t retryCount = 3)
+ubyte[] retryDownload(URL url, size_t retryCount = 3, uint timeout = 8)
 {
 	foreach(i; 0..retryCount) {
 		version(DubUseCurl) {
 			try {
-				return download(url);
+				return download(url, timeout);
 			}
 			catch(HTTPStatusException e) {
 				if (e.status == 404) throw e;

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -17,6 +17,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 	import std.datetime : Clock, Duration, hours, SysTime, UTC;
 
 	private {
+		enum httpTimeout = 16;
 		URL m_mavenUrl;
 		struct CacheEntry { Json data; SysTime cacheTime; }
 		CacheEntry[string] m_metadataCache;
@@ -57,7 +58,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		auto url = m_mavenUrl~NativePath("%s/%s/%s-%s.zip".format(packageId, vers, packageId, vers));
 
 		try {
-			retryDownload(url, path);
+			retryDownload(url, path, 3, httpTimeout);
 			return;
 		}
 		catch(HTTPStatusException e) {
@@ -93,7 +94,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		string xmlData;
 
 		try
-			xmlData = cast(string)retryDownload(url);
+			xmlData = cast(string)retryDownload(url, 3, httpTimeout);
 		catch(HTTPStatusException e) {
 			if (e.status == 404) {
 				logDebug("Maven metadata %s not found at %s (404): %s", packageId, description, e.msg);


### PR DESCRIPTION
Maven (Nexus) is quite slow, often it needs more than 8 seconds for establishing a connection and therefore the downloading the dependencies fails. A timeout of 16 seconds should be sufficient.