### PR TITLE
Add flag --submodules to add git submodules in the project folder as available packages.

### DIFF
--- a/build-files.txt
+++ b/build-files.txt
@@ -4,6 +4,7 @@ source/dub/dependency.d
 source/dub/dependencyresolver.d
 source/dub/description.d
 source/dub/dub.d
+source/dub/git.d
 source/dub/init.d
 source/dub/packagemanager.d
 source/dub/packagesupplier.d

--- a/changelog/submodules.dd
+++ b/changelog/submodules.dd
@@ -1,0 +1,5 @@
+Support for git submodules as packages
+
+Dub now supports the flag `--submodules`, which will scan the root folder for git submodules and add them as
+available packages.
+The git tag on the repository defines the version of the package.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -11,6 +11,7 @@ import dub.compilers.compiler;
 import dub.dependency;
 import dub.dub;
 import dub.generators.generator;
+import dub.git;
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.data.json;
@@ -266,6 +267,10 @@ int runDubCommandLine(string[] args)
 			// parent package.
 			try dub.packageManager.getOrLoadPackage(NativePath(options.root_path));
 			catch (Exception e) { logDiagnostic("No valid package found in current working directory: %s", e.msg); }
+
+			if (options.submodules) {
+				addGitSubmodules(dub.packageManager, NativePath(options.root_path));
+			}
 		}
 	}
 
@@ -284,12 +289,11 @@ int runDubCommandLine(string[] args)
 	}
 }
 
-
 /** Contains and parses options common to all commands.
 */
 struct CommonOptions {
 	bool verbose, vverbose, quiet, vquiet, verror;
-	bool help, annotate, bare;
+	bool help, annotate, bare, submodules;
 	string[] registry_urls;
 	string root_path;
 	SkipPackageSuppliers skipRegistry = SkipPackageSuppliers.none;
@@ -314,6 +318,7 @@ struct CommonOptions {
 			]);
 		args.getopt("annotate", &annotate, ["Do not perform any action, just print what would be done"]);
 		args.getopt("bare", &bare, ["Read only packages contained in the current directory"]);
+		args.getopt("submodules", &submodules, ["Include git submodules as direct packages"]);
 		args.getopt("v|verbose", &verbose, ["Print diagnostic output"]);
 		args.getopt("vverbose", &vverbose, ["Print debug output"]);
 		args.getopt("q|quiet", &quiet, ["Only print warnings and errors"]);

--- a/source/dub/git.d
+++ b/source/dub/git.d
@@ -22,7 +22,12 @@ import std.string;
 public void addGitSubmodules(PackageManager packageManager, NativePath rootPath) {
 	import std.process : execute;
 
-	const submoduleInfo = execute(["git", "--git-dir=" ~ (rootPath ~ ".git").toNativeString, "submodule", "status"]);
+	auto rootScmPath = rootPath ~ ".git";
+	const submoduleInfo = execute([
+		"git",
+		"-C", rootPath.toNativeString,
+		"--git-dir=" ~ (rootScmPath.relativeTo(rootPath)).toNativeString,
+		"submodule", "status"]);
 
 	enforce(submoduleInfo.status == 0,
 		format("git submodule status exited with error code %s: %s", submoduleInfo.status, submoduleInfo.output));

--- a/source/dub/git.d
+++ b/source/dub/git.d
@@ -1,0 +1,42 @@
+// functionality to supply packages from git submodules
+module dub.git;
+
+import dub.dependency;
+import dub.internal.vibecompat.core.file;
+import dub.package_;
+import dub.packagemanager;
+
+import std.algorithm;
+import std.ascii : newline;
+import std.exception : enforce;
+import std.range;
+import std.string;
+
+/** Adds the git submodules checked out in the root path as direct packages.
+	Package version is derived from the submodule's tag by `getOrLoadPackage`.
+
+	Params:
+		packageManager = Package manager to track the added packages.
+		rootPath = the root path of the git repository to check for submodules.
+ */
+public void addGitSubmodules(PackageManager packageManager, NativePath rootPath) {
+	import std.process : execute;
+
+	const submoduleInfo = execute(["git", "--git-dir=" ~ (rootPath ~ ".git").toNativeString, "submodule", "status"]);
+
+	enforce(submoduleInfo.status == 0,
+		format("git submodule status exited with error code %s: %s", submoduleInfo.status, submoduleInfo.output));
+
+	foreach (line; submoduleInfo.output.lines) {
+		const parts = line.split(" ").map!strip.filter!(a => !a.empty).array;
+		const subPath = rootPath ~ parts[1];
+		const packageFile = Package.findPackageFile(subPath);
+
+		if (packageFile != NativePath.init) {
+			const scmPath = rootPath ~ NativePath(".git/modules/" ~ parts[1]);
+			packageManager.getOrLoadPackage(subPath, packageFile, false, scmPath);
+		}
+	}
+}
+
+private alias lines = text => text.split(newline).map!strip.filter!(a => !a.empty);

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -187,18 +187,20 @@ class PackageManager {
 		Params:
 			path = NativePath to the root directory of the package
 			recipe_path = Optional path to the recipe file of the package
+			scm_path = The directory in which the VCS (Git) stores its state.
 			allow_sub_packages = Also return a sub package if it resides in the given folder
 
 		Returns: The packages loaded from the given path
 		Throws: Throws an exception if no package can be loaded
 	*/
-	Package getOrLoadPackage(NativePath path, NativePath recipe_path = NativePath.init, bool allow_sub_packages = false)
+	Package getOrLoadPackage(NativePath path, NativePath recipe_path = NativePath.init,
+		bool allow_sub_packages = false, NativePath scm_path = NativePath.init)
 	{
 		path.endsWithSlash = true;
 		foreach (p; getPackageIterator())
 			if (p.path == path && (!p.parentPackage || (allow_sub_packages && p.parentPackage.path != p.path)))
 				return p;
-		auto pack = Package.load(path, recipe_path);
+		auto pack = Package.load(path, recipe_path, null, "", scm_path);
 		addPackages(m_temporaryPackages, pack);
 		return pack;
 	}

--- a/test/git-submodule.sh
+++ b/test/git-submodule.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -e
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+LAST_DIR=$PWD
+TEMP_DIR="submodule-test"
+
+function cleanup {
+	cd "$LAST_DIR"
+	rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir "$TEMP_DIR"
+cd "$TEMP_DIR"
+
+mkdir -p dependency/src
+
+cat << EOF >> dependency/dub.sdl
+name "dependency"
+sourcePaths "src"
+EOF
+
+cat << EOF >> dependency/src/foo.d
+module foo;
+void foo() { }
+EOF
+
+function git_ {
+	git -C dependency -c "user.name=Name" -c "user.email=Email" "$@"
+}
+git_ init
+git_ add dub.sdl
+git_ add src/foo.d
+git_ commit -m "first commit"
+git_ tag v1.0.0
+
+mkdir project
+
+cat << EOF >> project/dub.sdl
+name "project"
+mainSourceFile "project.d"
+targetType "executable"
+dependency "dependency" version="1.0.0"
+EOF
+
+cat << EOF >> project/project.d
+module project;
+import foo : foo;
+void main() { foo(); }
+EOF
+
+function git_ {
+	git -C project -c "user.name=Name" -c "user.email=Email" "$@"
+}
+git_ init
+git_ add dub.sdl
+git_ add project.d
+git_ submodule add ../dependency dependency
+git_ commit -m "first commit"
+
+# dub should now pick up the dependency
+$DUB --root=project --submodules run
+
+if ! grep -c -e "\"dependency\": \"1.0.0\"" project/dub.selections.json; then
+	die $LINENO "Dependency version was not identified correctly."
+fi


### PR DESCRIPTION
Also, adjust git version determination to support submodule folders with the -C flag.
(Submodules are folders that have distinct git state (tags etc.) but do not contain a `.git` folder, since they share the `.git` folder of the parent project.)
