### PR TITLE
Make 'dub remove' remove all packages by default in non-interactive mode 

### DIFF
--- a/changelog/dub-remove.dd
+++ b/changelog/dub-remove.dd
@@ -1,0 +1,9 @@
+`dub remove --non-interactive` will now remove all packages by default
+
+When calling a command with a package name and no version specification,
+the latest version is usually assumed.
+While this behavior makes sense for `dub fetch` or `dub run`,
+it can come  as a surprise when cleaning up local packages through `dub remove`,
+and so previous version would simply error out when more than one version was available.
+From this version, `dub remove -n $PKGNAME` will just remove all cached versions
+of the package named `$PKGNAME`, without asking you to use `$PKGNAME@*`.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1026,17 +1026,9 @@ class Dub {
 	void remove(string package_id, string version_, PlacementLocation location)
 	{
 		remove(package_id, location, (in packages) {
-			if (version_ == RemoveVersionWildcard)
+			if (version_ == RemoveVersionWildcard || version_.empty)
 				return packages.length;
-			if (version_.empty && packages.length > 1) {
-				logError("Cannot remove package '" ~ package_id ~ "', there are multiple possibilities at location\n"
-						 ~ "'" ~ to!string(location) ~ "'.");
-				logError("Available versions:");
-				foreach(pack; packages)
-					logError("  %s", pack.version_);
-				throw new Exception("Please specify a individual version using --version=... or use the"
-									~ " wildcard --version=" ~ RemoveVersionWildcard ~ " to remove all versions.");
-			}
+
 			foreach (i, p; packages) {
 				if (p.version_ == Version(version_))
 					return i;

--- a/test/fetchzip.sh
+++ b/test/fetchzip.sh
@@ -5,7 +5,7 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 PORT=$(getRandomPort)
 
-$DUB remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null || true
+$DUB remove gitcompatibledubpackage --non-interactive 2>/dev/null || true
 
 "$DUB" build --single "$DIR"/test_registry.d
 "$DIR"/test_registry --folder="$DIR/issue1336-registry" --port=$PORT &
@@ -32,7 +32,7 @@ if ! zipCount=$(grep -Fc 'Failed to extract zip archive' <<<"$zipOut") || [ "$zi
 elif [ $rc -eq 124 ]; then
     die 'DUB timed out unexpectedly.'
 fi
-if dub remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null; then
+if dub remove gitcompatibledubpackage --non-interactive 2>/dev/null; then
     die 'DUB should not have installed a broken package.'
 fi
 
@@ -47,7 +47,7 @@ if ! retryCount=$(echo "$retryOut" | grep -Fc 'Bad Gateway') || [ "$retryCount" 
 elif [ $rc -eq 124 ]; then
     die 'DUB timed out unexpectedly.'
 fi
-if $DUB remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null; then
+if $DUB remove gitcompatibledubpackage --non-interactive 2>/dev/null; then
     die 'DUB should not have installed a package.'
 fi
 

--- a/test/fetchzip.sh
+++ b/test/fetchzip.sh
@@ -5,7 +5,7 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 PORT=$(getRandomPort)
 
-dub remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null || true
+$DUB remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null || true
 
 "$DUB" build --single "$DIR"/test_registry.d
 "$DIR"/test_registry --folder="$DIR/issue1336-registry" --port=$PORT &
@@ -18,7 +18,7 @@ timeout 1s "$DUB" fetch gitcompatibledubpackage --version=1.0.4 --skip-registry=
 if [ $? -eq 124 ]; then
     die 'Fetching from responsive registry should not time-out.'
 fi
-dub remove gitcompatibledubpackage --non-interactive --version=1.0.4
+$DUB remove gitcompatibledubpackage --non-interactive --version=1.0.4
 
 echo "Downloads should be retried when the zip is corrupted - gitcompatibledubpackage (1.0.3)"
 zipOut=$(! timeout 1s "$DUB" fetch gitcompatibledubpackage --version=1.0.3 --skip-registry=all --registry=http://localhost:$PORT 2>&1)
@@ -47,7 +47,7 @@ if ! retryCount=$(echo "$retryOut" | grep -Fc 'Bad Gateway') || [ "$retryCount" 
 elif [ $rc -eq 124 ]; then
     die 'DUB timed out unexpectedly.'
 fi
-if dub remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null; then
+if $DUB remove gitcompatibledubpackage --non-interactive --version=* 2>/dev/null; then
     die 'DUB should not have installed a package.'
 fi
 
@@ -56,4 +56,4 @@ timeout 1s "$DUB" fetch gitcompatibledubpackage --version=1.0.2 --skip-registry=
 if [ $? -eq 124 ]; then
     die 'Fetching from responsive registry should not time-out.'
 fi
-dub remove gitcompatibledubpackage --non-interactive --version=1.0.2
+$DUB remove gitcompatibledubpackage --non-interactive --version=1.0.2

--- a/test/help.sh
+++ b/test/help.sh
@@ -2,8 +2,6 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
-DUB=dub
-
 ### It shows the general help message
 if ! { ${DUB} help | grep "Manages the DUB project in the current directory."; } then
     die 'DUB did not print the default help message, with the `help` command.'

--- a/test/interactive-remove.sh
+++ b/test/interactive-remove.sh
@@ -7,32 +7,34 @@
 # Ideally, we should not have this run by default / run it in a container.
 # In the meantime, in order to make it pass on developer's machines,
 # we need to nuke every `dub` version in the user cache...
-$DUB remove dub -n --version=* || true
+$DUB remove dub -n || true
 
 $DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
 $DUB fetch dub --version=1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
-if $DUB remove dub --non-interactive 2>/dev/null; then
-    die $LINENO 'Non-interactive remove should fail'
-fi
+
 echo 1 | $DUB remove dub | tr -d '\n' | grep --ignore-case 'select.*1\.9\.0.*1\.10\.0.*'
 if [ -d $HOME/.dub/packages/dub-1.9.0/dub ]; then
     die $LINENO 'Failed to remove dub-1.9.0'
 fi
+
 $DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
 # EOF aborts remove
 echo -xn '' | $DUB remove dub
 if [ ! -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ ! -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Aborted dub still removed a package'
 fi
+
 # validates input
 echo -e 'abc\n4\n-1\n3' | $DUB remove dub
 if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Failed to remove all version of dub'
 fi
+
 $DUB fetch dub --version=1.9.0 && [ -d $HOME/.dub/packages/dub-1.9.0/dub ]
 $DUB fetch dub@1.10.0 && [ -d $HOME/.dub/packages/dub-1.10.0/dub ]
-# is non-interactive with --version=
-$DUB remove dub --version=\*
+# is non-interactive with `--version=<version-spec>`
+$DUB remove dub@1.9.0
+$DUB remove dub@1.10.0
 if [ -d $HOME/.dub/packages/dub-1.9.0/dub ] || [ -d $HOME/.dub/packages/dub-1.10.0/dub ]; then
     die $LINENO 'Failed to non-interactively remove specified versions'
 fi

--- a/test/issue1180-local-cache-broken.sh
+++ b/test/issue1180-local-cache-broken.sh
@@ -5,7 +5,7 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 PORT=$(getRandomPort)
 
-"$DUB" remove maven-dubpackage --root="$DIR/issue1180-local-cache-broken" --non-interactive --version=* 2>/dev/null || true
+"$DUB" remove maven-dubpackage --root="$DIR/issue1180-local-cache-broken" --non-interactive 2>/dev/null || true
 
 "$DUB" build --single "$DIR"/test_registry.d
 "$DIR"/test_registry --folder="$DIR/issue1416-maven-repo-pkg-supplier" --port=$PORT &

--- a/test/issue1401-filesystem-supplier.sh
+++ b/test/issue1401-filesystem-supplier.sh
@@ -3,8 +3,8 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 . "$DIR"/common.sh
 
-dub remove fs-json-dubpackage --non-interactive --version=* 2>/dev/null || true
-dub remove fs-sdl-dubpackage --non-interactive --version=* 2>/dev/null || true
+dub remove fs-json-dubpackage --non-interactive 2>/dev/null || true
+dub remove fs-sdl-dubpackage --non-interactive 2>/dev/null || true
 
 echo "Trying to get fs-sdl-dubpackage (1.0.5)"
 "$DUB" fetch fs-sdl-dubpackage --version=1.0.5 --skip-registry=all --registry=file://"$DIR"/issue1401-file-system-pkg-supplier

--- a/test/issue1416-maven-repo-pkg-supplier.sh
+++ b/test/issue1416-maven-repo-pkg-supplier.sh
@@ -5,7 +5,7 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 PORT=$(getRandomPort)
 
-dub remove maven-dubpackage --non-interactive --version=* 2>/dev/null || true
+$DUB remove maven-dubpackage --non-interactive 2>/dev/null || true
 
 "$DUB" build --single "$DIR"/test_registry.d
 "$DIR"/test_registry --folder="$DIR/issue1416-maven-repo-pkg-supplier" --port=$PORT &

--- a/test/issue1524-maven-upgrade-dependency-tree.sh
+++ b/test/issue1524-maven-upgrade-dependency-tree.sh
@@ -5,8 +5,8 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 PORT=$(getRandomPort)
 
-dub remove maven-dubpackage-a --non-interactive --version=* 2>/dev/null || true
-dub remove maven-dubpackage-b --non-interactive --version=* 2>/dev/null || true
+dub remove maven-dubpackage-a --non-interactive 2>/dev/null || true
+dub remove maven-dubpackage-b --non-interactive 2>/dev/null || true
 
 "$DUB" build --single "$DIR"/test_registry.d
 "$DIR"/test_registry --folder="$DIR/issue1524-maven-upgrade-dependency-tree" --port=$PORT &

--- a/test/issue1556-fetch-and-build.sh
+++ b/test/issue1556-fetch-and-build.sh
@@ -3,8 +3,8 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 
 . "$DIR"/common.sh
 
-dub remove main-package --non-interactive --version=* 2>/dev/null || true
-dub remove dependency-package --non-interactive --version=* 2>/dev/null || true
+dub remove main-package --non-interactive 2>/dev/null || true
+dub remove dependency-package --non-interactive 2>/dev/null || true
 
 
 echo "Trying to fetch fs-sdl-dubpackage"

--- a/test/issue1567-fetch-sub-package.sh
+++ b/test/issue1567-fetch-sub-package.sh
@@ -4,7 +4,7 @@ DIR=$(dirname "${BASH_SOURCE[0]}")
 packname="fetch-sub-package-dubpackage"
 sub_packagename="my-sub-package"
 
-$DUB remove $packname --non-interactive --version=* 2>/dev/null || true
+$DUB remove $packname --non-interactive 2>/dev/null || true
 $DUB fetch "$packname:$sub_packagename" --skip-registry=all --registry=file://"$DIR"/issue1567-fetch-sub-package
 
 if ! dub remove $packname --non-interactive --version=1.0.1 2>/dev/null; then

--- a/test/issue1651-custom-dub-init-type.sh
+++ b/test/issue1651-custom-dub-init-type.sh
@@ -3,7 +3,7 @@
 DIR=$(dirname "${BASH_SOURCE[0]}")
 packname="custom-dub-init-type-sample"
 
-$DUB remove custom-dub-init-dubpackage --non-interactive --version=* 2>/dev/null || true
+$DUB remove custom-dub-init-dubpackage --non-interactive 2>/dev/null || true
 $DUB init -n $packname --format sdl -t custom-dub-init-dubpackage --skip-registry=all --registry=file://"$DIR"/issue1651-custom-dub-init-type -- --foo=bar
 
 function cleanup {

--- a/test/issue990-download-optional-selected.sh
+++ b/test/issue990-download-optional-selected.sh
@@ -3,5 +3,5 @@
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/issue990-download-optional-selected
 ${DUB} clean
-${DUB} remove gitcompatibledubpackage -n --version=* 2>/dev/null || true
+${DUB} remove gitcompatibledubpackage -n 2>/dev/null || true
 ${DUB} run


### PR DESCRIPTION
This is a new feature that simplify writing scripts a tiny bit.
Also included one fix from my Alpine PR since otherwise the lack of `--version` could error out.