### PR TITLE
Fix #1206: Remove warning when using ldmd2 or gdmd

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -142,11 +142,6 @@ interface Compiler {
 		auto build_platform = readPlatformJsonProbe(result.output);
 		build_platform.compilerBinary = compiler_binary;
 
-		if (build_platform.compiler != this.name) {
-			logWarn(`The determined compiler type "%s" doesn't match the expected type "%s". `~
-				`This will probably result in build errors.`, build_platform.compiler, this.name);
-		}
-
 		auto ver = determineVersion(compiler_binary, result.output)
 			.strip;
 		if (ver.empty) {


### PR DESCRIPTION
This warning is being triggered frequently when ldmd2 or gdmd
(dmd-like CLI interface for ldc2 and gdc, respectively)
are used as '--compiler' argument.
They were introduced at the same time as the platform probe
(8ac4848bbb14ec785c69ce72a8c0d05cf225669c),
probably for defensive programming, but have not proved useful.