### PR TITLE
[stable] Deduplicate dflags and lflags

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -89,10 +89,10 @@ struct BuildSettings {
 		addPostRunCommands(bs.postRunCommands);
 	}
 
-	void addDFlags(in string[] value...) { dflags ~= value; }
+	void addDFlags(in string[] value...) { add(dflags, value); }
 	void prependDFlags(in string[] value...) { prepend(dflags, value); }
 	void removeDFlags(in string[] value...) { remove(dflags, value); }
-	void addLFlags(in string[] value...) { lflags ~= value; }
+	void addLFlags(in string[] value...) { add(lflags, value); }
 	void addLibs(in string[] value...) { add(libs, value); }
 	void addLinkerFiles(in string[] value...) { add(linkerFiles, value); }
 	void addSourceFiles(in string[] value...) { add(sourceFiles, value); }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -164,11 +164,7 @@ class Dub {
 
 		init(m_rootPath);
 
-		if (skip_registry == SkipPackageSuppliers.none)
-			m_packageSuppliers = getPackageSuppliers(additional_package_suppliers);
-		else
-			m_packageSuppliers = getPackageSuppliers(additional_package_suppliers, skip_registry);
-
+		m_packageSuppliers = getPackageSuppliers(additional_package_suppliers, skip_registry);
 		m_packageManager = new PackageManager(m_rootPath, m_dirs.localRepository, m_dirs.systemSettings);
 
 		auto ccps = m_config.customCachePaths;


### PR DESCRIPTION
Before:
<img width="839" alt="Screen Shot 2020-09-28 at 12 03 40" src="https://user-images.githubusercontent.com/2180215/94386690-4252d380-0183-11eb-8ffb-3462994a785f.png">

After:
<img width="839" alt="Screen Shot 2020-09-28 at 12 04 49" src="https://user-images.githubusercontent.com/2180215/94386760-5c8cb180-0183-11eb-93b2-8ed8184cd709.png">

There are still some improvements needed (notice the duplicated `-L-framework`), but the diff / benefit ratio is already great.
Packed in another tiny cleanup to avoid endless CI retriggers.
Targeting stable because I'm working on propagating dflags downwards and obviously this will come in handy.