### PR TITLE
Dont export DFLAGS & LFLAGS by default

### DIFF
--- a/changelog/dont-propagate-flags.dd
+++ b/changelog/dont-propagate-flags.dd
@@ -1,0 +1,10 @@
+`DFLAGS` and `LFLAGS` no longer propagate to nested `dub` invocations
+
+`DFLAGS` and `LFLAGS` will no longer be exported as environment variables by default
+when invoking pre-generate, pre-build, pre-run, post-generate, post-build, or post-run commands.
+
+If the previous behavior is still desired, they can be accessed using `$DFLAGS` and `$LFLAGS` in dub.json
+E.g.:
+`preGenerateCommands : ["DFLAGS=$DFLAGS env | grep DFLAGS"]`
+
+will output DFLAGS environment variable with all the dflags used.

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -776,8 +776,6 @@ void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	string[string] env = environment.toAA();
 	// TODO: do more elaborate things here
 	// TODO: escape/quote individual items appropriately
-	env["DFLAGS"]                = join(cast(string[])build_settings.dflags, " ");
-	env["LFLAGS"]                = join(cast(string[])build_settings.lflags," ");
 	env["VERSIONS"]              = join(cast(string[])build_settings.versions," ");
 	env["LIBS"]                  = join(cast(string[])build_settings.libs," ");
 	env["SOURCE_FILES"]          = join(cast(string[])build_settings.sourceFiles," ");

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1396,6 +1396,15 @@ private string getVariable(Project, Package)(string name, in Project project, in
 
 	if (name == "BUILD_TYPE") return gsettings.buildType;
 
+	if (name == "DFLAGS" || name == "LFLAGS")
+	{
+		auto buildSettings = pack.getBuildSettings(gsettings.platform, gsettings.config);
+		if (name == "DFLAGS")
+			return join(buildSettings.dflags," ");
+		else if (name == "LFLAGS")
+			return join(buildSettings.lflags," ");
+	}
+
 	auto envvar = environment.get(name);
 	if (envvar !is null) return envvar;
 
@@ -1419,6 +1428,10 @@ unittest
 		}
 		string name;
 		NativePath path;
+		BuildSettings getBuildSettings(in BuildPlatform platform, string config) const
+		{
+			return BuildSettings();
+		}
 	}
 
 	static struct MockProject


### PR DESCRIPTION
DFLAGS and LFLAGS will not be exported as environment variables by default.
They can be accessed with $DFLAGS and $LFLAGS variables in dub.json

Eg;

`preGenerateCommands : ["DFLAGS=$DFLAGS env | grep DFLAGS"]`

will output DFLAGS environment variable with all the dflags used. 