### PR TITLE
Update supported compiler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,18 @@ jobs:
     - d: gdc
   include:
     - stage: test
-      d: dmd-2.090.1
-      env: [FRONTEND=2.090]
+      d: dmd-2.093.0
+      env: [FRONTEND=2.093, COVERAGE=true]
     - d: dmd-2.089.1,dub
       env: [FRONTEND=2.089]
-    - d: dmd-2.077.1,dub
-      env: [FRONTEND=2.077, COVERAGE=true]
-    - d: dmd-2.076.1,dub
-      env: [FRONTEND=2.076]
-    - d: ldc-1.20.0
+    - d: dmd-2.083.1,dub
+      env: [FRONTEND=2.083]
+    - d: ldc-1.22.0
+      env: [FRONTEND=2.092]
+    - d: ldc-1.20.0,dub
       env: [FRONTEND=2.090]
-    - d: ldc-1.19.0,dub
-      env: [FRONTEND=2.089]
     - stage: deploy
-      d: ldc-1.20.0,dub
+      d: ldc-1.22.0,dub
       os: osx
       script: echo "Deploying to GitHub releases ..." && ./scripts/ci/release.sh
       deploy:
@@ -38,7 +36,7 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: ldc-1.20.0,dub
+    - d: ldc-1.22.0,dub
       script: echo "Deploying to GitHub releases ..." && ./scripts/ci/release.sh
       env: [ARCH=32]
       addons:
@@ -54,7 +52,7 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: ldc-1.20.0,dub
+    - d: ldc-1.22.0,dub
       script: echo "Deploying to GitHub releases ..." && ./scripts/ci/release.sh
       deploy:
         - provider: releases
@@ -64,7 +62,7 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: ldc-1.20.0,dub
+    - d: ldc-1.22.0,dub
       script: echo "Deploying to GitHub releases (win32) ..." && ./scripts/ci/release-windows.sh
       addons:
         apt:
@@ -78,7 +76,7 @@ jobs:
           api_key: $GH_REPO_TOKEN
           on:
             tags: true
-    - d: ldc-1.20.0,dub
+    - d: ldc-1.22.0,dub
       script: echo "Deploying to GitHub releases (win64) ..." && ARCH=64 ./scripts/ci/release-windows.sh
       addons:
         apt:

--- a/scripts/ci/setup-ldc-windows.sh
+++ b/scripts/ci/setup-ldc-windows.sh
@@ -4,7 +4,7 @@
 
 # Make sure this version matches the version of LDC2 used in .travis.yml,
 # otherwise the compiler and the lib used might mismatch.
-LDC_VERSION="1.20.0"
+LDC_VERSION="1.22.0"
 ARCH=${ARCH:-32}
 VERSION=$(git describe --abbrev=0 --tags)
 OS=windows


### PR DESCRIPTION
Update LDC used for release from v1.20 to v1.22,
move coverage target to be the latest compiler
(so hopefully the less buggy too),
and make sure we only support the last 10 releases.