### PR TITLE
Remove activation of the compiler in travis-ci.sh

### DIFF
--- a/semaphore-ci.sh
+++ b/semaphore-ci.sh
@@ -35,7 +35,7 @@ if  [ "${D_VERSION:-dmd}" == "gdc" ] ; then
     echo "deactivate(){ echo;}" > ~/dlang/gdc-9/activate
 
 else
-    curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 1 --retry-max-time 60 https://dlang.org/install.sh | bash -s "$D_VERSION"
+    . $(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 1 --retry-max-time 60 https://dlang.org/install.sh | bash -s "$D_VERSION" -a)
 fi
 
 ./travis-ci.sh

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -2,8 +2,6 @@
 
 set -v -e -o pipefail
 
-source ~/dlang/*/activate # activate host compiler
-
 vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
 dub fetch vibe-d --version=$vibe_ver # get optional dependency
 dub test --compiler=${DC} -c library-nonet
@@ -39,7 +37,6 @@ fi
 if [ "$COVERAGE" = true ]; then
     # run tests with different compilers
     DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
-    deactivate
     clean
 
     export FRONTEND=2.077


### PR DESCRIPTION
It is not necessary when run from Travis, as the compiler is already activated.
When run from semaphore-ci, just source it on install.
It also allows removing a custom step in dlang/ci's config.