### PR TITLE
Remove redundant COND || false statement in tests

### DIFF
--- a/test/version-spec.sh
+++ b/test/version-spec.sh
@@ -5,29 +5,29 @@
 $DUB add-local "$CURR_DIR/version-spec/newfoo"
 $DUB add-local "$CURR_DIR/version-spec/oldfoo"
 
-[[ $($DUB describe foo | grep path | head -1) == *"/newfoo/"* ]] || false
-[[ $($DUB describe foo@1.0.0 | grep path | head -1) == *"/newfoo/"* ]] || false
-[[ $($DUB describe foo@0.1.0 | grep path | head -1) == *"/oldfoo/"* ]] || false
+[[ $($DUB describe foo | grep path | head -1) == *"/newfoo/"* ]]
+[[ $($DUB describe foo@1.0.0 | grep path | head -1) == *"/newfoo/"* ]]
+[[ $($DUB describe foo@0.1.0 | grep path | head -1) == *"/oldfoo/"* ]]
 
-[[ $($DUB test foo | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB test foo@1.0.0 | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB test foo@0.1.0 | head -1) == *"/oldfoo/" ]] || false
+[[ $($DUB test foo | head -1) == *"/newfoo/" ]]
+[[ $($DUB test foo@1.0.0 | head -1) == *"/newfoo/" ]]
+[[ $($DUB test foo@0.1.0 | head -1) == *"/oldfoo/" ]]
 
-[[ $($DUB lint foo | tail -1) == *"/newfoo/" ]] || false
-[[ $($DUB lint foo@1.0.0 | tail -1) == *"/newfoo/" ]] || false
-[[ $($DUB lint foo@0.1.0 | tail -1) == *"/oldfoo/" ]] || false
+[[ $($DUB lint foo | tail -1) == *"/newfoo/" ]]
+[[ $($DUB lint foo@1.0.0 | tail -1) == *"/newfoo/" ]]
+[[ $($DUB lint foo@0.1.0 | tail -1) == *"/oldfoo/" ]]
 
-[[ $($DUB generate cmake foo | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB generate cmake foo@1.0.0 | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB generate cmake foo@0.1.0 | head -1) == *"/oldfoo/" ]] || false
+[[ $($DUB generate cmake foo | head -1) == *"/newfoo/" ]]
+[[ $($DUB generate cmake foo@1.0.0 | head -1) == *"/newfoo/" ]]
+[[ $($DUB generate cmake foo@0.1.0 | head -1) == *"/oldfoo/" ]]
 
-[[ $($DUB build -n foo | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB build -n foo@1.0.0 | head -1) == *"/newfoo/" ]] || false
-[[ $($DUB build -n foo@0.1.0 | head -1) == *"/oldfoo/" ]] || false
+[[ $($DUB build -n foo | head -1) == *"/newfoo/" ]]
+[[ $($DUB build -n foo@1.0.0 | head -1) == *"/newfoo/" ]]
+[[ $($DUB build -n foo@0.1.0 | head -1) == *"/oldfoo/" ]]
 
-[[ $($DUB run -n foo | tail -1) == 'new-foo' ]] || false
-[[ $($DUB run -n foo@1.0.0 | tail -1) == 'new-foo' ]] || false
-[[ $($DUB run -n foo@0.1.0 | tail -1) == 'old-foo' ]] || false
+[[ $($DUB run -n foo | tail -1) == 'new-foo' ]]
+[[ $($DUB run -n foo@1.0.0 | tail -1) == 'new-foo' ]]
+[[ $($DUB run -n foo@0.1.0 | tail -1) == 'old-foo' ]]
 
 $DUB remove-local "$CURR_DIR/version-spec/newfoo"
 $DUB remove-local "$CURR_DIR/version-spec/oldfoo"


### PR DESCRIPTION
I'm seeing some weird failures in my other PRs so splitting this to make sure `master` still works...