### PR TITLE
In single mode the current working directory is added to import paths by default

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1392,6 +1392,7 @@ class TestCommand : PackageBuildCommand {
 		settings.tempBuild = m_single;
 		settings.run = true;
 		settings.runArgs = app_args;
+		settings.single = m_single;
 
 		dub.testProject(settings, m_buildConfig, NativePath(m_mainFile));
 		return 0;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -660,6 +660,8 @@ class Dub {
 			// prepare the list of tested modules
 
 			string[] import_modules;
+			if (settings.single)
+				lbuildsettings.importPaths ~= ".";
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
 					auto fname = NativePath(file).head.name;


### PR DESCRIPTION
Fix #2051 

This PR adds the current working dir to the list of import paths if user run `test` command in single file mode like:
```
dub test --single path/to/file.d
```
to let dub to find the file.

Important:
the file should not be named `main.d` because the file is imported as module `main` and there will be conflict between `static import main` and `function D main`:
```
/tmp/dub_test_root_test.d(9,12): Error: function D main conflicts with static import dub_test_root.main at /tmp/dub_test_root_test.d(3,15)
```