### PR TITLE
Revert "Deduplicate dflags and lflags" (#2016)

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -89,10 +89,10 @@ struct BuildSettings {
 		addPostRunCommands(bs.postRunCommands);
 	}
 
-	void addDFlags(in string[] value...) { add(dflags, value); }
+	void addDFlags(in string[] value...) { dflags ~= value; }
 	void prependDFlags(in string[] value...) { prepend(dflags, value); }
 	void removeDFlags(in string[] value...) { remove(dflags, value); }
-	void addLFlags(in string[] value...) { add(lflags, value); }
+	void addLFlags(in string[] value...) { lflags ~= value; }
 	void addLibs(in string[] value...) { add(libs, value); }
 	void addLinkerFiles(in string[] value...) { add(linkerFiles, value); }
 	void addSourceFiles(in string[] value...) { add(sourceFiles, value); }


### PR DESCRIPTION
PR #2016 introducted a de-duplication strategy that is too eager and corrupts argument chains, such as "-framework CoreServices -framework CoreFoundation" where the "-framework" argument needs to be duplicated for each framework.

This reverts commit 10bea6f07fa460c806cbec56323d600af00d9f09.