### PR TITLE
Fix issue 1860: Main man page does not mention subcommands

### DIFF
--- a/scripts/man/README.md
+++ b/scripts/man/README.md
@@ -8,6 +8,14 @@
 2) Preview
 ----------
 
+On Linux:
 ```shell
 man -l dub.1
+```
+
+On OSX:
+```shell
+mkdir -p man1
+mv *.1 man1
+man -M . dub
 ```

--- a/scripts/man/gen_man.d
+++ b/scripts/man/gen_man.d
@@ -73,7 +73,10 @@ void writeMainManFile(CommandArgs args, CommandGroup[] commands,
 {
 	auto manFile = File(config.cwd.buildPath(fileName), "w");
 	manFile.writeHeader("DUB", config);
-	auto seeAlso = ["dmd(1)".br, "rdmd(1)"].joiner("\n").to!string;
+	auto seeAlso = ["dmd(1)", "rdmd(1)"]
+        .chain(commands.map!(a => a.commands).joiner
+               .map!(cmd => format("dub-%s(1)", cmd.name)))
+        .joiner(", ").to!string.bold;
 	scope(exit) manFile.writeFooter(seeAlso, config);
 
 	alias writeln = (m) => manFile.writeln(m);
@@ -146,7 +149,7 @@ void writeManFile(Command command, const Config config)
 	auto manFile = File(config.cwd.buildPath(fileName), "w");
 	auto manName = format("DUB-%s", command.name).toUpper;
 	manFile.writeHeader(manName, config);
-	static immutable seeAlso = ["dmd(1)".br, "dub(1)"].joiner("\n").to!string;
+	static immutable seeAlso = ["dmd(1)", "dub(1)"].map!bold.joiner(", ").to!string;
 	scope(exit) manFile.writeFooter(seeAlso, config);
 
 	alias writeln = (m) => manFile.writeln(m);


### PR DESCRIPTION
Before (man dub):
<img width="162" alt="Screen Shot 2020-02-07 at 13 53 58" src="https://user-images.githubusercontent.com/2180215/74002102-54dc8a80-49b1-11ea-99a5-335a6c106e92.png">

After (man dub):
<img width="1505" alt="Screen Shot 2020-02-07 at 13 50 21" src="https://user-images.githubusercontent.com/2180215/74002053-2959a000-49b1-11ea-82ea-482dad2c3307.png">

Before (man dub-init):
<img width="159" alt="Screen Shot 2020-02-07 at 13 53 44" src="https://user-images.githubusercontent.com/2180215/74002107-57d77b00-49b1-11ea-9dcc-63a1b30e5604.png">

After (man dub-init):
<img width="184" alt="Screen Shot 2020-02-07 at 13 52 20" src="https://user-images.githubusercontent.com/2180215/74002039-2068ce80-49b1-11ea-9cb8-b3f66e073b3f.png">
