### PR TITLE
Single-file build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,19 @@ fi
 MACOSX_DEPLOYMENT_TARGET=10.8
 
 echo Running $DMD...
-$DMD -ofbin/dub -g -O -w -version=DubUseCurl -version=DubApplication -Isource $* @build-files.txt
+
+declare -ax objects # array
+while read f; do
+	echo Compiling $f ...
+	object="bin/$f.o"
+	objects+=($object)
+	# compile one file
+	$DMD -of$object -c $f -Os -w -version=DubUseCurl -version=DubApplication -Isource $*
+done < build-files.txt
+
+# link
+$DMD -ofbin/dub -Os -w -version=DubUseCurl -version=DubApplication -Isource $* ${objects[@]}
+echo Linking...
 bin/dub --version
 echo DUB has been built as bin/dub.
 echo


### PR DESCRIPTION
This is needed for dub to self-host in environments with limited RAM, like Termux/Android. `commandline.d` requires 1 Gb alone. For comparison, the OOM killer kicks in at 1.5 Gb on my system, and takes the entire Termux+editor session with it.

I don't believe there's value in full optimization or debug info here, so I went with `-Os` for a reasonable balance with build time.