### PR TITLE
merge stable

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -82,6 +82,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		switch (arch_override) {
 			case "": break;
 			case "x86": arch_flags = ["-march=x86"]; break;
+			case "x86_mscoff": arch_flags = ["-march=x86"]; break;
 			case "x86_64": arch_flags = ["-march=x86-64"]; break;
 			case "aarch64": arch_flags = ["-march=aarch64"]; break;
 			case "powerpc64": arch_flags = ["-march=powerpc64"]; break;

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -44,10 +44,10 @@ string computeBuildName(string config, GeneratorSettings settings, const string[
 		addHash(strings);
 	auto hashstr = hash.finish().toHexString().idup;
 
-    return format("%s-%s-%s-%s-%s_%s-%s", config, settings.buildType,
+    return format("%s-%s-%s-%s-%s_v%s-%s", config, settings.buildType,
 			settings.platform.platform.join("."),
 			settings.platform.architecture.join("."),
-			settings.platform.compiler, settings.platform.frontendVersion, hashstr);
+			settings.platform.compiler, settings.platform.compilerVersion, hashstr);
 }
 
 class BuildGenerator : ProjectGenerator {
@@ -359,7 +359,7 @@ class BuildGenerator : ProjectGenerator {
 				(cast(uint)buildsettings.options).to!string,
 				settings.platform.compilerBinary,
 				settings.platform.compiler,
-				settings.platform.frontendVersion.to!string,
+				settings.platform.compilerVersion,
 			],
 		];
 

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.23.0";
+enum dubVersion = "v1.24.0-beta.1";


### PR DESCRIPTION
- update version to v1.24.0-beta.1
- Use compiler version, not frontend version for build IDs and paths
- Add support for --arch=x86_mscoff for LDC (for DMD compatibility)
