### PR TITLE
Recognize git semantic version tags without leading "v".

### DIFF
--- a/source/dub/internal/git.d
+++ b/source/dub/internal/git.d
@@ -87,10 +87,11 @@ private string determineVersionWithGitTool(NativePath path)
 		auto commit = parts[$-1];
 		auto num = parts[$-2].to!int;
 		tag = parts[0 .. $-2].join("-");
-		if (tag.startsWith("v") && isValidVersion(tag[1 .. $])) {
-			if (num == 0) return tag[1 .. $];
-			else if (tag.canFind("+")) return format("%s.commit.%s.%s", tag[1 .. $], num, commit);
-			else return format("%s+commit.%s.%s", tag[1 .. $], num, commit);
+		if (tag.startsWith("v")) tag = tag[1 .. $];
+		if (isValidVersion(tag)) {
+			if (num == 0) return tag;
+			else if (tag.canFind("+")) return format("%s.commit.%s.%s", tag, num, commit);
+			else return format("%s+commit.%s.%s", tag, num, commit);
 		}
 	}
 


### PR DESCRIPTION
Note that `code.dlang.org` still requires `v`, so this only affects version detection on internal repositories.

https://forum.dlang.org/thread/cdtzzufsejkmdwmnsoul@forum.dlang.org seems broadly in favor, though I forgot to ask about the specific case of repository-local version detection.

This is part of my effort to get git submodules supported in dub for internal use, since we have a lot of internal projects that don't use dub-type 'v' tags - simply because there has been zero reason to use 'v' tags, because we weren't using dub anyways.