### PR TITLE
Enable exact search for maven registry provider

### DIFF
--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -119,7 +119,13 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 
 	SearchResult[] searchPackages(string query)
 	{
-		return [];
+		// Only exact search is supported
+		// This enables retrival of dub packages on dub run
+		auto md = getMetadata(query);
+		if (md.type == Json.Type.null_)
+			return [];
+		auto json = getBestPackage(md, query, Dependency(">=0.0.0"), true);
+		return [SearchResult(json["name"].opt!string, "", json["version"].opt!string)];
 	}
 }
 

--- a/test/issue1416-maven-repo-pkg-supplier.sh
+++ b/test/issue1416-maven-repo-pkg-supplier.sh
@@ -24,5 +24,8 @@ echo "Trying to download maven-dubpackage (latest)"
 "$DUB" fetch maven-dubpackage --skip-registry=all --registry=mvn+http://localhost:$PORT/maven/release/dubpackages
 
 if ! dub remove maven-dubpackage --non-interactive --version=1.0.6 2>/dev/null; then
-    die 'DUB did not install latest package from maven registry.'
+    die 'DUB fetch did not install latest package from maven registry.'
 fi
+
+echo "Trying to search (exact) maven-dubpackage"
+"$DUB" search maven-dubpackage --skip-registry=all --registry=mvn+http://localhost:$PORT/maven/release/dubpackages | grep -c "maven-dubpackage (1.0.6)"


### PR DESCRIPTION
This will enable downloading dub packages on ```dub run``` as introduced by Seb (https://github.com/dlang/dub/pull/1428) also for maven repository provider.

Only exact search is possible, which is sufficient for dub run. 
For a "real" search different html dialects (Nexus, Artifactory, ...) has to be parsed.
For example the html code of this site has to be parsed to get the 3 artifacts
https://repo1.maven.org/maven2/com/devspan/vendor/jquery/