### PR TITLE
version-spec: Use non-obsolete syntax for head/tail

### DIFF
--- a/test/version-spec.sh
+++ b/test/version-spec.sh
@@ -5,29 +5,29 @@
 $DUB add-local "$CURR_DIR/version-spec/newfoo"
 $DUB add-local "$CURR_DIR/version-spec/oldfoo"
 
-[[ $($DUB describe foo | grep path | head -1) == *"/newfoo/"* ]]
-[[ $($DUB describe foo@1.0.0 | grep path | head -1) == *"/newfoo/"* ]]
-[[ $($DUB describe foo@0.1.0 | grep path | head -1) == *"/oldfoo/"* ]]
+[[ $($DUB describe foo | grep path | head -n 1) == *"/newfoo/"* ]]
+[[ $($DUB describe foo@1.0.0 | grep path | head -n 1) == *"/newfoo/"* ]]
+[[ $($DUB describe foo@0.1.0 | grep path | head -n 1) == *"/oldfoo/"* ]]
 
-[[ $($DUB test foo | head -1) == *"/newfoo/" ]]
-[[ $($DUB test foo@1.0.0 | head -1) == *"/newfoo/" ]]
-[[ $($DUB test foo@0.1.0 | head -1) == *"/oldfoo/" ]]
+[[ $($DUB test foo | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB test foo@1.0.0 | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB test foo@0.1.0 | head -n 1) == *"/oldfoo/" ]]
 
-[[ $($DUB lint foo | tail -1) == *"/newfoo/" ]]
-[[ $($DUB lint foo@1.0.0 | tail -1) == *"/newfoo/" ]]
-[[ $($DUB lint foo@0.1.0 | tail -1) == *"/oldfoo/" ]]
+[[ $($DUB lint foo | tail -n 1) == *"/newfoo/" ]]
+[[ $($DUB lint foo@1.0.0 | tail -n 1) == *"/newfoo/" ]]
+[[ $($DUB lint foo@0.1.0 | tail -n 1) == *"/oldfoo/" ]]
 
-[[ $($DUB generate cmake foo | head -1) == *"/newfoo/" ]]
-[[ $($DUB generate cmake foo@1.0.0 | head -1) == *"/newfoo/" ]]
-[[ $($DUB generate cmake foo@0.1.0 | head -1) == *"/oldfoo/" ]]
+[[ $($DUB generate cmake foo | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB generate cmake foo@1.0.0 | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB generate cmake foo@0.1.0 | head -n 1) == *"/oldfoo/" ]]
 
-[[ $($DUB build -n foo | head -1) == *"/newfoo/" ]]
-[[ $($DUB build -n foo@1.0.0 | head -1) == *"/newfoo/" ]]
-[[ $($DUB build -n foo@0.1.0 | head -1) == *"/oldfoo/" ]]
+[[ $($DUB build -n foo | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB build -n foo@1.0.0 | head -n 1) == *"/newfoo/" ]]
+[[ $($DUB build -n foo@0.1.0 | head -n 1) == *"/oldfoo/" ]]
 
-[[ $($DUB run -n foo | tail -1) == 'new-foo' ]]
-[[ $($DUB run -n foo@1.0.0 | tail -1) == 'new-foo' ]]
-[[ $($DUB run -n foo@0.1.0 | tail -1) == 'old-foo' ]]
+[[ $($DUB run -n foo | tail -n 1) == 'new-foo' ]]
+[[ $($DUB run -n foo@1.0.0 | tail -n 1) == 'new-foo' ]]
+[[ $($DUB run -n foo@0.1.0 | tail -n 1) == 'old-foo' ]]
 
 $DUB remove-local "$CURR_DIR/version-spec/newfoo"
 $DUB remove-local "$CURR_DIR/version-spec/oldfoo"


### PR DESCRIPTION
```
This syntax is hardly documented, with the Linux manpage saying:
> For backwards compatibility, `-number` is equivalent to `-n number`.
http://schillix.sourceforge.net/man/man1/head.1.html
While some other man pages either don't mention it or call it obsolete.
For maximum compatibility, just use `-n 1`.
```

Doubt that's the cause of the failure, but had to go to stackoverflow to learn about this syntax: https://unix.stackexchange.com/questions/467157/why-isnt-head-1-equivalent-with-head-n-1-but-instead-its-the-same-as-h