### PR TITLE
CI: Add test for building on Alpine Linux / Musl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Build files are ignored to avoid collision and large context
+# in the event someone hasn't run `dub clean` for a while
+*.a
+*.o
+.dub/
+test/*/.dub/

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,44 @@
+# Build dub on Alpine Linux, testing compatibility with Musl
+name: Alpine
+
+on:
+  pull_request:
+    branches:
+      - master
+      - stable
+  push:
+    branches:
+      - master
+      - stable
+      # Use this branch name in your fork to test changes
+      - github-actions
+
+jobs:
+  main:
+    name: Run
+    strategy:
+      # Default, disable if you want to debug
+      fail-fast: false
+      matrix:
+        include:
+# Disabled as we rely on DIP1000 `foreach (scope)` which GDC < 12 doesn't support
+#          - { dc: gdc, dcpkg: gcc-gdc, dcbin: gdc  }
+          - { dc: ldc, dcpkg: ldc,     dcbin: ldc2 }
+          - { dc: dmd, dcpkg: dmd,     dcbin: dmd  }
+
+    # OS doesn't matter, we just need Docker
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout the repository
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: |
+        docker build -t alpine-dub-image \
+          --build-arg="DCPKG=${{ matrix.dcpkg}}" \
+          --build-arg="DCBIN=${{ matrix.dcbin}}" \
+          -f docker/Dockerfile.alpine $(pwd)
+
+    - name: Test
+      run: docker run alpine-dub-image

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,23 @@
+FROM alpine:edge AS Builder
+
+# DCPKG is the name of the package, DCBIN the name of the binary
+# We need this because of the ldc / ldc2 disparity
+ARG DCPKG
+ARG DCBIN
+
+# Build dub (and install tests dependencies in the process)
+WORKDIR /root/build/
+RUN apk add --no-cache bash build-base curl curl-dev dtools dub git grep rsync $DCPKG
+ADD . /root/build/
+RUN dub test --compiler=$DCBIN && dub build --compiler=$DCBIN
+
+# Remove dub to avoid the risk of using the wrong binary
+RUN apk del dub
+
+# Used by the `run-unittest.sh` script
+ENV DUB=/root/build/bin/dub
+ENV DC=$DCBIN
+
+# Finally, just run the test-suite
+WORKDIR /root/build/test/
+ENTRYPOINT [ "/root/build/test/run-unittest.sh" ]

--- a/test/issue1408-inherit-linker-files/dub.sdl
+++ b/test/issue1408-inherit-linker-files/dub.sdl
@@ -10,5 +10,5 @@ subPackage {
 	sourceFiles "dep.d"
 	sourceFiles "lib/liblib.a" platform="posix"
 	sourceFiles "lib/lib.lib" platform="windows"
-	preBuildCommands "dub build --root=\"$PACKAGE_DIR/lib\""
+	preBuildCommands "$DUB_EXE build --root=\"$PACKAGE_DIR/lib\""
 }


### PR DESCRIPTION
Tried to upgrade the Alpine Musl package, realized it was broken. So might as well do this.
It also found some issues in the testsuite, so it's an instant win.
This will fail the CI, just putting it up there in case someone is interested / has suggestions.