### PR TITLE
added run/test '--gdb' command line argument

### DIFF
--- a/changelog/gdb.dd
+++ b/changelog/gdb.dd
@@ -1,0 +1,4 @@
+added run/test `--gdb` command line argument
+
+If `--gdb` is used, then the executable will be started with gdb attached.
+The gdb executable can be specified with the DEBUGGER environment variable.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1080,6 +1080,7 @@ class GenerateCommand : PackageBuildCommand {
 		bool m_rdmd = false;
 		bool m_tempBuild = false;
 		bool m_run = false;
+		bool m_gdb = false;
 		bool m_force = false;
 		bool m_combined = false;
 		bool m_parallel = false;
@@ -1164,6 +1165,7 @@ class GenerateCommand : PackageBuildCommand {
 		gensettings.combined = m_combined;
 		gensettings.filterVersions = m_filterVersions;
 		gensettings.run = m_run;
+		gensettings.gdb = m_gdb;
 		gensettings.runArgs = app_args;
 		gensettings.force = m_force;
 		gensettings.rdmd = m_rdmd;
@@ -1303,6 +1305,10 @@ class RunCommand : BuildCommand {
 			"Builds the project in the temp folder if possible."
 		]);
 
+		args.getopt("gdb", &m_gdb, [
+			"Attach gdb. The gdb executable can be specified with the DEBUGGER environment variable (default 'gdb' is used)"
+		]);
+
 		super.prepare(args);
 		m_run = true;
 	}
@@ -1319,6 +1325,7 @@ class TestCommand : PackageBuildCommand {
 		bool m_combined = false;
 		bool m_parallel = false;
 		bool m_force = false;
+		bool m_gdb = false;
 	}
 
 	this() @safe pure nothrow
@@ -1368,6 +1375,9 @@ class TestCommand : PackageBuildCommand {
 		]);
 		if (coverage) m_buildType = "unittest-cov";
 
+		args.getopt("gdb", &m_gdb, [
+			"Attach gdb. The gdb executable can be specified with the DEBUGGER environment variable (default 'gdb' is used)"
+		]);
 		super.prepare(args);
 	}
 
@@ -1391,6 +1401,7 @@ class TestCommand : PackageBuildCommand {
 		settings.force = m_force;
 		settings.tempBuild = m_single;
 		settings.run = true;
+		settings.gdb = m_gdb;
 		settings.runArgs = app_args;
 
 		dub.testProject(settings, m_buildConfig, NativePath(m_mainFile));

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -544,13 +544,20 @@ class BuildGenerator : ProjectGenerator {
 			}
 			runPreRunCommands(m_project.rootPackage, m_project, settings, buildsettings);
 			logInfo("Running %s %s", exe_path_string, run_args.join(" "));
+
+			auto exec = exe_path_string ~ run_args;
+			if(settings.gdb){
+				auto gdb = environment.get("DUB_DEBUGGER", "gdb");
+				exec = [gdb, "--args"] ~ exec;
+			}
+
 			if (settings.runCallback) {
-				auto res = execute(exe_path_string ~ run_args);
+				auto res = execute(exec);
 				settings.runCallback(res.status, res.output);
 				settings.targetExitStatus = res.status;
 				runPostRunCommands(m_project.rootPackage, m_project, settings, buildsettings);
 			} else {
-				auto prg_pid = spawnProcess(exe_path_string ~ run_args);
+				auto prg_pid = spawnProcess(exec);
 				auto result = prg_pid.wait();
 				settings.targetExitStatus = result;
 				runPostRunCommands(m_project.rootPackage, m_project, settings, buildsettings);

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -590,7 +590,7 @@ struct GeneratorSettings {
 	bool filterVersions;
 
 	// only used for generator "build"
-	bool run, force, direct, rdmd, tempBuild, parallelBuild;
+	bool run, gdb, force, direct, rdmd, tempBuild, parallelBuild;
 
 	/// single file dub package
 	bool single;


### PR DESCRIPTION
If `--gdb` is used, then the executable will be started with gdb attached.
The gdb executable can be specified with the DEBUGGER environment variable.
