### PR TITLE
Print the platform probe atomically

### DIFF
--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -298,6 +298,7 @@ NativePath generatePlatformProbeFile()
 	import dub.internal.vibecompat.core.file;
 	import dub.internal.vibecompat.data.json;
 	import dub.internal.utils;
+	import std.string : format;
 
 	// try to not use phobos in the probe to avoid long import times
 	enum probe = q{
@@ -314,7 +315,7 @@ NativePath generatePlatformProbeFile()
 			return res;
 		}
 
-		pragma(msg, } ~ `"` ~ probeBeginMark ~ `"` ~q{
+		pragma(msg, `%1$s`
 			~ '\n' ~ `{`
 			~ '\n' ~ `  "compiler": "`~ determineCompiler() ~ `",`
 			~ '\n' ~ `  "frontendVersion": ` ~ toString!__VERSION__ ~ `,`
@@ -326,11 +327,13 @@ NativePath generatePlatformProbeFile()
 			~ '\n' ~ `    ` ~ determineArchitecture().stringArray
 			~ '\n' ~ `   ],`
 			~ '\n' ~ `}`
-			~ '\n' ~ } ~ `"` ~ probeEndMark ~ `"` ~ q{ );
+			~ '\n' ~ `%2$s`);
 
-		string[] determinePlatform() } ~ '{' ~ platformCheck ~ '}' ~ q{
-		string[] determineArchitecture() } ~ '{' ~ archCheck ~ '}' ~ q{
-		string determineCompiler() } ~ '{' ~ compilerCheck ~ '}';
+		string[] determinePlatform() { %3$s }
+		string[] determineArchitecture() { %4$s }
+		string determineCompiler() { %5$s }
+
+		}.format(probeBeginMark, probeEndMark, platformCheck, archCheck, compilerCheck);
 
 	auto path = getTempFile("dub_platform_probe", ".d");
 	auto fil = openFile(path, FileMode.createTrunc);

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -314,19 +314,19 @@ NativePath generatePlatformProbeFile()
 			return res;
 		}
 
-		pragma(msg, } ~ `"` ~ probeBeginMark ~ `"` ~q{ );
-		pragma(msg, `{`);
-		pragma(msg,`  "compiler": "`~ determineCompiler() ~ `",`);
-		pragma(msg, `  "frontendVersion": ` ~ toString!__VERSION__ ~ `,`);
-		pragma(msg, `  "compilerVendor": "` ~ __VENDOR__ ~ `",`);
-		pragma(msg, `  "platform": [`);
-		pragma(msg, `    ` ~ determinePlatform().stringArray);
-		pragma(msg, `  ],`);
-		pragma(msg, `  "architecture": [`);
-		pragma(msg, `    ` ~ determineArchitecture().stringArray);
-		pragma(msg, `   ],`);
-		pragma(msg, `}`);
-		pragma(msg, } ~ `"` ~ probeEndMark ~ `"` ~ q{ );
+		pragma(msg, } ~ `"` ~ probeBeginMark ~ `"` ~q{
+			~ '\n' ~ `{`
+			~ '\n' ~ `  "compiler": "`~ determineCompiler() ~ `",`
+			~ '\n' ~ `  "frontendVersion": ` ~ toString!__VERSION__ ~ `,`
+			~ '\n' ~ `  "compilerVendor": "` ~ __VENDOR__ ~ `",`
+			~ '\n' ~ `  "platform": [`
+			~ '\n' ~ `    ` ~ determinePlatform().stringArray
+			~ '\n' ~ `  ],`
+			~ '\n' ~ `  "architecture": [`
+			~ '\n' ~ `    ` ~ determineArchitecture().stringArray
+			~ '\n' ~ `   ],`
+			~ '\n' ~ `}`
+			~ '\n' ~ } ~ `"` ~ probeEndMark ~ `"` ~ q{ );
 
 		string[] determinePlatform() } ~ '{' ~ platformCheck ~ '}' ~ q{
 		string[] determineArchitecture() } ~ '{' ~ archCheck ~ '}' ~ q{


### PR DESCRIPTION
DMD may print some stuff in between calls of `pragma(msg)` and corrupt the json data.

This is blocking DMD PR https://github.com/dlang/dmd/pull/10539, all buildkite tests which depend on dub are failing.

After debugging, I found out It's printing a probe like this:
```json
__dub_probe_begin__
{
  "compiler": "dmd",
  "frontendVersion": 2088,
  "compilerVendor": "Digital Mars D",
  "platform": [
import    core.internal.array.utils	(/home/ss/Downloads/dmd/generated/linux/debug/64/../../../../../druntime/import/core/internal/array/utils.d)
    "linux", "posix"
  ],
  "architecture": [
    "x86_64"
   ],
}
__dub_probe_end__
```
It fails at parsing the probe as json and aborts everything.