### PR TITLE
Use timeout value for low_speed_time

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -547,7 +547,7 @@ version(DubUseCurl) {
 			conn.handle.set(CurlOption.connecttimeout, timeout);
 			// transfers time out after 8s below 10 byte/s
 			conn.handle.set(CurlOption.low_speed_limit, 10);
-			conn.handle.set(CurlOption.low_speed_time, 5);
+			conn.handle.set(CurlOption.low_speed_time, timeout);
 		}
 
 		conn.addRequestHeader("User-Agent", "dub/"~getDUBVersion()~" (std.net.curl; +https://github.com/rejectedsoftware/dub)");


### PR DESCRIPTION
Maven repositories (Nexus) could be really slow. While connect timeout of 16 seconds works fine, the low speed value of 5 is too low and causing failing builds.

This PR proposes to use the parameter ```timeout``` for low_speed_time instead of the fixed value 5. 
(Per default timeout is 8 and for maven repository it is 16)