### PR TITLE
Feature: git submodule support via path selection

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -479,6 +479,7 @@ struct Dependency {
 		d.m_inclusiveA = !m_inclusiveA && acmp >= 0 ? false : o.m_inclusiveA;
 		d.m_versA = acmp > 0 ? m_versA : o.m_versA;
 		d.m_inclusiveB = !m_inclusiveB && bcmp <= 0 ? false : o.m_inclusiveB;
+		if (bcmp < 0) d.m_inclusiveB = m_inclusiveB;
 		d.m_versB = bcmp < 0 ? m_versB : o.m_versB;
 		d.m_optional = m_optional && o.m_optional;
 		if (!d.valid) return invalid;
@@ -541,6 +542,9 @@ unittest {
 	assert (!m.matches(Version("1.1.0")));
 	assert (!m.matches(Version("0.0.1")));
 
+	a = Dependency("0.4.0"); b = Dependency("^0.4.0");
+	m = a.merge(b);
+	assert (m.valid(), m.toString());
 
 	// branches / head revisions
 	a = Dependency(Version.masterBranch);

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -93,6 +93,17 @@ struct Dependency {
 		m_path = path;
 	}
 
+	/** Constructs a new dependency specification that matches a specific
+		version *and* path.
+	*/
+	this(const Version ver, NativePath path)
+	{
+		m_inclusiveA = m_inclusiveB = true;
+		m_versA = ver;
+		m_versB = ver;
+		m_path = path;
+	}
+
 	/// If set, overrides any version based dependency selection.
 	@property void path(NativePath value) { m_path = value; }
 	/// ditto
@@ -470,7 +481,7 @@ struct Dependency {
 		if (m_versB.isBranch != o.m_versB.isBranch) return invalid;
 		if (m_versA.isBranch) return m_versA == o.m_versA ? this : invalid;
 		// NOTE Path is @system in vibe.d 0.7.x and in the compatibility layer
-		if (() @trusted { return this.path != o.path; } ()) return invalid;
+		if (() @trusted { return !m_path.empty && !o.m_path.empty && m_path != o.m_path; } ()) return invalid;
 
 		int acmp = m_versA.opCmp(o.m_versA);
 		int bcmp = m_versB.opCmp(o.m_versB);
@@ -482,6 +493,7 @@ struct Dependency {
 		if (bcmp < 0) d.m_inclusiveB = m_inclusiveB;
 		d.m_versB = bcmp < 0 ? m_versB : o.m_versB;
 		d.m_optional = m_optional && o.m_optional;
+		d.m_path = () @trusted { return !m_path.empty ? m_path : o.m_path; }();
 		if (!d.valid) return invalid;
 
 		return d;

--- a/source/dub/internal/git.d
+++ b/source/dub/internal/git.d
@@ -71,7 +71,14 @@ private string determineVersionWithGitTool(NativePath path)
 	import std.process;
 
 	auto git_dir = path ~ ".git";
-	if (!existsFile(git_dir) || !isDir(git_dir.toNativeString)) return null;
+	if (!existsFile(git_dir)) return null;
+
+	if (!isDir(git_dir.toNativeString)) {
+		auto gitredirect = readText(git_dir.toNativeString).strip();
+		if (!gitredirect.startsWith("gitdir: ")) return null;
+		git_dir = path ~ NativePath(gitredirect.drop("gitdir: ".length));
+		if (!isDir(git_dir.toNativeString)) return null;
+	}
 	auto git_dir_param = "--git-dir=" ~ git_dir.toNativeString();
 
 	static string exec(scope string[] params...) {


### PR DESCRIPTION
Second try! (ping @wilzbach @atilaneves )

This approach relies on hardcoding the submodules in `dub.selections.json` and thus requires some more user intervention. The idea here is to extend dependencies to include both path and version, and for `dub.selections.json` determine the version from the SCM. Then, instead of overwriting the dependencies with `dub.selections.json` we check if the selected package actually matches the version requirements, which is probably something we should do anyways - if `dub.selections.json` says `2.3.4` but the package requires `>=2.4.0` it's highly questionable to continue with `2.3.4` anyways.

Open question: how does this interact with `dub upgrade`? How should it?

Open task: write test for it.

See https://github.com/dlang/dub/pull/1780 for previous debate.