### PR TITLE
Allow custom dflags to be defined for dependencies

### DIFF
--- a/changelog/dependency-build-settings.dd
+++ b/changelog/dependency-build-settings.dd
@@ -1,0 +1,15 @@
+Allow custom build settings to be defined for dependencies
+
+For example:
+---
+{
+    "name": "example",
+    "dependencies": {
+        "vibe-d": { "version" : "~>0.9.2", "dflags" : ["-preview=in"] }
+    }
+}
+---
+
+In this example, `-preview=in` will be applied to `vibe-d` and all of its dependencies.
+Any $(LINK2 build settings, https://dub.pm/package-format-json.html#build-settings) field will be parsed,
+however only `dflags` is taken into account when compiling for now.

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -314,20 +314,45 @@ class ProjectGenerator
 		visited.clear();
 
 		// 1. downwards inherits versions, debugVersions, and inheritable build settings
-		static void configureDependencies(const scope ref TargetInfo ti, TargetInfo[string] targets, size_t level = 0)
+		static void configureDependencies(const scope ref TargetInfo ti, TargetInfo[string] targets,
+											BuildSettings[string] dependBS, size_t level = 0)
 		{
+
+			static void applyForcedSettings(const scope ref BuildSettings forced, ref BuildSettings child) {
+				child.addDFlags(forced.dflags);
+			}
+
 			// do not use `visited` here as dependencies must inherit
 			// configurations from *all* of their parents
 			logDebug("%sConfigure dependencies of %s, deps:%(%s, %)", ' '.repeat(2 * level), ti.pack.name, ti.dependencies);
 			foreach (depname; ti.dependencies)
 			{
+				BuildSettings forcedSettings;
 				auto pti = &targets[depname];
 				mergeFromDependent(ti.buildSettings, pti.buildSettings);
-				configureDependencies(*pti, targets, level + 1);
+
+				if (auto matchedSettings = depname in dependBS)
+					forcedSettings = *matchedSettings;
+				else if (auto matchedSettings = "*" in dependBS)
+					forcedSettings = *matchedSettings;
+
+				applyForcedSettings(forcedSettings, pti.buildSettings);
+				configureDependencies(*pti, targets, ["*" : forcedSettings], level + 1);
 			}
 		}
 
-		configureDependencies(*roottarget, targets);
+		BuildSettings[string] dependencyBuildSettings;
+		foreach (key, value; rootPackage.recipe.buildSettings.dependencyBuildSettings)
+		{
+			BuildSettings buildSettings;
+			if (auto target = key in targets)
+			{
+				value.getPlatformSettings(buildSettings, genSettings.platform, target.pack.path);
+				buildSettings.processVars(m_project, target.pack, buildSettings, genSettings, true);
+				dependencyBuildSettings[key] = buildSettings;
+			}
+		}
+		configureDependencies(*roottarget, targets, dependencyBuildSettings);
 
 		// 2. add Have_dependency_xyz for all direct dependencies of a target
 		// (includes incorporated non-target dependencies and their dependencies)

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -177,7 +177,7 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 						pkg = package_name ~ pkg;
 					}
 					enforce(pkg !in bs.dependencies, "The dependency '"~pkg~"' is specified more than once." );
-					bs.dependencies[pkg] = deserializeJson!Dependency(verspec);
+					bs.dependencies[pkg] = Dependency.fromJson(verspec);
 				}
 				break;
 			case "systemDependencies":
@@ -251,7 +251,7 @@ private Json toJson(const scope ref BuildSettingsTemplate bs)
 	if( bs.dependencies !is null ){
 		auto deps = Json.emptyObject;
 		foreach( pack, d; bs.dependencies )
-			deps[pack] = serializeToJson(d);
+			deps[pack] = d.toJson();
 		ret["dependencies"] = deps;
 	}
 	if (bs.systemDependencies !is null) ret["systemDependencies"] = bs.systemDependencies;

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -178,6 +178,12 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 					}
 					enforce(pkg !in bs.dependencies, "The dependency '"~pkg~"' is specified more than once." );
 					bs.dependencies[pkg] = Dependency.fromJson(verspec);
+					if (verspec.type == Json.Type.object)
+					{
+						BuildSettingsTemplate dbs;
+						dbs.parseJson(verspec, package_name);
+						bs.dependencyBuildSettings[pkg] = dbs;
+					}
 				}
 				break;
 			case "systemDependencies":

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -176,6 +176,7 @@ struct ConfigurationInfo {
 /// a certain BuildPlatform.
 struct BuildSettingsTemplate {
 	Dependency[string] dependencies;
+	BuildSettingsTemplate[string] dependencyBuildSettings;
 	string systemDependencies;
 	TargetType targetType = TargetType.autodetect;
 	string targetPath;

--- a/test/depen-build-settings/.gitignore
+++ b/test/depen-build-settings/.gitignore
@@ -1,0 +1,4 @@
+depend.json
+depend2.json
+depen-build-settings.json
+depen-build-settings

--- a/test/depen-build-settings/depend/depend2/dub.json
+++ b/test/depen-build-settings/depend/depend2/dub.json
@@ -1,0 +1,5 @@
+{
+	"targetType": "library",
+	"description": "A minimal D application.",
+	"name": "depend2"
+}

--- a/test/depen-build-settings/depend/depend2/source/depend2.d
+++ b/test/depen-build-settings/depend/depend2/source/depend2.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+extern (C) void depend2_func()
+{
+	writeln("depend2_func");
+}

--- a/test/depen-build-settings/depend/dub.json
+++ b/test/depen-build-settings/depend/dub.json
@@ -1,0 +1,9 @@
+{
+	"targetType": "library",
+	"description": "A minimal D application.",
+	"name": "depend1",
+
+	"dependencies": {
+		"depend2": { "version" : "*" }
+	}
+}

--- a/test/depen-build-settings/depend/source/depend.d
+++ b/test/depen-build-settings/depend/source/depend.d
@@ -1,0 +1,9 @@
+import std.stdio;
+
+extern (C) void depend2_func();
+
+extern (C) void depend1_func()
+{
+	writeln("depend1_func");
+	depend2_func();
+}

--- a/test/depen-build-settings/dub.json
+++ b/test/depen-build-settings/dub.json
@@ -1,0 +1,8 @@
+{
+	"description": "A minimal D application.",
+	"name": "depen-build-settings",
+
+	"dependencies": {
+		"depend1": { "version" : "*", "dflags" : ["-X"] }
+	}
+}

--- a/test/depen-build-settings/dub.selections.json
+++ b/test/depen-build-settings/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"depend1": {"path":"depend/"},
+		"depend2": {"path":"depend/depend2/"}
+	}
+}

--- a/test/depen-build-settings/source/app.d
+++ b/test/depen-build-settings/source/app.d
@@ -1,0 +1,12 @@
+import std.stdio;
+import std.file;
+
+extern (C) void depend1_func();
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+	depend1_func();
+	assert(exists("depend2.json"));
+	assert(exists("depend.json"));
+}


### PR DESCRIPTION
For example;
```
{
	"authors": [
		"omer"
	],
	"copyright": "Copyright © 2020, omer",
	"description": "A simple vibe.d server application.",
	"license": "proprietary",
	"name": "dubtest",

	"dependencies": {
		"vibe-d": { "version" : "~>0.9.2", "dflags" : ["-preview=in"] }
	}
}
```

`-preview=in` will be applied to `vibe-d` and all of its dependencies. Any `BuildSettings` field can be used, parsing support is present. But, for now only, `dflags` is taken into account when compiling. 
