### PR TITLE
gdc: Build dub_platform_probe with -fsyntax-only

### DIFF
--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -80,7 +80,7 @@ class GDCCompiler : Compiler {
 
 		return probePlatform(
 			compiler_binary,
-			arch_flags ~ ["-S", "-v"],
+			arch_flags ~ ["-fsyntax-only", "-v"],
 			arch_override
 		);
 	}


### PR DESCRIPTION
Not quite related to #576, but the use of -S can leave tons of dub_platform_probe.S files in the project directory if left unchecked.