### PR TITLE
Add architecture x86_omf for windows-dmd

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -156,12 +156,6 @@ interface Compiler {
 		// cmdline option does not lead to the same string being found among
 		// `build_platform.architecture`, as it's brittle and doesn't work with triples.
 		if (build_platform.compiler != "ldc") {
-			// Hack: see #1059
-			// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
-			// This hack prevents unnesessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
-			// And also makes "x86_mscoff" available as a platform specifier in the package recipe
-			if (arch_override == "x86_mscoff")
-				build_platform.architecture ~= arch_override;
 			if (arch_override.length && !build_platform.architecture.canFind(arch_override)) {
 				logWarn(`Failed to apply the selected architecture %s. Got %s.`,
 					arch_override, build_platform.architecture);

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -54,6 +54,14 @@ enum string platformCheck = q{
 enum string archCheck = q{
 	string[] ret;
 	version(X86) ret ~= "x86";
+	// Hack: see #1535
+	// Makes "x86_omf" available as a platform specifier in the package recipe
+	version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
+	// Hack: see #1059
+	// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
+	// This hack prevents unnesessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
+	// And also makes "x86_mscoff" available as a platform specifier in the package recipe
+	version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
 	version(X86_64) ret ~= "x86_64";
 	version(ARM) ret ~= "arm";
 	version(AArch64) ret ~= "aarch64";


### PR DESCRIPTION
This pull request is in support of #1535.
#1535 is meant to point out x86_mscoff will also match x86, so it cannot specialize in omf.