### PR TITLE
Enforce proper package loading on 'dub update'. Fixes #1970.

### DIFF
--- a/changelog/enforce_proper_package_loading.dd
+++ b/changelog/enforce_proper_package_loading.dd
@@ -1,0 +1,5 @@
+Enforce proper package loading on 'dub update'
+
+Rather than doing `dub.loadPackage`, `enforce(loadCwdPackage...)` ensures that the package exists.
+This prevents `update` code from force-creating `dub.selections.json`, and generates a proper error message.
+That message is similar to one you get running `dub build` or `dub test` etc.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1747,7 +1747,7 @@ class UpgradeCommand : Command {
 		enforceUsage(free_args.length <= 1, "Unexpected arguments.");
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 		enforceUsage(!m_verify, "--verify is not yet implemented.");
-		dub.loadPackage();
+		enforce(loadCwdPackage(dub, true), "Failed to load package.");
 		logInfo("Upgrading project in %s", dub.projectPath.toNativeString());
 		auto options = UpgradeOptions.upgrade|UpgradeOptions.select;
 		if (m_missingOnly) options &= ~UpgradeOptions.upgrade;


### PR DESCRIPTION
The change is rather simple and should not break anything. Instead of manually doing `dub.loadPackage()`, `enforce(loadCwdPackage...)` ensures that a proper package file actually exists.

As an added bonus, using `enforce(loadCwdPackage...)` generates a pretty error message that is consistent to other `dub` commands! :)