### PR TITLE
Add codemirror.dlang.org as the primary fallback registry.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -61,6 +61,7 @@ deprecated("use defaultRegistryURLs") enum defaultRegistryURL = defaultRegistryU
 /// The URL to the official package registry and it's default fallback registries.
 static immutable string[] defaultRegistryURLs = [
 	"https://code.dlang.org/",
+	"https://codemirror.dlang.org/",
 	"https://code-mirror.dlang.io/",
 	"https://dub-registry.herokuapp.com/",
 ];


### PR DESCRIPTION
I've migrated the registry to a dedicated server with a decent amount of RAM (64G), so that the high memory usage of the registry is not a problem anymore. The old server is now running the registry in mirror mode (which does not exhibit the memory problematic) and is available at https://codemirror.dlang.org/ as the official fallback.

This should finally provide virtually 100% uptime, especially with #1870 also present.