### PR TITLE
Clean up PackageManager handling of search path

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -260,8 +260,7 @@ class Dub {
 	{
 		init(NativePath());
 		m_overrideSearchPath = override_path;
-		m_packageManager = new PackageManager(NativePath(), NativePath(), NativePath(), false);
-		updatePackageSearchPath();
+		m_packageManager = new PackageManager(override_path);
 	}
 
 	private void init(NativePath root_path)
@@ -445,9 +444,7 @@ class Dub {
 		loadSingleFilePackage(NativePath(path));
 	}
 
-	/** Disables the default search paths and only searches a specific directory
-		for packages.
-	*/
+	deprecated("Instantiate a Dub instance with the single-argument constructor: `new Dub(path)`")
 	void overrideSearchPath(NativePath path)
 	{
 		if (!path.absolute) path = NativePath(getcwd()) ~ path;
@@ -1350,19 +1347,21 @@ class Dub {
 
 	private void updatePackageSearchPath()
 	{
+		// TODO: Remove once `overrideSearchPath` is removed
 		if (!m_overrideSearchPath.empty) {
-			m_packageManager.disableDefaultSearchPaths = true;
+			m_packageManager._disableDefaultSearchPaths = true;
 			m_packageManager.searchPath = [m_overrideSearchPath];
-		} else {
-			auto p = environment.get("DUBPATH");
-			NativePath[] paths;
-
-			version(Windows) enum pathsep = ";";
-			else enum pathsep = ":";
-			if (p.length) paths ~= p.split(pathsep).map!(p => NativePath(p))().array();
-			m_packageManager.disableDefaultSearchPaths = false;
-			m_packageManager.searchPath = paths;
+			return;
 		}
+
+		auto p = environment.get("DUBPATH");
+		NativePath[] paths;
+
+		version(Windows) enum pathsep = ";";
+		else enum pathsep = ":";
+		if (p.length) paths ~= p.split(pathsep).map!(p => NativePath(p))().array();
+		m_packageManager._disableDefaultSearchPaths = false;
+		m_packageManager.searchPath = paths;
 	}
 
 	private void determineDefaultCompiler()

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -37,6 +37,24 @@ class PackageManager {
 		bool m_disableDefaultSearchPaths = false;
 	}
 
+	/**
+	   Instantiate an instance with a single search path
+
+	   This constructor is used when dub is invoked with the '--bar' CLI switch.
+	   The instance will not look up the default repositories
+	   (e.g. ~/.dub/packages), using only `path` instead.
+
+	   Params:
+		 path = Path of the single repository
+	 */
+	this(NativePath path)
+	{
+		this.m_searchPath = [ path ];
+		this.m_disableDefaultSearchPaths = true;
+		this.refresh(true);
+	}
+
+	deprecated("Use the overload which accepts 3 `NativePath` arguments")
 	this(NativePath user_path, NativePath system_path, bool refresh_packages = true)
 	{
 		m_repositories = [
@@ -69,7 +87,17 @@ class PackageManager {
 
 	/** Disables searching DUB's predefined search paths.
 	*/
+	deprecated("Instantiate a PackageManager instance with the single-argument constructor: `new PackageManager(path)`")
 	@property void disableDefaultSearchPaths(bool val)
+	{
+		this._disableDefaultSearchPaths(val);
+	}
+
+	// Non deprecated instance of the previous symbol,
+	// as `Dub.updatePackageSearchPath` calls it and while nothing in Dub app
+	// itself relies on it, just removing the call from `updatePackageSearchPath`
+	// could break the library use case.
+	package(dub) void _disableDefaultSearchPaths(bool val)
 	{
 		if (val == m_disableDefaultSearchPaths) return;
 		m_disableDefaultSearchPaths = val;
@@ -571,7 +599,7 @@ class PackageManager {
 			NativePath list_path = m_repositories[type].packagePath;
 			Package[] packs;
 			NativePath[] paths;
-			if (!m_disableDefaultSearchPaths) try {
+			try {
 				auto local_package_file = list_path ~ LocalPackagesFilename;
 				logDiagnostic("Looking for local package map at %s", local_package_file.toNativeString());
 				if( !existsFile(local_package_file) ) return;
@@ -624,9 +652,12 @@ class PackageManager {
 			m_repositories[type].localPackages = packs;
 			m_repositories[type].searchPath = paths;
 		}
-		scanLocalPackages(LocalPackageType.system);
-		scanLocalPackages(LocalPackageType.user);
-		scanLocalPackages(LocalPackageType.package_);
+		if (!m_disableDefaultSearchPaths)
+		{
+			scanLocalPackages(LocalPackageType.system);
+			scanLocalPackages(LocalPackageType.user);
+			scanLocalPackages(LocalPackageType.package_);
+		}
 
 		auto old_packages = m_packages;
 
@@ -693,9 +724,12 @@ class PackageManager {
 				}
 			}
 		}
-		loadOverrides(LocalPackageType.package_);
-		loadOverrides(LocalPackageType.user);
-		loadOverrides(LocalPackageType.system);
+		if (!m_disableDefaultSearchPaths)
+		{
+			loadOverrides(LocalPackageType.package_);
+			loadOverrides(LocalPackageType.user);
+			loadOverrides(LocalPackageType.system);
+		}
 	}
 
 	alias Hash = ubyte[];

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -521,6 +521,7 @@ class PackageManager {
 	}
 
 	/// Compatibility overload. Use the version without a `force_remove` argument instead.
+	deprecated("Use `remove(pack)` directly instead, the boolean has no effect")
 	void remove(in Package pack, bool force_remove)
 	{
 		remove(pack);


### PR DESCRIPTION
```
The PackageManager is a complicated beast:
it is responsible for handling the local caches where downloaded
packages are stored, including looking up a specific version of a specific package.

One feature that stood out while going over the code was the ability to disable
the default search path.
After looking up inside of Dub more, it turns out that this feature is exclusively
used when dub is called with the '--bare' option.

However, when this happen, a special constructor of the Dub class is called,
one that calls the 'PackageManager' constructor with 3 dummy arguments,
and rely on a boolean being set to avoid those 3 dummy arguments having any effect.
This ends up with effectively providing the ability to toggle the ability to
search default search paths in theory, but in practice the dummy arguments
means that it wouldn't work, nor is it actually needed.

Instead, a special argument for the single-search path approach is provided now.
In order not to break library users, the public symbols have been deprecated,
but their usage still works.
Note that some symbols are deeply entangled: for example, 'Dub.m_overrideSearchPath'
being non-empty means that 'PackageManager.m_disableDefaultSearchPaths' is 'true'.
It also means that 'PackageManager.m_repositories' is unused (and can be empty).
Hopefully removing the ability to toggle the default search path will allow
us to simplify things and make 'PackageManager.m_repositories' the only way
to specify whether or not the default packages search path are used.

Note that additionally to the changes aiming to deprecate 'Dub.m_overrideSearchPath'
and 'PackageManager.m_disableDefaultSearchPath', an unused constructor of PackageManager
has been deprecated.
```