### PR TITLE
Use build.d everywhere, fix windows build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-Build a development version of dub using either `./build.sh` or `./build.cmd` on Windows.
+You can build a development version of dub using `./build.d`.
 When you already have a working dub binary, you can also just run `dub build`, though that won't update the version string.
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DUB comes [precompiled](http://code.dlang.org/download) for Windows, OS X and Li
 
 The `dub` executable then just needs to be accessible from `PATH` and can be invoked from the root folder of any DUB enabled project to build and run it.
 
-If you want to build for yourself, just install [DMD](http://dlang.org/download.html) and libcurl development headers and run `./build.sh`. On Windows you can simply run `build.cmd` without installing anything besides DMD.
+If you want to build for yourself, just install a D compiler such as [DMD](http://dlang.org/download.html) and libcurl development headers and run `./build.d`.
 
 ### Arch Linux
 

--- a/build.d
+++ b/build.d
@@ -40,6 +40,7 @@ immutable DubBinPath = RootPath.buildPath("bin", "dub");
 // Flags for DMD
 immutable OutputFlag = "-of" ~ DubBinPath;
 immutable IncludeFlag = "-I" ~ RootPath.buildPath("source");
+immutable DefaultDFLAGS = [ "-g", "-O", "-w" ];
 
 
 /// Entry point
@@ -49,28 +50,27 @@ int main(string[] args)
     // special cases (e.g. package maintainers can use it for bootstrapping),
     // not for general / everyday usage by newcomer.
     // So the following is just an heuristic / best effort approach.
-    if (args.length > 2 ||
-        (args.length == 2 && (args[1].canFind("help", "?") || args[1] == "-h")))
+    if (args.canFind("--help", "/?", "-h"))
     {
-        writeln("USAGE: ", args[0], " [version]");
+        writeln("USAGE: ./build.d [compiler args (default:", DefaultDFLAGS, "]");
+        writeln();
         writeln("  In order to build DUB, a version module must first be generated.");
-        writeln("  If one is already existing, it won't be overriden. " ~
-                "Otherwise this script will use the first argument, if any, " ~
-                "or the GITVER environment variable.");
-        writeln("  If both are empty, `git describe` will be called");
-        writeln("  Build flags can be provided via the `DFLAGS` environment variable.");
+        writeln("  If the GITVER environment variable is present, it will be used to generate the version module.");
+        writeln("  Otherwise this script will look for a pre-existing version module.");
+        writeln("  If no GITVER is provided and no version module exists, `git describe` will be called");
+        writeln("  Build flags can be provided as arguments.");
         writeln("  LDC or GDC can be used by setting the `DMD` value to " ~
                 "`ldmd2` and `gdmd` (or their path), respectively.");
         return 1;
     }
 
-    immutable dubVersion = args.length > 1 ? args[1] : environment.get("GITVER", "");
+    immutable dubVersion = environment.get("GITVER", "");
     if (!writeVersionFile(dubVersion))
         return 1;
 
     immutable dmd = getCompiler();
     if (!dmd.length) return 1;
-    immutable dflags = environment.get("DFLAGS", "-g -O -w").split();
+    const dflags = args.length > 1 ? args[1 .. $] : DefaultDFLAGS;
 
     // Compiler says no to immutable (because it can't handle the appending)
     const command = [
@@ -79,7 +79,7 @@ int main(string[] args)
         "-version=DubUseCurl", "-version=DubApplication",
         ] ~ dflags ~ [ "@build-files.txt" ];
 
-    writeln("Building dub using ", dmd, ", this may take a while...");
+    writeln("Building dub using ", dmd, " (dflags: ", dflags, "), this may take a while...");
     auto proc = execute(command);
     if (proc.status != 0)
     {

--- a/build.d
+++ b/build.d
@@ -88,14 +88,6 @@ int main(string[] args)
         return 1;
     }
 
-    // Check dub
-    auto check = execute([DubBinPath, "--version"]);
-    if (check.status != 0)
-    {
-        writeln("Running newly built `dub` failed: ", check.output);
-        return 1;
-    }
-
     writeln("DUB has been built as: ", DubBinPath);
     version (Posix)
         writeln("You may want to run `sudo ln -s ", DubBinPath, " /usr/local/bin` now");

--- a/build.sh
+++ b/build.sh
@@ -20,4 +20,4 @@ if [ "$DMD" = "" ]; then
 	exit 1
 fi
 
-$DMD -run build.d
+$DMD -run build.d $*

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -8,17 +8,14 @@ BIN_NAME=dub
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-# Save the rdmd used to run build.d
-RDMD=$(command -v rdmd)
-
+# Setup cross compiler
 source setup-ldc-windows.sh
 
 # Run LDC with cross-compilation
 archiveName="$BIN_NAME-$VERSION-$OS-$ARCH_SUFFIX.zip"
 echo "Building $archiveName"
 mkdir -p bin
-DMD=ldmd2 ${RDMD} ./build.d -release ${DFLAGS}
+DMD=ldmd2 ldc2 -run ./build.d -release ${LDC_XDFLAGS}
 
 cd bin
-mv "${BIN_NAME}" "${BIN_NAME}.exe"
 zip "$archiveName" "${BIN_NAME}.exe"

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -8,13 +8,16 @@ BIN_NAME=dub
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
+# Save the rdmd used to run build.d
+RDMD=$(command -v rdmd)
+
 source setup-ldc-windows.sh
 
 # Run LDC with cross-compilation
 archiveName="$BIN_NAME-$VERSION-$OS-$ARCH_SUFFIX.zip"
 echo "Building $archiveName"
 mkdir -p bin
-DC=ldmd2 DFLAGS="-release" ./build.sh
+DMD=ldmd2 ${RDMD} ./build.d -release ${DFLAGS}
 
 cd bin
 mv "${BIN_NAME}" "${BIN_NAME}.exe"

--- a/release.sh
+++ b/release.sh
@@ -35,5 +35,5 @@ esac
 archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
 
 echo "Building $archiveName"
-DFLAGS="-release -m$ARCH ${CUSTOM_FLAGS[@]}" DMD="$(command -v $DMD)" ./build.sh
+DMD="$(command -v $DMD)" ./build.d -release -m$ARCH ${CUSTOM_FLAGS[@]}
 tar cvfz "bin/$archiveName" -C bin dub

--- a/scripts/rpm-package/dub.spec
+++ b/scripts/rpm-package/dub.spec
@@ -26,7 +26,7 @@ Package Manager for the D Programming language
 
 %build
 echo build
-cd %{srcpath} && ./build.sh
+cd %{srcpath} && ./build.d
 
 %install
 echo install

--- a/scripts/rpm-package/make_installer.sh
+++ b/scripts/rpm-package/make_installer.sh
@@ -3,7 +3,7 @@ set -e
 cd ../../
 DUB_PATH=`pwd`
 #rm -f ~/rpmbuild/SOURCES/dub.tar.gz
-#tar -pczf ~/rpmbuild/SOURCES/dub.tar.gz source build-files.txt build.sh LICENSE*
+#tar -pczf ~/rpmbuild/SOURCES/dub.tar.gz source build-files.txt build.d LICENSE*
 cd scripts/rpm-package/
 for i in $(git describe | tr "-" "\n"); do
 	if [ "$VER" == "" ]; then

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -8,8 +8,10 @@ vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
 dub fetch vibe-d --version=$vibe_ver # get optional dependency
 dub test --compiler=${DC} -c library-nonet
 
+export DMD="$(command -v $DMD)"
+
 if [ "$FRONTEND" \> 2.087.z ]; then
-    DFLAGS='-preview=dip1000 -w -g -debug' DMD="$(command -v $DMD)" ./build.sh
+    ./build.d -preview=dip1000 -w -g -debug
 fi
 
 function clean() {
@@ -22,12 +24,12 @@ function clean() {
 if [ "$COVERAGE" = true ]; then
     # library-nonet fails to build with coverage (Issue 13742)
     dub test --compiler=${DC} -b unittest-cov
-    ./build.sh -cov
+    ./build.d -cov
 
     wget https://codecov.io/bash -O codecov.sh
     bash codecov.sh
 else
-    ./build.sh
+    ./build.d
     DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
 fi
 


### PR DESCRIPTION
It seems easier to forward arguments from the build script this way,
and it's much more common to change the build arguments than the version.