### PR TITLE
Mildly refactor dependency resolver

### DIFF
--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -44,6 +44,7 @@ class DependencyResolver {
 	static struct TreeNode {
 		string pack;
 		Dependency config;
+		invariant (config.isExactVersion);
 	}
 
 	Dependency[string] resolve(TreeNode root, bool throw_on_failure = true)

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -90,7 +90,6 @@ class DependencyResolver {
 	protected abstract Dependency[] getAllConfigs(string pack);
 	protected abstract Dependency[] getSpecificConfigs(string pack, PackageDependency packDependency);
 	protected abstract PackageDependency[] getChildren(TreeNode node);
-	protected abstract bool matches(Dependency configs, Dependency config);
 
 	private static struct ResolveConfig {
 		Dependency config;
@@ -166,7 +165,7 @@ class DependencyResolver {
 			bool any_config = false;
 			foreach (i, ref c; *di)
 				if (c.included) {
-					if (!matches(dep.dependency, c.config))
+					if (!dep.dependency.merge(c.config).valid)
 						c.included = false;
 					else any_config = true;
 				}
@@ -294,7 +293,7 @@ class DependencyResolver {
 			foreach (d; deps) {
 				// filter out trivial self-dependencies
 				if (d[0].pack.basePackageName == failbase
-					&& matches(d[1].dependency, d[0].config))
+					&& d[1].dependency.merge(d[0].config).valid)
 					continue;
 				msg ~= format("\n  %s %s depends on %s %s", d[0].pack, d[0].config, d[1].pack, d[1].dependency);
 			}
@@ -523,5 +522,4 @@ private class TestResolver : DependencyResolver {
 	protected override PackageDependency[] getChildren(TreeNode node) {
 		return m_children.get(node.pack ~ ":" ~ node.config.to!string(), null);
 	}
-	protected override bool matches(Dependency configs, Dependency config) { return configs.merge(config).valid; }
 }

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -33,7 +33,7 @@ class DependencyResolver {
 	*/
 	static struct TreeNodes {
 		string pack;
-		Dependency configs;
+		Dependency dependency;
 		DependencyType depType = DependencyType.required;
 	}
 
@@ -154,7 +154,7 @@ class DependencyResolver {
 			bool any_config = false;
 			foreach (i, ref c; *di)
 				if (c.included) {
-					if (!matches(dep.configs, c.config))
+					if (!matches(dep.dependency, c.config))
 						c.included = false;
 					else any_config = true;
 				}
@@ -225,7 +225,7 @@ class DependencyResolver {
 
 		// should have thrown in constrainRec before reaching this
 		assert(false, format("Got no configuration for dependency %s %s of %s %s!?",
-			dep.pack, dep.configs, n.pack, n.config));
+			dep.pack, dep.dependency, n.pack, n.config));
 	}
 
 	private void purgeOptionalDependencies(TreeNode root, ref Dependency[string] configs)
@@ -281,9 +281,9 @@ class DependencyResolver {
 			foreach (d; deps) {
 				// filter out trivial self-dependencies
 				if (d[0].pack.basePackageName == failbase
-					&& matches(d[1].configs, d[0].config))
+					&& matches(d[1].dependency, d[0].config))
 					continue;
-				msg ~= format("\n  %s %s depends on %s %s", d[0].pack, d[0].config, d[1].pack, d[1].configs);
+				msg ~= format("\n  %s %s depends on %s %s", d[0].pack, d[0].config, d[1].pack, d[1].dependency);
 			}
 		}
 	}

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1651,12 +1651,6 @@ private class DependencyVersionResolver : DependencyResolver {
 		return ret.data;
 	}
 
-	protected override bool matches(Dependency configs, Dependency config)
-	{
-		if (!configs.path.empty) return configs.path == config.path;
-		return configs.merge(config).valid;
-	}
-
 	private Package getPackage(string name, Dependency dep)
 	{
 		auto key = PackageDependency(name, dep);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1484,7 +1484,7 @@ enum SkipPackageSuppliers {
 	all         /// Uses only manually specified package suppliers.
 }
 
-private class DependencyVersionResolver : DependencyResolver!(Dependency, Dependency) {
+private class DependencyVersionResolver : DependencyResolver {
 	protected {
 		Dub m_dub;
 		UpgradeOptions m_options;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1494,7 +1494,7 @@ private class DependencyVersionResolver : DependencyResolver {
 		Package m_rootPackage;
 		bool[string] m_packagesToUpgrade;
 		Package[PackageDependency] m_packages;
-		TreeNodes[][TreeNode] m_children;
+		PackageDependency[][TreeNode] m_children;
 	}
 
 
@@ -1577,14 +1577,16 @@ private class DependencyVersionResolver : DependencyResolver {
 		return ret;
 	}
 
-	protected override Dependency[] getSpecificConfigs(string pack, TreeNodes nodes)
+	protected override Dependency[] getSpecificConfigs(string pack, PackageDependency packDependency)
 	{
-		if (!nodes.dependency.path.empty && getPackage(pack, nodes.dependency)) return [nodes.dependency];
+		if (!packDependency.dependency.path.empty && getPackage(pack, packDependency.dependency)) {
+			return [packDependency.dependency];
+		}
 		else return null;
 	}
 
 
-	protected override TreeNodes[] getChildren(TreeNode node)
+	protected override PackageDependency[] getChildren(TreeNode node)
 	{
 		if (auto pc = node in m_children)
 			return *pc;
@@ -1593,10 +1595,10 @@ private class DependencyVersionResolver : DependencyResolver {
 		return ret;
 	}
 
-	private final TreeNodes[] getChildrenRaw(TreeNode node)
+	private final PackageDependency[] getChildrenRaw(TreeNode node)
 	{
 		import std.array : appender;
-		auto ret = appender!(TreeNodes[]);
+		auto ret = appender!(PackageDependency[]);
 		auto pack = getPackage(node.pack, node.config);
 		if (!pack) {
 			// this can hapen when the package description contains syntax errors
@@ -1620,7 +1622,7 @@ private class DependencyVersionResolver : DependencyResolver {
 						format("Dependency from %s to root package references wrong path: %s vs. %s",
 							node.pack, absdeppath.toNativeString(), desireddeppath.toNativeString()));
 				}
-				ret ~= TreeNodes(d.name, node.config);
+				ret ~= PackageDependency(d.name, node.config);
 				continue;
 			}
 
@@ -1644,7 +1646,7 @@ private class DependencyVersionResolver : DependencyResolver {
 					dt = DependencyType.optionalDefault;
 			}
 
-			ret ~= TreeNodes(d.name, dspec, dt);
+			ret ~= PackageDependency(d.name, dspec, dt);
 		}
 		return ret.data;
 	}

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1579,7 +1579,7 @@ private class DependencyVersionResolver : DependencyResolver {
 
 	protected override Dependency[] getSpecificConfigs(string pack, TreeNodes nodes)
 	{
-		if (!nodes.configs.path.empty && getPackage(pack, nodes.configs)) return [nodes.configs];
+		if (!nodes.dependency.path.empty && getPackage(pack, nodes.dependency)) return [nodes.dependency];
 		else return null;
 	}
 


### PR DESCRIPTION
DependencyResolver is a template for no good reason. Replace its parameters with concrete types.
Change the unittest to use the actual Dependency type instead of a weird, int-based imitation.
Rename TreeNodes to PackageDependency, because we're no longer pretending to be a generic pseudo-array type.
