### PR TITLE
Up the dub optional dependency to workaround code.dlang.org limitations.

### DIFF
--- a/test/issue672-upgrade-optional.sh
+++ b/test/issue672-upgrade-optional.sh
@@ -3,9 +3,9 @@
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/issue672-upgrade-optional
 rm -rf b/.dub
-echo "{\"fileVersion\": 1,\"versions\": {\"dub\": \"1.0.0\"}}" > dub.selections.json
+echo "{\"fileVersion\": 1,\"versions\": {\"dub\": \"1.5.0\"}}" > dub.selections.json
 ${DUB} upgrade
 
-if ! grep -c -e "\"dub\": \"1.1.0\"" dub.selections.json; then
+if ! grep -c -e "\"dub\": \"1.6.0\"" dub.selections.json; then
 	die $LINENO 'Dependency not upgraded.'
 fi

--- a/test/issue672-upgrade-optional/dub.sdl
+++ b/test/issue672-upgrade-optional/dub.sdl
@@ -1,2 +1,2 @@
 name "b"
-dependency "dub" version=">=1.0.0 <=1.1.0" optional=true
+dependency "dub" version=">=1.5.0 <=1.6.0" optional=true

--- a/test/issue672-upgrade-optional/dub.selections.json
+++ b/test/issue672-upgrade-optional/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dub": "1.1.0"
+		"dub": "1.5.0"
 	}
 }


### PR DESCRIPTION
buildkite is failing everywhere because of issue dlang/dub-registry#458 and dub. The altered test here just increases the tag version to a later tag that will be included in the first 100 tags from github.

Obviously dub-registry fix is preferred (and without one, this will keep happening), but this could at least get buildkite working again.