### PR TITLE
Update setup-dlang action to v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,9 @@ jobs:
 
     # Compiler to test with
     - name: Prepare compiler
-      uses: mihails-strasuns/setup-dlang@v0.5.0
+      uses: mihails-strasuns/setup-dlang@v1
       with:
         compiler: ${{ matrix.dc }}
-        gh_token: ${{ secrets.GITHUB_TOKEN }}
 
     # Checkout the repository
     - name: Checkout


### PR DESCRIPTION
Removes the need to specify the token, as it is now specified by default.