### PR TITLE
add flush before reading input for Windows msys2/mingw

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -521,8 +521,7 @@ class InitCommand : Command {
 		static string input(string caption, string default_value)
 		{
 			writef("%s [%s]: ", caption, default_value);
-			// Msys2 and mingw on Windows require this flush()
-			version (Windows) stdout.flush();
+			stdout.flush();
 			auto inp = readln();
 			return inp.length > 1 ? inp[0 .. $-1] : default_value;
 		}

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -521,6 +521,8 @@ class InitCommand : Command {
 		static string input(string caption, string default_value)
 		{
 			writef("%s [%s]: ", caption, default_value);
+			// Msys2 and mingw on Windows require this flush()
+			version (Windows) stdout.flush();
 			auto inp = readln();
 			return inp.length > 1 ? inp[0 .. $-1] : default_value;
 		}


### PR DESCRIPTION
When I use dub with msys2 and mingw, `dub init` shows nothing. This is because the message prompt (e.g., `Package recipe format (sdl/json) [json]:`) does not flush stdout before reading input in that environment (I found powershell and cmd are OK). Therefore, I propose to add a manual `stdout.flush()` before the `readln()`.