### PR TITLE
Fix build errors caused by wrongly reused build artifacts

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -353,6 +353,7 @@ class BuildGenerator : ProjectGenerator {
 		addHash(buildsettings.lflags);
 		addHash((cast(uint)buildsettings.options).to!string);
 		addHash(buildsettings.stringImportPaths);
+		addHash(buildsettings.importPaths);
 		addHash(settings.platform.architecture);
 		addHash(settings.platform.compilerBinary);
 		addHash(settings.platform.compiler);


### PR DESCRIPTION
The build ID of two builds of the same package with differing dependency versions could previously be equal, leading to mixed code between the two dependency versions. Adding all import paths, together with the regular up-to-date check should be able to avoid this reliably.