### PR TITLE
Use DC env variable as the default compiler

### DIFF
--- a/changelog/env-d-compiler.dd
+++ b/changelog/env-d-compiler.dd
@@ -1,0 +1,6 @@
+Use DC environment variable as default D compiler
+
+dub now respects the `DC` environment variable, meaning that `DC=ldc2 dub build` will behave as `dub build --compiler=ldc2`.
+In case both are supplied, the `--compiler` switch still has priority.
+Note that when DUB recursively invokes itself, for example in `preGenerateCommands`,
+it sets the `DC` variable to the compiler it is using, meaning that nested dub invocation will now use the same compiler.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1380,7 +1380,11 @@ class Dub {
 		import std.process : environment;
 		import std.range : front;
 
-		m_defaultCompiler = m_config.defaultCompiler.expandTilde;
+		// Env takes precedence
+		if (auto envCompiler = environment.get("DC"))
+			m_defaultCompiler = envCompiler;
+		else
+			m_defaultCompiler = m_config.defaultCompiler.expandTilde;
 		if (m_defaultCompiler.length && m_defaultCompiler.isAbsolute)
 			return;
 

--- a/test/dc-env.sh
+++ b/test/dc-env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+cd ${CURR_DIR}/issue2012-dc-env
+
+$DUB app.d ${DC}

--- a/test/issue2012-dc-env/app.d
+++ b/test/issue2012-dc-env/app.d
@@ -1,0 +1,18 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+	name "app"
++/
+
+import std.format;
+
+void main(string[] args)
+{
+    version (LDC)
+        immutable expected = "ldc2";
+    version (DigitalMars)
+        immutable expected = "dmd";
+    version (GNU)
+        immutable expected = "gdc";
+
+    assert(expected == args[1], format!"Expected '%s' but got '%s'"(expected, args[1]));
+}

--- a/test/issue895-local-configuration.sh
+++ b/test/issue895-local-configuration.sh
@@ -20,6 +20,8 @@ function cleanup {
 
 trap cleanup EXIT
 
+unset DC
+
 if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Unknown compiler: $(dirname $CURR_DIR)/bin/foo"; then
 	rm ../bin/foo
 	die $LINENO 'DUB did not find the local configuration with an adjacent compiler.'


### PR DESCRIPTION
When DUB recursively invokes itself, it sets up the DC
env var with the compiler it is using. The `callee` dub should
use that compiler if it is not overriden with "--compiler". 

`DC=ldc2 dub build` is equivalent to `dub build --compiler=ldc2`
`DC=ldc2 dub build --compiler=dmd` would use `dmd`

This addresses the issue 1 mentioned in #2012 