### PR TITLE
Support for .netrc file added

### DIFF
--- a/changelog/support-for-.netrc-file-added.dd
+++ b/changelog/support-for-.netrc-file-added.dd
@@ -1,0 +1,5 @@
+Support for .netrc file added
+
+Basic authentication credentials defined in .netrc file
+will now be taken into account while connecting to secured
+repositories.

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -474,6 +474,9 @@ version(DubUseCurl) {
 		}
 
 		conn.addRequestHeader("User-Agent", "dub/"~getDUBVersion()~" (std.net.curl; +https://github.com/rejectedsoftware/dub)");
+
+		enum CURL_NETRC_OPTIONAL = 1;
+		conn.handle.set(CurlOption.netrc, CURL_NETRC_OPTIONAL);
 	}
 }
 


### PR DESCRIPTION
Basic authentication credentials defined in .netrc file will now be taken into account while connecting to secured repositories.