### PR TITLE
Replace calls to NativePath.toString() with .name

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -164,9 +164,9 @@ private:
 	static void addSI(ref string[] arr, in string[] vals)
 	{
 		bool[string] existing;
-		foreach (v; arr) existing[NativePath(v).head.toString()] = true;
+		foreach (v; arr) existing[NativePath(v).head.name] = true;
 		foreach (v; vals) {
-			auto s = NativePath(v).head.toString();
+			auto s = NativePath(v).head.name;
 			if (s !in existing) {
 				existing[s] = true;
 				arr ~= v;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -677,14 +677,14 @@ class Dub {
 				import std.path;
 				tcinfo.sourceFiles[""] ~= custom_main_file.relativeTo(m_project.rootPackage.path).toNativeString();
 				tcinfo.importPaths[""] ~= custom_main_file.parentPath.toNativeString();
-				custommodname = custom_main_file.head.toString().baseName(".d");
+				custommodname = custom_main_file.head.name.baseName(".d");
 			}
 
 			// prepare the list of tested modules
 			string[] import_modules;
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
-					auto fname = NativePath(file).head.toString();
+					auto fname = NativePath(file).head.name;
 					if (NativePath(file).relativeTo(m_project.rootPackage.path) == NativePath(mainfil)) {
 						logWarn("Excluding main source file %s from test.", mainfil);
 						tcinfo.excludedSourceFiles[""] ~= mainfil;
@@ -1300,7 +1300,7 @@ class Dub {
 		}
 
 		auto srcfile = m_project.rootPackage.recipePath;
-		auto srcext = srcfile.head.toString().extension;
+		auto srcext = srcfile.head.name.extension;
 		if (srcext == "."~destination_file_ext) {
 			logInfo("Package format is already %s.", destination_file_ext);
 			return;

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -217,7 +217,7 @@ class VisualDGenerator : ProjectGenerator {
 					foreach(unused; 0..decrease)
 						ret.put("\n    </Folder>");
 					foreach(idx; 0..increase)
-						ret.formattedWrite("\n    <Folder name=\"%s\">", cur[same + idx].toString());
+						ret.formattedWrite("\n    <Folder name=\"%s\">", cur[same + idx].name);
 					lastFolder = cur;
 				}
 				ret.formattedWrite("\n      <File %spath=\"%s\" />", source.build ? "" : "tool=\"None\" ", source.filePath.toNativeString());

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -53,7 +53,7 @@ void initPackage(NativePath root_path, string[string] deps, string type,
 	string username = getUserName();
 
 	PackageRecipe p;
-	p.name = root_path.head.toString().toLower();
+	p.name = root_path.head.name.toLower();
 	p.authors ~= username;
 	p.license = "proprietary";
 	foreach (pack, v; deps) {

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -148,7 +148,7 @@ string packageInfoFileFromZip(NativePath zip, out string fileName) {
 	foreach (ArchiveMember am; archive.directory) {
 		auto path = NativePath(am.name).bySegment.array;
 		foreach (fil; packageInfoFiles) {
-			if ((path.length == 1 && path[0] == fil.filename) || (path.length == 2 && path[$-1].toString == fil.filename)) {
+			if ((path.length == 1 && path[0] == fil.filename) || (path.length == 2 && path[$-1].name == fil.filename)) {
 				fileName = fil.filename;
 				return stripUTF8Bom(cast(string) archive.expand(archive.directory[am.name]));
 			}
@@ -612,7 +612,7 @@ string determineModuleName(BuildSettings settings, NativePath file, NativePath b
 	//create module name from path
 	foreach (i; 0 .. mpath.length) {
 		import std.path;
-		auto p = mpath[i].toString();
+		auto p = mpath[i].name;
 		if (p == "package.d") break;
 		if (i > 0) ret ~= ".";
 		if (i+1 < mpath.length) ret ~= p;

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -387,7 +387,7 @@ class PackageManager {
 		outer: foreach(ArchiveMember am; archive.directory) {
 			auto path = NativePath(am.name).bySegment.array;
 			foreach (fil; packageInfoFiles)
-				if (path.length == 2 && path[$-1].toString == fil.filename) {
+				if (path.length == 2 && path[$-1].name == fil.filename) {
 					zip_prefix = path[0 .. $-1];
 					break outer;
 				}
@@ -696,12 +696,12 @@ class PackageManager {
 		string[] ignored_files = [];
 		SHA1 sha1;
 		foreach(file; dirEntries(pack.path.toNativeString(), SpanMode.depth)) {
-			if(file.isDir && ignored_directories.canFind(NativePath(file.name).head.toString()))
+			if(file.isDir && ignored_directories.canFind(NativePath(file.name).head.name))
 				continue;
-			else if(ignored_files.canFind(NativePath(file.name).head.toString()))
+			else if(ignored_files.canFind(NativePath(file.name).head.name))
 				continue;
 
-			sha1.put(cast(ubyte[])NativePath(file.name).head.toString());
+			sha1.put(cast(ubyte[])NativePath(file.name).head.name);
 			if(file.isDir) {
 				logDebug("Hashed directory name %s", NativePath(file.name).head);
 			}

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -30,7 +30,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 			NativePath p = NativePath(d.name);
 			logDebug("Entry: %s", p);
 			enforce(to!string(p.head)[$-4..$] == ".zip");
-			auto vers = p.head.toString()[package_id.length+1..$-4];
+			auto vers = p.head.name[package_id.length+1..$-4];
 			logDebug("Version: %s", vers);
 			ret ~= Version(vers);
 		}

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -239,7 +239,7 @@ class Project {
 			string ret;
 			ret ~= `Please modify the "name" field in %s accordingly.`.format(m_rootPackage.recipePath.toNativeString());
 			if (!m_rootPackage.recipe.buildSettings.targetName.length) {
-				if (m_rootPackage.recipePath.head.toString().endsWith(".sdl")) {
+				if (m_rootPackage.recipePath.head.name.endsWith(".sdl")) {
 					ret ~= ` You can then add 'targetName "%s"' to keep the current executable name.`.format(m_rootPackage.name);
 				} else {
 					ret ~= ` You can then add '"targetName": "%s"' to keep the current executable name.`.format(m_rootPackage.name);
@@ -1430,7 +1430,7 @@ unittest
 
 	import std.path : dirSeparator;
 
-	static Path woSlash(Path p) { p.endsWithSlash = false; return p; }
+	static NativePath woSlash(NativePath p) { p.endsWithSlash = false; return p; }
 	// basic vars
 	assert(processVars("Hello $PACKAGE_DIR", proj, pack, gsettings, !isPath) == "Hello "~woSlash(pack.path).toNativeString);
 	assert(processVars("Hello $ROOT_PACKAGE_DIR", proj, pack, gsettings, !isPath) == "Hello "~woSlash(proj.rootPackage.path).toNativeString.chomp(dirSeparator));


### PR DESCRIPTION
This has been deprecated in vibe-core and only triggers with 'library-nonet'.