### PR TITLE
Remove traces of VibeCustomMain

### DIFF
--- a/examples/vibed-main/dub.json
+++ b/examples/vibed-main/dub.json
@@ -3,6 +3,5 @@
 	"description": "A project using vibe.d and a custom main() function",
 	"dependencies": {
 		"vibe-d": "~master"
-	},
-	"versions": ["VibeCustomMain"]
+	}
 }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -664,10 +664,6 @@ class Dub {
 			BuildSettingsTemplate tcinfo = m_project.rootPackage.recipe.getConfiguration(config).buildSettings;
 			tcinfo.targetType = TargetType.executable;
 			tcinfo.targetName = test_config;
-			// HACK for vibe.d's legacy main() behavior:
-			tcinfo.versions[""] ~= "VibeCustomMain";
-			m_project.rootPackage.recipe.buildSettings.versions[""] = m_project.rootPackage.recipe.buildSettings.versions.get("", null).remove!(v => v == "VibeDefaultMain");
-			// TODO: remove this ^ once vibe.d has removed the default main implementation
 
 			auto mainfil = tcinfo.mainSourceFile;
 			if (!mainfil.length) mainfil = m_project.rootPackage.recipe.buildSettings.mainSourceFile;


### PR DESCRIPTION
```
VibeCustomMain support was removed in Vibe.d v0.7.0,
released over 4 years ago (2015-11-04).
```

https://github.com/vibe-d/vibe.d/commit/db527ccb7a7c3087b0c748345bd606fd1fe9c814
Note: This also remove the `VibeDefaultMain` handling, but this should only be defined in application build, not library one.