### PR TITLE
Testsuite: Fix calls to die to always include line numbers

### DIFF
--- a/test/4-describe-data-2-dmd.sh
+++ b/test/4-describe-data-2-dmd.sh
@@ -29,7 +29,7 @@ if ! $DUB describe --compiler=$DC --filter-versions \
     --data=import-files \
     --data=options \
     > "$temp_file"; then
-    die 'Printing project data failed!'
+    die $LINENO 'Printing project data failed!'
 fi
 
 # Create the expected output path file to compare against.
@@ -79,6 +79,6 @@ echo -n "-wi" >> "$expected_file"
 echo "" >> "$expected_file"
 
 if ! diff "$expected_file" "$temp_file"; then
-    die 'The project data did not match the expected output!'
+    die $LINENO 'The project data did not match the expected output!'
 fi
 

--- a/test/4-describe-data-3-zero-delim.sh
+++ b/test/4-describe-data-3-zero-delim.sh
@@ -40,7 +40,7 @@ if ! $DUB describe --compiler=$DC --data-list \
     --data=requirements \
     --data=options \
     > "$temp_file_normal"; then
-    die 'Printing list-style project data failed!'
+    die $LINENO 'Printing list-style project data failed!'
 fi
 
 if ! $DUB describe --compiler=$DC --data-0 --data-list \
@@ -68,26 +68,26 @@ if ! $DUB describe --compiler=$DC --data-0 --data-list \
     --data=requirements \
     --data=options \
     | xargs -0 printf "%s\n" > "$temp_file_zero_delim"; then
-    die 'Printing null-delimited list-style project data failed!'
+    die $LINENO 'Printing null-delimited list-style project data failed!'
 fi
 
 if ! diff -b -B "$temp_file_normal" "$temp_file_zero_delim"; then
-    die 'The null-delimited list-style project data did not match the expected output!'
+    die $LINENO 'The null-delimited list-style project data did not match the expected output!'
 fi
 
 # Test --import-paths
 if ! $DUB describe --compiler=$DC --import-paths \
     > "$temp_file_normal"; then
-    die 'Printing --import-paths failed!'
+    die $LINENO 'Printing --import-paths failed!'
 fi
 
 if ! $DUB describe --compiler=$DC --data-0 --import-paths \
     | xargs -0 printf "%s\n" > "$temp_file_zero_delim"; then
-    die 'Printing null-delimited --import-paths failed!'
+    die $LINENO 'Printing null-delimited --import-paths failed!'
 fi
 
 if ! diff -b -B "$temp_file_normal" "$temp_file_zero_delim"; then
-    die 'The null-delimited --import-paths data did not match the expected output!'
+    die $LINENO 'The null-delimited --import-paths data did not match the expected output!'
 fi
 
 # DMD-only beyond this point
@@ -99,29 +99,29 @@ fi
 # Test dmd-style --data=versions
 if ! $DUB describe --compiler=$DC --data=versions \
     > "$temp_file_normal"; then
-    die 'Printing dmd-style --data=versions failed!'
+    die $LINENO 'Printing dmd-style --data=versions failed!'
 fi
 
 if ! $DUB describe --compiler=$DC --data-0 --data=versions \
     | xargs -0 printf "%s " > "$temp_file_zero_delim"; then
-    die 'Printing null-delimited dmd-style --data=versions failed!'
+    die $LINENO 'Printing null-delimited dmd-style --data=versions failed!'
 fi
 
 if ! diff -b -B "$temp_file_normal" "$temp_file_zero_delim"; then
-    die 'The null-delimited dmd-style --data=versions did not match the expected output!'
+    die $LINENO 'The null-delimited dmd-style --data=versions did not match the expected output!'
 fi
 
 # Test dmd-style --data=source-files
 if ! $DUB describe --compiler=$DC --data=source-files \
     > "$temp_file_normal"; then
-    die 'Printing dmd-style --data=source-files failed!'
+    die $LINENO 'Printing dmd-style --data=source-files failed!'
 fi
 
 if ! $DUB describe --compiler=$DC --data-0 --data=source-files \
     | xargs -0 printf "'%s' " > "$temp_file_zero_delim"; then
-    die 'Printing null-delimited dmd-style --data=source-files failed!'
+    die $LINENO 'Printing null-delimited dmd-style --data=source-files failed!'
 fi
 
 if ! diff -b -B "$temp_file_normal" "$temp_file_zero_delim"; then
-    die 'The null-delimited dmd-style --data=source-files did not match the expected output!'
+    die $LINENO 'The null-delimited dmd-style --data=source-files did not match the expected output!'
 fi

--- a/test/4-describe-import-paths.sh
+++ b/test/4-describe-import-paths.sh
@@ -13,7 +13,7 @@ function cleanup {
 trap cleanup EXIT
 
 if ! $DUB describe --compiler=$DC --import-paths > "$temp_file"; then
-    die 'Printing import paths failed!'
+    die $LINENO 'Printing import paths failed!'
 fi
 
 # Create the expected output path file to compare against.
@@ -23,6 +23,6 @@ echo "$CURR_DIR/describe-dependency-2/some-path/" >> "$CURR_DIR/expected-import-
 echo "$CURR_DIR/describe-dependency-3/dep3-source/" >> "$CURR_DIR/expected-import-path-output"
 
 if ! diff "$CURR_DIR"/expected-import-path-output "$temp_file"; then
-    die 'The import paths did not match the expected output!'
+    die $LINENO 'The import paths did not match the expected output!'
 fi
 

--- a/test/4-describe-json.sh
+++ b/test/4-describe-json.sh
@@ -13,6 +13,6 @@ function cleanup {
 trap cleanup EXIT
 
 if ! $DUB describe --compiler=$DC > "$temp_file"; then
-    die 'Printing describe JSON failed!'
+    die $LINENO 'Printing describe JSON failed!'
 fi
 

--- a/test/4-describe-string-import-paths.sh
+++ b/test/4-describe-string-import-paths.sh
@@ -13,7 +13,7 @@ function cleanup {
 trap cleanup EXIT
 
 if ! $DUB describe --compiler=$DC --string-import-paths > "$temp_file"; then
-    die 'Printing string import paths failed!'
+    die $LINENO 'Printing string import paths failed!'
 fi
 
 # Create the expected output path file to compare against.
@@ -22,6 +22,6 @@ echo "$CURR_DIR/describe-dependency-2/some-extra-string-import-path/" >> "$CURR_
 echo "$CURR_DIR/describe-dependency-3/dep3-string-import-path/" >> "$CURR_DIR/expected-string-import-path-output"
 
 if ! diff "$CURR_DIR"/expected-string-import-path-output "$temp_file"; then
-    die 'The string import paths did not match the expected output!'
+    die $LINENO 'The string import paths did not match the expected output!'
 fi
 

--- a/test/dustmite-no-redirect.sh
+++ b/test/dustmite-no-redirect.sh
@@ -20,7 +20,7 @@ $DUB --root=$DM_TEST dustmite --no-redirect --program-status=1 $DM_TMP &> $LOG |
 if ! grep -q "$EXPECTED" "$LOG"
 then
     cat $LOG
-    die 1
+    die $LINENO "Diff between expected and actual output"
 fi
 
 rm -rf $DM_TMP $DM_TMP.* $LOG

--- a/test/fetchzip.sh
+++ b/test/fetchzip.sh
@@ -16,7 +16,7 @@ trap 'kill $PID 2>/dev/null || true' exit
 echo "Trying to download gitcompatibledubpackage (1.0.4)"
 timeout 1s "$DUB" fetch gitcompatibledubpackage --version=1.0.4 --skip-registry=all --registry=http://localhost:$PORT
 if [ $? -eq 124 ]; then
-    die 'Fetching from responsive registry should not time-out.'
+    die $LINENO 'Fetching from responsive registry should not time-out.'
 fi
 $DUB remove gitcompatibledubpackage --non-interactive --version=1.0.4
 
@@ -28,12 +28,12 @@ if ! zipCount=$(grep -Fc 'Failed to extract zip archive' <<<"$zipOut") || [ "$zi
     echo '========== +Output was ==========' >&2
     echo "$zipOut" >&2
     echo '========== -Output was ==========' >&2
-    die 'DUB should have tried to download the zip archive multiple times.'
+    die $LINENO 'DUB should have tried to download the zip archive multiple times.'
 elif [ $rc -eq 124 ]; then
-    die 'DUB timed out unexpectedly.'
+    die $LINENO 'DUB timed out unexpectedly.'
 fi
 if dub remove gitcompatibledubpackage --non-interactive 2>/dev/null; then
-    die 'DUB should not have installed a broken package.'
+    die $LINENO 'DUB should not have installed a broken package.'
 fi
 
 echo "HTTP status errors on downloads should be retried - gitcompatibledubpackage (1.0.2)"
@@ -43,17 +43,17 @@ if ! retryCount=$(echo "$retryOut" | grep -Fc 'Bad Gateway') || [ "$retryCount" 
     echo '========== +Output was ==========' >&2
     echo "$retryOut" >&2
     echo '========== -Output was ==========' >&2
-    die "DUB should have retried download on server error multiple times, but only tried $retryCount times."
+    die $LINENO "DUB should have retried download on server error multiple times, but only tried $retryCount times."
 elif [ $rc -eq 124 ]; then
-    die 'DUB timed out unexpectedly.'
+    die $LINENO 'DUB timed out unexpectedly.'
 fi
 if $DUB remove gitcompatibledubpackage --non-interactive 2>/dev/null; then
-    die 'DUB should not have installed a package.'
+    die $LINENO 'DUB should not have installed a package.'
 fi
 
 echo "HTTP status errors on downloads should retry with fallback mirror - gitcompatibledubpackage (1.0.2)"
 timeout 1s "$DUB" fetch gitcompatibledubpackage --version=1.0.2 --skip-registry=all --registry="http://localhost:$PORT http://localhost:$PORT/fallback"
 if [ $? -eq 124 ]; then
-    die 'Fetching from responsive registry should not time-out.'
+    die $LINENO 'Fetching from responsive registry should not time-out.'
 fi
 $DUB remove gitcompatibledubpackage --non-interactive --version=1.0.2

--- a/test/help.sh
+++ b/test/help.sh
@@ -4,22 +4,22 @@
 
 ### It shows the general help message
 if ! { ${DUB} help | grep "Manages the DUB project in the current directory."; } then
-    die 'DUB did not print the default help message, with the `help` command.'
+    die $LINENO 'DUB did not print the default help message, with the `help` command.'
 fi
 
 if ! { ${DUB} -h | grep "Manages the DUB project in the current directory."; } then
-    die 'DUB did not print the default help message, with the `-h` argument.'
+    die $LINENO 'DUB did not print the default help message, with the `-h` argument.'
 fi
 
 if ! { ${DUB} --help | grep "Manages the DUB project in the current directory."; } then
-    die 'DUB did not print the default help message, with the `--help` argument.'
+    die $LINENO 'DUB did not print the default help message, with the `--help` argument.'
 fi
 
 ### It shows the build command help
 if ! { ${DUB} build -h | grep "Builds a package"; } then
-    die 'DUB did not print the build help message, with the `-h` argument.'
+    die $LINENO 'DUB did not print the build help message, with the `-h` argument.'
 fi
 
 if ! { ${DUB} build --help | grep "Builds a package"; } then
-    die 'DUB did not print the build help message, with the `--help` argument.'
+    die $LINENO 'DUB did not print the build help message, with the `--help` argument.'
 fi

--- a/test/issue1037-better-dependency-messages.sh
+++ b/test/issue1037-better-dependency-messages.sh
@@ -19,7 +19,7 @@ sed "s#DIR#$CURR_DIR/issue1037-better-dependency-messages#" "$expected_file" > "
 $DUB upgrade 2>$temp_file && exit 1 # dub upgrade should fail
 
 if ! diff "$temp_file2" "$temp_file"; then
-    die 'output not containing conflict information'
+    die $LINENO 'output not containing conflict information'
 fi
 
 exit 0

--- a/test/issue1180-local-cache-broken.sh
+++ b/test/issue1180-local-cache-broken.sh
@@ -17,5 +17,5 @@ echo "Trying to download maven-dubpackage (1.0.5)"
 "$DUB" upgrade --root="$DIR/issue1180-local-cache-broken" --cache=local --skip-registry=all --registry=mvn+http://localhost:$PORT/maven/release/dubpackages
 
 if ! "$DUB" remove maven-dubpackage --root="$DIR/issue1180-local-cache-broken" --non-interactive --version=1.0.5 2>/dev/null; then
-    die 'DUB did not install package from maven registry.'
+    die $LINENO 'DUB did not install package from maven registry.'
 fi

--- a/test/issue1372-ignore-files-in-hidden-dirs.sh
+++ b/test/issue1372-ignore-files-in-hidden-dirs.sh
@@ -12,7 +12,7 @@ rm -rf ${BASEDIR}/issue1372
 echo "Compile and ignore hidden directories"
 ${DUB} build --root ${BASEDIR} --config=normal --force
 OUTPUT=`${BASEDIR}/issue1372`
-if [[ "$OUTPUT" != "no hidden file compiled" ]]; then die "Normal compilation failed"; fi
+if [[ "$OUTPUT" != "no hidden file compiled" ]]; then die $LINENO "Normal compilation failed"; fi
 
 rm -rf ${BASEDIR}/.dub
 rm -rf ${BASEDIR}/issue1372
@@ -22,7 +22,7 @@ echo "Compile and explcitly include file in hidden directories"
 ${DUB} build --root ${BASEDIR} --config=hiddenfile --force
 OUTPUT=`${BASEDIR}/issue1372`
 
-if [[ "$OUTPUT" != "hidden file compiled" ]]; then die "Hidden file compilation failed"; fi
+if [[ "$OUTPUT" != "hidden file compiled" ]]; then die $LINENO "Hidden file compilation failed"; fi
 
 rm -rf ${BASEDIR}/.dub
 rm -rf ${BASEDIR}/issue1372
@@ -31,7 +31,7 @@ echo "Compile and explcitly include extra hidden directories"
 ${DUB} build --root ${BASEDIR} --config=hiddendir --force
 OUTPUT=`${BASEDIR}/issue1372`
 
-if [[ "$OUTPUT" != "hidden dir compiled" ]]; then die "Hidden directory compilation failed"; fi
+if [[ "$OUTPUT" != "hidden dir compiled" ]]; then die $LINENO "Hidden directory compilation failed"; fi
 
 rm -rf ${BASEDIR}/.dub
 rm -rf ${BASEDIR}/issue1372

--- a/test/issue1401-filesystem-supplier.sh
+++ b/test/issue1401-filesystem-supplier.sh
@@ -10,19 +10,19 @@ echo "Trying to get fs-sdl-dubpackage (1.0.5)"
 "$DUB" fetch fs-sdl-dubpackage --version=1.0.5 --skip-registry=all --registry=file://"$DIR"/issue1401-file-system-pkg-supplier
 
 if ! dub remove fs-sdl-dubpackage --non-interactive --version=1.0.5 2>/dev/null; then
-    die 'DUB did not install package from file system.'
+    die $LINENO 'DUB did not install package from file system.'
 fi
 
 echo "Trying to get fs-sdl-dubpackage (latest)"
 "$DUB" fetch fs-sdl-dubpackage --skip-registry=all --registry=file://"$DIR"/issue1401-file-system-pkg-supplier
 
 if ! dub remove fs-sdl-dubpackage --non-interactive --version=1.0.6 2>/dev/null; then
-    die 'DUB did not install latest package from file system.'
+    die $LINENO 'DUB did not install latest package from file system.'
 fi
 
 echo "Trying to get fs-json-dubpackage (1.0.7)"
 "$DUB" fetch fs-json-dubpackage --version=1.0.7 --skip-registry=all --registry=file://"$DIR"/issue1401-file-system-pkg-supplier
 
 if ! dub remove fs-json-dubpackage --non-interactive --version=1.0.7 2>/dev/null; then
-    die 'DUB did not install package from file system.'
+    die $LINENO 'DUB did not install package from file system.'
 fi

--- a/test/issue1416-maven-repo-pkg-supplier.sh
+++ b/test/issue1416-maven-repo-pkg-supplier.sh
@@ -17,14 +17,14 @@ echo "Trying to download maven-dubpackage (1.0.5)"
 "$DUB" fetch maven-dubpackage --version=1.0.5 --skip-registry=all --registry=mvn+http://localhost:$PORT/maven/release/dubpackages
 
 if ! dub remove maven-dubpackage --non-interactive --version=1.0.5 2>/dev/null; then
-    die 'DUB did not install package from maven registry.'
+    die $LINENO 'DUB did not install package from maven registry.'
 fi
 
 echo "Trying to download maven-dubpackage (latest)"
 "$DUB" fetch maven-dubpackage --skip-registry=all --registry=mvn+http://localhost:$PORT/maven/release/dubpackages
 
 if ! dub remove maven-dubpackage --non-interactive --version=1.0.6 2>/dev/null; then
-    die 'DUB fetch did not install latest package from maven registry.'
+    die $LINENO 'DUB fetch did not install latest package from maven registry.'
 fi
 
 echo "Trying to search (exact) maven-dubpackage"

--- a/test/issue1447-build-settings-vars.sh
+++ b/test/issue1447-build-settings-vars.sh
@@ -18,4 +18,4 @@ OUTPUT=`${CURR_DIR}/issue1447-build-settings-vars/test`
 rm -rf ${CURR_DIR}/issue1447-build-settings-vars/.dub
 rm -rf ${CURR_DIR}/issue1447-build-settings-vars/test
 
-if [[ "$OUTPUT" != "$ARCH" ]]; then die "Build settings ARCH var incorrect"; fi
+if [[ "$OUTPUT" != "$ARCH" ]]; then die $LINENO "Build settings ARCH var incorrect"; fi

--- a/test/issue1524-maven-upgrade-dependency-tree.sh
+++ b/test/issue1524-maven-upgrade-dependency-tree.sh
@@ -18,10 +18,10 @@ echo "Trying to download maven-dubpackage-a (1.0.5) with dependency to maven-dub
 "$DUB" upgrade --root "$DIR/issue1524-maven-upgrade-dependency-tree" --skip-registry=standard --registry=mvn+http://localhost:$PORT/maven/release/dubpackages
 
 if ! dub remove maven-dubpackage-a --non-interactive --version=1.0.5 2>/dev/null; then
-    die 'DUB did not install package "maven-dubpackage-a" from maven registry.'
+    die $LINENO 'DUB did not install package "maven-dubpackage-a" from maven registry.'
 fi
 
 if ! dub remove maven-dubpackage-b --non-interactive --version=1.0.6 2>/dev/null; then
-    die 'DUB did not install package "maven-dubpackage-b" from maven registry.'
+    die $LINENO 'DUB did not install package "maven-dubpackage-b" from maven registry.'
 fi
 

--- a/test/issue1531-toolchain-requirements.sh
+++ b/test/issue1531-toolchain-requirements.sh
@@ -3,7 +3,7 @@ set -e
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
-cat << EOF | $DUB - || die "Did not pass without toolchainRequirements"
+cat << EOF | $DUB - || die $LINENO "Did not pass without toolchainRequirements"
 /+ dub.sdl:
 +/
 void main() {}
@@ -11,7 +11,7 @@ EOF
 
 # pass test dub requirement given as $1
 function test_dub_req_pass {
-    cat << EOF | $DUB - || die "Did not pass requirement dub=\"$1\""
+    cat << EOF | $DUB - || die $LINENO "Did not pass requirement dub=\"$1\""
 /+ dub.sdl:
     toolchainRequirements dub="$1"
 +/
@@ -21,7 +21,7 @@ EOF
 
 # fail test dub requirement given as $1
 function test_dub_req_fail {
-    ! cat << EOF | $DUB - || die "Did not pass requirement dub=\"$1\""
+    ! cat << EOF | $DUB - || die $LINENO "Did not pass requirement dub=\"$1\""
 /+ dub.sdl:
     toolchainRequirements dub="$1"
 +/
@@ -44,7 +44,7 @@ elif [[ $DC == *gdc* ]]; then
     VER_REG='\) (([[:digit:]]+)(\.[[:digit:]]+\.[[:digit:]]+[A-Za-z0-9.+-]*))'
     DC_NAME=gdc
 else
-    die "Did not recognize compiler"
+    die $LINENO "Did not recognize compiler"
 fi
 if [[ $($DC --version) =~ $VER_REG ]]; then
     DC_VER=${BASH_REMATCH[1]}
@@ -54,7 +54,7 @@ if [[ $($DC --version) =~ $VER_REG ]]; then
     echo $DC version is $DC_VER
 else
     $DC --version
-    die "Could not extract compiler version"
+    die $LINENO "Could not extract compiler version"
 fi
 
 # create test app directory
@@ -76,13 +76,13 @@ EOF
 # pass test compiler requirement given as $1
 function test_cl_req_pass {
     write_cl_req $1
-    $DUB --compiler=$DC --root=$TMPDIR || die "Did not pass with $DC_NAME=\"$1\""
+    $DUB --compiler=$DC --root=$TMPDIR || die $LINENO "Did not pass with $DC_NAME=\"$1\""
 }
 
 # fail test compiler requirement given as $1
 function test_cl_req_fail {
     write_cl_req $1
-    ! $DUB --compiler=$DC --root=$TMPDIR || die "Did not fail with $DC_NAME=\"$1\""
+    ! $DUB --compiler=$DC --root=$TMPDIR || die $LINENO "Did not fail with $DC_NAME=\"$1\""
 }
 
 

--- a/test/issue1567-fetch-sub-package.sh
+++ b/test/issue1567-fetch-sub-package.sh
@@ -8,5 +8,5 @@ $DUB remove $packname --non-interactive 2>/dev/null || true
 $DUB fetch "$packname:$sub_packagename" --skip-registry=all --registry=file://"$DIR"/issue1567-fetch-sub-package
 
 if ! dub remove $packname --non-interactive --version=1.0.1 2>/dev/null; then
-    die 'DUB did not install package $packname:$sub_packagename.'
+    die $LINENO 'DUB did not install package $packname:$sub_packagename.'
 fi

--- a/test/issue616-describe-vs-generate-commands.sh
+++ b/test/issue616-describe-vs-generate-commands.sh
@@ -13,7 +13,7 @@ trap cleanup EXIT
 
 if ! $DUB describe --compiler=$DC --data-list --data=target-name \
     > "$temp_file" 2>&1; then
-    die 'Printing project data failed!'
+    die $LINENO 'Printing project data failed!'
 fi
 
 # Create the expected output file to compare stdout against.
@@ -25,5 +25,5 @@ echo "$CURR_DIR/issue616-subsubpack/src/" >> "$expected_file"
 echo "issue616-describe-vs-generate-commands" >> "$expected_file"
 
 if ! diff "$expected_file" "$temp_file"; then
-    die 'The stdout output did not match the expected output!'
+    die $LINENO 'The stdout output did not match the expected output!'
 fi

--- a/test/pr1549-dub-exe-var.sh
+++ b/test/pr1549-dub-exe-var.sh
@@ -8,4 +8,4 @@ PR1549=$CURR_DIR/pr1549-dub-exe-var
 ${DUB} build --root ${PR1549}
 OUTPUT=$(${PR1549}/test-application)
 
-if [[ "$OUTPUT" != "modified code" ]]; then die "\$DUB build variable was (likely) not evaluated correctly"; fi
+if [[ "$OUTPUT" != "modified code" ]]; then die $LINENO "\$DUB build variable was (likely) not evaluated correctly"; fi

--- a/test/run-unittest.sh
+++ b/test/run-unittest.sh
@@ -25,7 +25,7 @@ export -f log
 export -f die
 
 if [ -z ${DUB:-} ]; then
-    die 'Variable $DUB must be defined to run the tests.'
+    die $LINENO 'Variable $DUB must be defined to run the tests.'
 fi
 
 if [ -z ${DC:-} ]; then

--- a/test/timeout.sh
+++ b/test/timeout.sh
@@ -7,18 +7,18 @@ PORT=$(getRandomPort)
 
 log '    Testing unconnectable registry'
 if timeout 1s $DUB fetch dub --skip-registry=all --registry=http://localhost:$PORT; then
-    die 'Fetching from unconnectable registry should fail.'
+    die $LINENO 'Fetching from unconnectable registry should fail.'
 elif [ $? -eq 124 ]; then
-    die 'Fetching from unconnectable registry should fail immediately.'
+    die $LINENO 'Fetching from unconnectable registry should fail immediately.'
 fi
 
 log '    Testing non-responding registry'
 cat | nc -l $PORT >/dev/null &
 PID=$!
 if timeout 10s $DUB fetch dub --skip-registry=all --registry=http://localhost:$PORT; then
-    die 'Fetching from non-responding registry should fail.'
+    die $LINENO 'Fetching from non-responding registry should fail.'
 elif [ $? -eq 124 ]; then
-    die 'Fetching from non-responding registry should time-out within 8s.'
+    die $LINENO 'Fetching from non-responding registry should time-out within 8s.'
 fi
 kill $PID 2>/dev/null || true
 
@@ -37,8 +37,8 @@ Content-Length: 2\r
 } | nc -l $PORT >/dev/null &
 PID=$!
 if timeout 10s time $DUB fetch dub --skip-registry=all --registry=http://localhost:$PORT; then
-    die 'Fetching from too slow registry should fail.'
+    die $LINENO 'Fetching from too slow registry should fail.'
 elif [ $? -eq 124 ]; then
-    die 'Fetching from too slow registry should time-out within 8s.'
+    die $LINENO 'Fetching from too slow registry should time-out within 8s.'
 fi
 kill $PID 2>/dev/null || true


### PR DESCRIPTION
'die' actually taking two parameters seems to be a little-known fact.