### PR TITLE
ci: build release .tar.gz without travis owner and group id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ jobs:
     - stage: deploy
       d: ldc-1.22.0,dub
       os: osx
+      addons:
+        homebrew:
+          packages:
+            - gnu-tar
+          update: true
       script: echo "Deploying to GitHub releases ..." && ./scripts/ci/release.sh
       deploy:
         - provider: releases

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -40,4 +40,4 @@ archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
 
 echo "Building $archiveName"
 DMD="$(command -v $DMD)" ./build.d -release -m$ARCH ${CUSTOM_FLAGS[@]}
-tar cvfz "bin/$archiveName" -C bin dub
+tar cvfz "bin/$archiveName" --owner=0 --group=0 -C bin dub

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -40,4 +40,10 @@ archiveName="dub-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
 
 echo "Building $archiveName"
 DMD="$(command -v $DMD)" ./build.d -release -m$ARCH ${CUSTOM_FLAGS[@]}
-tar cvfz "bin/$archiveName" --owner=0 --group=0 -C bin dub
+if [[ "$OSTYPE" == darwin* ]]; then
+    TAR=gtar
+else
+    TAR=tar
+fi
+
+"$TAR" cvfz "bin/$archiveName" --owner=0 --group=0 -C bin dub


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

The current release `.tar.gz` have `dub` binary under `travis:travis` owner. We should set it as `root:root` which is described as anonymous on GNU tar documentation . https://www.gnu.org/software/tar/manual/html_section/tar_33.html#SEC69

![image](https://user-images.githubusercontent.com/5050669/96867855-24684e00-1465-11eb-8af1-01c2e1300d99.png)
