### PR TITLE
GH Actions: Use new syntax for set-env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install pkg-config coreutils
-        echo ::set-env name=PKG_CONFIG_PATH::/usr/local/opt/openssl@1.1/lib/pkgconfig/
+        echo "PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig/" >> $GITHUB_ENV
 
     - name: '[Linux] Install dependencies'
       if: runner.os == 'Linux'


### PR DESCRIPTION
Due to a security vulnerability, Github hass removed set-env and add-path.
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/