### PR TITLE
dub_test_root: remove commented code

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -709,7 +709,6 @@ class Dub {
 								import core.runtime;
 								import std.exception;
 								Runtime.moduleUnitTester = () => true;
-								//runUnitTests!app(new JsonTestResultWriter("results.json"));
 								enforce(runUnitTests!allModules(new ConsoleTestResultWriter), "Unit tests failed.");
 							}
 						}


### PR DESCRIPTION
This module is injected on all unittest's produced by dub. Because this comment is inside quasiquotes, I don't see a proper reason for this line being generated on all `dub_test_root` files.

