### PR TITLE
[stable] Use compiler version, not frontend version for build IDs and paths

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -44,10 +44,10 @@ string computeBuildName(string config, GeneratorSettings settings, const string[
 		addHash(strings);
 	auto hashstr = hash.finish().toHexString().idup;
 
-    return format("%s-%s-%s-%s-%s_%s-%s", config, settings.buildType,
+    return format("%s-%s-%s-%s-%s_v%s-%s", config, settings.buildType,
 			settings.platform.platform.join("."),
 			settings.platform.architecture.join("."),
-			settings.platform.compiler, settings.platform.frontendVersion, hashstr);
+			settings.platform.compiler, settings.platform.compilerVersion, hashstr);
 }
 
 class BuildGenerator : ProjectGenerator {
@@ -359,7 +359,7 @@ class BuildGenerator : ProjectGenerator {
 				(cast(uint)buildsettings.options).to!string,
 				settings.platform.compilerBinary,
 				settings.platform.compiler,
-				settings.platform.frontendVersion.to!string,
+				settings.platform.compilerVersion,
 			],
 		];
 


### PR DESCRIPTION
This prevents artifacts from being reused after upgrading the compiler from a beta to a final or to a newer patch release (well, I hope).