### PR TITLE
Improve output of toolchain requirements test, workaround heisenbug

### DIFF
--- a/test/issue1531-toolchain-requirements.sh
+++ b/test/issue1531-toolchain-requirements.sh
@@ -75,12 +75,14 @@ EOF
 
 # pass test compiler requirement given as $1
 function test_cl_req_pass {
+    echo "Expecting success on '$DC $1'" 2>&1
     write_cl_req $1
-    $DUB --compiler=$DC --root=$TMPDIR || die $LINENO "Did not pass with $DC_NAME=\"$1\""
+    $DUB build -q --compiler=$DC --root=$TMPDIR || die $LINENO "Did not pass with $DC_NAME=\"$1\""
 }
 
 # fail test compiler requirement given as $1
 function test_cl_req_fail {
+    echo "Expecting failure on '$DC $1'" 2>&1
     write_cl_req $1
     ! $DUB --compiler=$DC --root=$TMPDIR || die $LINENO "Did not fail with $DC_NAME=\"$1\""
 }


### PR DESCRIPTION
```
There is currently an Heisenbug in Github CI where dub fails to run the program.
E.g. we see the following in the logs:
---
Performing "debug" build using ldc2 for x86_64.
dubtest1531 ~master: building configuration "application"...
Linking...
Running ../../../../../tmp/dubtest1531_2enU78/dubtest1531
Failed to execute program (No such file or directory)
[ERROR] -e:79 Did not pass with ldc="<=1.23.0"
[ERROR] Script failure.
---
This works around said bug by only building the package,
but not running it.
```

Also using `-q` to reduce noise.