### PR TITLE
Fix #2051: Running unit tests from DUB single file packages fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
         # The value doesn't matter as long as it's > 2.087
         FRONTEND: 2.093.0
       run: |
+        dub build --compiler=${{ env.DC }}
+        dub run   --compiler=${{ env.DC }} --single test/issue_2051_running_unittests_from_dub_single_file_packages_fails.d
         ./scripts/ci/travis.sh
 
     - name: '[Windows] Test'
@@ -72,3 +74,4 @@ jobs:
       run: |
         dub build --compiler=${{ env.DC }}
         dub test  --compiler=${{ env.DC }}
+        dub run   --compiler=${{ env.DC }} --single test\issue_2051_running_unittests_from_dub_single_file_packages_fails.d

--- a/changelog/fix-2051.dd
+++ b/changelog/fix-2051.dd
@@ -1,0 +1,3 @@
+Fix #2051 "Running unit tests from DUB single file packages fails"
+
+Now dub is capable run test command in single mode like: `dub test --single yoursinglefile.d`

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -663,7 +663,10 @@ class Dub {
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
 					auto fname = NativePath(file).head.name;
-					if (NativePath(file).relativeTo(m_project.rootPackage.path) == NativePath(mainfil)) {
+					NativePath msf = NativePath(mainfil);
+					if (msf.absolute)
+						msf = msf.relativeTo(m_project.rootPackage.path);
+					if (NativePath(file).relativeTo(m_project.rootPackage.path) == msf) {
 						logWarn("Excluding main source file %s from test.", mainfil);
 						tcinfo.excludedSourceFiles[""] ~= mainfil;
 						continue;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -17,3 +17,4 @@ version-spec/**/foo.cmake
 version-spec/**/foo
 
 /test_registry
+/issue_2051_running_unittests_from_dub_single_file_packages_fails

--- a/test/issue_2051_running_unittests_from_dub_single_file_packages_fails.d
+++ b/test/issue_2051_running_unittests_from_dub_single_file_packages_fails.d
@@ -1,0 +1,76 @@
+/+ dub.sdl:
+   name "issue_2051_running_unittests_from_dub_single_file_packages_fails"
+ +/
+
+import std.algorithm : any;
+import std.conv : text;
+import std.file : tempDir;
+import std.stdio : File, writeln;
+import std.string : lineSplitter;
+import std.path : buildPath;
+import std.process : environment, executeShell;
+
+auto executeCommand(string command)
+{
+	import std.exception : enforce;
+
+	auto dub = executeShell(command);
+	writeln("--- dub output:");
+	foreach(line; dub.output.lineSplitter)
+		writeln("\t", line);
+	writeln("--- end of dub output");
+
+	enforce(dub.status == 0, "couldn't build the project, see above");
+
+	return dub.output;
+}
+
+/// check dub output to determine rebuild has not been triggered
+auto checkUnittestsResult(string output)
+{
+	if (output.lineSplitter.any!(a=> a == "All unit tests have been run successfully."))
+	{
+		writeln("\nOk. Unittest passed.");
+		return 0;
+	}
+	else
+	{
+		writeln("\nError. Unittests failed.");
+		return 1;
+	}
+}
+
+int main()
+{
+	auto dub = environment.get("DUB");
+	if (!dub.length)
+		dub = buildPath(".", "bin", "dub");
+
+	string filename;
+	// create test_project
+	{
+		filename = tempDir.buildPath("issue_2051.d");
+		auto f = File(filename, "w");
+		f.write(
+`#!/usr/bin/env dub
+/+ dub.sdl:
+	name "issue2051"
++/
+
+version(unittest) {}
+else void main()
+{
+}
+
+unittest
+{
+	auto input = [1721];
+	assert(input[0] == 1721);
+}
+`		);
+	}
+
+	return text(dub, " test --single ", filename)
+		.executeCommand
+		.checkUnittestsResult;
+}


### PR DESCRIPTION
Performing test command dub imports every source file as module to build the project excluding the main source file. But this excluding may fail and in this case dub try to import the main source file as module. Single file package building fails because the main source file does not belong to any import path. Now both the current file and the main source file paths are compared in relative form to prevent importing the main source file as module.
