### PR TITLE
Make the testsuite re-runnable on OSX

### DIFF
--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -2,6 +2,13 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
+# This test messes with the user's package directory
+# Hence it's a pretty bad test, but we need it.
+# Ideally, we should not have this run by default / run it in a container.
+# In the meantime, in order to make it pass on developer's machines,
+# we need to nuke every `dub` version in the user cache...
+$DUB remove dub -n --version=* || true
+
 $DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
 $DUB fetch dub --version=1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
 if $DUB remove dub --non-interactive 2>/dev/null; then

--- a/test/issue1091-bogus-rebuild.sh
+++ b/test/issue1091-bogus-rebuild.sh
@@ -4,5 +4,6 @@
 
 cd ${CURR_DIR}/1-exec-simple
 rm -f dub.selections.json
+${DUB} clean
 ${DUB} build --compiler=${DC} 2>&1 | grep -e 'building configuration' -c
 ${DUB} build --compiler=${DC} 2>&1 | { ! grep -e 'building configuration' -c; }

--- a/test/issue1117-extra-dependency-files.sh
+++ b/test/issue1117-extra-dependency-files.sh
@@ -3,6 +3,8 @@
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/issue1117-extra-dependency-files
 
+# Ensure the test can be re-run
+${DUB} clean
 
 if ! { ${DUB} build 2>&1 || true; } | grep -cF 'building configuration'; then
 	die $LINENO 'Build was not executed.'

--- a/test/issue782-gtkd-pkg-config.sh
+++ b/test/issue782-gtkd-pkg-config.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
-if [ "${DC}" != "dmd" ]; then
+
+if [ $(uname) != "Linux" ]; then
+    echo "Skipping issue782-dtkd-pkg-config test on non-Linux platform..."
+elif [ "${DC}" != "dmd" ]; then
 	echo "Skipping issue782-dtkd-pkg-config test for ${DC}..."
 else
     echo ${CURR_DIR-$(pwd)}

--- a/test/issue877-auto-fetch-package-on-run.sh
+++ b/test/issue877-auto-fetch-package-on-run.sh
@@ -19,7 +19,8 @@ $DUB remove gitcompatibledubpackage
 $DUB run -y gitcompatibledubpackage | grep "Hello DUB"
 $DUB remove gitcompatibledubpackage
 
-(! $DUB run --non-interactive gitcompatibledubpackage) 2>&1 | grep "Failed to find.*gitcompatibledubpackage.*locally"
+(! $DUB run --non-interactive gitcompatibledubpackage || true) 2>&1 | \
+    grep "Failed to find.*gitcompatibledubpackage.*locally"
 
 # check supplying versions directly
 dub_log="$($DUB run gitcompatibledubpackage@1.0.3)"
@@ -28,7 +29,7 @@ echo "$dub_log" | grep "Fetching.*1.0.3"
 $DUB remove gitcompatibledubpackage
 
 # check supplying an invalid version
-(! $DUB run gitcompatibledubpackage@0.42.43) 2>&1 | \
+(! $DUB run gitcompatibledubpackage@0.42.43 || true) 2>&1 | \
     grep 'No package gitcompatibledubpackage was found matching the dependency 0[.]42[.]43'
 
 ! $DUB remove gitcompatibledubpackage

--- a/test/issue990-download-optional-selected.sh
+++ b/test/issue990-download-optional-selected.sh
@@ -2,6 +2,6 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/issue990-download-optional-selected
-rm -rf b/.dub
+${DUB} clean
 ${DUB} remove gitcompatibledubpackage -n --version=* 2>/dev/null || true
 ${DUB} run


### PR DESCRIPTION
This does two things:
- It makes the test-suite pass on OSX (or at least, on my machine);
- It makes some tests re-runnable so they don't fail miserably after the first run;

There's still a lot to do, like cleaning up the mess the testsuite create, or not messing up with the users packages, but one step at a time.

Part of https://github.com/dlang/dub/issues/1829