### PR TITLE
dub.compilers.ldc: Fix --rdmd with --compiler=ldc2

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -112,7 +112,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		}
 
 		// since LDC always outputs multiple object files, avoid conflicts by default
-		settings.addDFlags("-oq", "-od=.dub/obj");
+		settings.addDFlags("--oq", "-od=.dub/obj");
 
 		if (!(fields & BuildSetting.versions)) {
 			settings.addDFlags(settings.versions.map!(s => "-d-version="~s)().array());


### PR DESCRIPTION
Use two dashes to make rdmd ignore the option. ldc2 doesn't care.