### PR TITLE
Lint: Add --report-file argument

### DIFF
--- a/changelog/lintReportFile.dd
+++ b/changelog/lintReportFile.dd
@@ -1,0 +1,5 @@
+Dub lint now supports --report-file argument.
+
+Dub lint can now be called with --report-file argument:
+dub lint --report-file report.json
+

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1051,6 +1051,7 @@ class LintCommand : PackageBuildCommand {
 		string m_errorFormat;
 		bool m_report = false;
 		string m_reportFormat;
+		string m_reportFile;
 		string[] m_importPaths;
 		string m_config;
 	}
@@ -1090,7 +1091,11 @@ class LintCommand : PackageBuildCommand {
 			"Specifies the format of the generated report."
 		]);
 
-		if (m_reportFormat) m_report = true;
+		args.getopt("report-file", &m_reportFile, [
+			"Write report to file."
+		]);
+
+		if (m_reportFormat || m_reportFile) m_report = true;
 
 		args.getopt("import-paths", &m_importPaths, [
 			"Import paths"
@@ -1117,6 +1122,7 @@ class LintCommand : PackageBuildCommand {
 		if (m_errorFormat) args ~= ["--errorFormat", m_errorFormat];
 		if (m_report) args ~= "--report";
 		if (m_reportFormat) args ~= ["--reportFormat", m_reportFormat];
+		if (m_reportFile) args ~= ["--reportFile", m_reportFile];
 		foreach (import_path; m_importPaths) args ~= ["-I", import_path];
 		if (m_config) args ~= ["--config", m_config];
 

--- a/test/issue1773-lint.sh
+++ b/test/issue1773-lint.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
-DIR=$(dirname "${BASH_SOURCE[0]}")
+cd ${CURR_DIR}/issue1773-lint
+rm -rf report.json
 
-if ! { ${DUB} lint --root ${DIR}/issue1773-lint || true; } | grep -cF "Parameter args is never used."; then
+if ! { ${DUB} lint || true; } | grep -cF "Parameter args is never used."; then
     die $LINENO 'DUB lint did not find expected warning.'
 fi
 
+${DUB} lint --report-file report.json
+if ! grep -c -e "Parameter args is never used." report.json; then
+	die $LINENO 'Linter report did not contain expected warning.'
+fi


### PR DESCRIPTION
Dub lint now supports:
`dub lint --report-file report.json`