### PR TITLE
Fix unnecessary rebuild of single file package

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -814,6 +814,7 @@ class GenerateCommand : PackageBuildCommand {
 		gensettings.rdmd = m_rdmd;
 		gensettings.tempBuild = m_tempBuild;
 		gensettings.parallelBuild = m_parallel;
+		gensettings.single = m_single;
 
 		logDiagnostic("Generating using %s", m_generator);
 		dub.generateProject(m_generator, gensettings);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -396,7 +396,8 @@ class BuildGenerator : ProjectGenerator {
 		foreach (p; packages)
 			allfiles ~= (p.recipePath != NativePath.init ? p : p.basePackage).recipePath.toNativeString();
 		foreach (f; additional_dep_files) allfiles ~= f.toNativeString();
-		if (main_pack is m_project.rootPackage && m_project.rootPackage.getAllDependencies().length > 0)
+		bool checkSelectedVersions = !settings.single;
+		if (checkSelectedVersions && main_pack is m_project.rootPackage && m_project.rootPackage.getAllDependencies().length > 0)
 			allfiles ~= (main_pack.path ~ SelectedVersions.defaultFile).toNativeString();
 
 		foreach (file; allfiles.data) {

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -591,6 +591,10 @@ struct GeneratorSettings {
 
 	// only used for generator "build"
 	bool run, force, direct, rdmd, tempBuild, parallelBuild;
+
+	/// single file dub package
+	bool single;
+
 	string[] runArgs;
 	void delegate(int status, string output) compileCallback;
 	void delegate(int status, string output) linkCallback;

--- a/test/issue103-single-file-package.sh
+++ b/test/issue103-single-file-package.sh
@@ -19,6 +19,11 @@ if [ -f single-file-test ]; then
 	die $LINENO 'Shebang invocation produced binary in current directory'
 fi
 
+if ! { ${DUB} run --single issue103-single-file-package-w-dep.d --temp-build 2>&1 || true; } | grep -cF "To force a rebuild"; then
+	echo "Invocation triggered unnecessary rebuild."
+	exit 1
+fi
+
 if ${DUB} "issue103-single-file-package-error.d" 2> /dev/null; then
 	echo "Invalid package comment syntax did not trigger an error."
 	exit 1


### PR DESCRIPTION
In case a single file package has dependencies, isUpToDate method checks whether `dub.selections.json` exists. As single file package has the UpgradeOptions.noSaveSelections `dub.selections.json` won't be created and therefore isUpToDate always returns false. 
This pull request passes the UpgradeOptions.noSaveSelections to the build generator and avoid the check of `dub.selections.json`