### PR TITLE
Default registry: add Skoppe's, remove Herokuapp

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -62,8 +62,8 @@ deprecated("use defaultRegistryURLs") enum defaultRegistryURL = defaultRegistryU
 static immutable string[] defaultRegistryURLs = [
 	"https://code.dlang.org/",
 	"https://codemirror.dlang.org/",
+	"https://dub.bytecraft.nl/",
 	"https://code-mirror.dlang.io/",
-	"https://dub-registry.herokuapp.com/",
 ];
 
 /** Returns a default list of package suppliers.


### PR DESCRIPTION
Replacement for https://github.com/dlang/dub/pull/1870 because the CI seems to be AWOL.
@s-ludwig comment addressed.