### PR TITLE
Fix issue 1277: Missing dub.json causes infinite loop

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -427,18 +427,18 @@ class Command {
 
 	private bool loadCwdPackage(Dub dub, bool warn_missing_package)
 	{
-		bool found = existsFile(dub.rootPath ~ "source/app.d");
-		if (!found)
-			foreach (f; packageInfoFiles)
-				if (existsFile(dub.rootPath ~ f.filename)) {
-					found = true;
-					break;
-				}
+		bool found;
+		foreach (f; packageInfoFiles)
+			if (existsFile(dub.rootPath ~ f.filename))
+			{
+				found = true;
+				break;
+			}
 
 		if (!found) {
 			if (warn_missing_package) {
 				logInfo("");
-				logInfo("Neither a package description file, nor source/app.d was found in");
+				logInfo("No package manifest (dub.json or dub.sdl) was found in");
 				logInfo(dub.rootPath.toNativeString());
 				logInfo("Please run DUB from the root directory of an existing package, or run");
 				logInfo("\"dub init --help\" to get information on creating a new package.");

--- a/test/issue1277.sh
+++ b/test/issue1277.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+cd ${CURR_DIR}/issue1003-check-empty-ld-flags
+
+# It should fail
+! ${DUB} --root=${CURR_DIR}/issue1277/ build

--- a/test/issue1277/source/app.d
+++ b/test/issue1277/source/app.d
@@ -1,0 +1,1 @@
+void main() {}


### PR DESCRIPTION
For some reason, having a 'source/app.d' was recognized as being in a package.
This would load an empty package with no manifest and send the dependency resolver
in an infinite loop.
Remove the special detection of 'source/app.d' and rely only on manifest.
Another option would have been to detect 'source/app.d' as a single-file package,
but that is a bit too much magic (the user can just 'dub run --single source/app.d').