### PR TITLE
[refactor] Add struct representing semantic versions, replacing string.

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -650,7 +650,7 @@ class Package {
 		else {
 			enum dv = dubVersion;
 		}
-		static assert(isValidVersion(dv));
+		assert(isValidVersion(dv), format!"dub built with invalid version '%s'"(dv));
 
 		enforce(dep.matches(dv),
 			"dub-" ~ dv ~ " does not comply with toolchainRequirements.dub "


### PR DESCRIPTION
Regex is taken from https://semver.org/ .

edit: Note that this is prep work for another PR that will introduce a new version operator, `~1.2.3`, to represent "semantic version compatible" (ie. identical version if `0.x.y`, up to next major if `x.y.z`), and can I just say how weird it is that Dub supports every conceivable version operation *except* "compatible semver"?