### PR TITLE
Set cwd on spawn functions instead of chdir

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -528,20 +528,19 @@ class BuildGenerator : ProjectGenerator {
 			if (buildsettings.workingDirectory.length) {
 				runcwd = NativePath(buildsettings.workingDirectory);
 				if (!runcwd.absolute) runcwd = cwd ~ runcwd;
-				logDiagnostic("Switching to %s", runcwd.toNativeString());
-				chdir(runcwd.toNativeString());
 			}
-			scope(exit) chdir(cwd.toNativeString());
 			if (!exe_file_path.absolute) exe_file_path = cwd ~ exe_file_path;
 			runPreRunCommands(m_project.rootPackage, m_project, settings, buildsettings);
 			logInfo("Running %s %s", exe_file_path.relativeTo(runcwd), run_args.join(" "));
 			if (settings.runCallback) {
-				auto res = execute([ exe_file_path.toNativeString() ] ~ run_args);
+				auto res = execute([ exe_file_path.toNativeString() ] ~ run_args,
+						   null, Config.none, size_t.max, runcwd.toNativeString());
 				settings.runCallback(res.status, res.output);
 				settings.targetExitStatus = res.status;
 				runPostRunCommands(m_project.rootPackage, m_project, settings, buildsettings);
 			} else {
-				auto prg_pid = spawnProcess([ exe_file_path.toNativeString() ] ~ run_args);
+				auto prg_pid = spawnProcess([ exe_file_path.toNativeString() ] ~ run_args,
+								null, Config.none, runcwd.toNativeString());
 				auto result = prg_pid.wait();
 				settings.targetExitStatus = result;
 				runPostRunCommands(m_project.rootPackage, m_project, settings, buildsettings);


### PR DESCRIPTION
It is more hygienic to use the cwd argument as it doesn't impact
the running process, and doesn't decouple the reason for it.