### PR TITLE
ldc: support --arch=aarch64 and powerpc64

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -83,6 +83,8 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 			case "": break;
 			case "x86": arch_flags = ["-march=x86"]; break;
 			case "x86_64": arch_flags = ["-march=x86-64"]; break;
+			case "aarch64": arch_flags = ["-march=aarch64"]; break;
+			case "powerpc64": arch_flags = ["-march=powerpc64"]; break;
 			default:
 				if (arch_override.canFind('-'))
 					arch_flags = ["-mtriple="~arch_override];


### PR DESCRIPTION
Because Meson calls e.g. `dub describe something --arch aarch64`.

I gueeeeessss we could teach Meson to use the full triple (#1755), but this way works with `x86_64`, why shouldn't it work with other architectures. 