### PR TITLE
Raise minimum Vibe.d requirement to v0.9.0

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -22,13 +22,13 @@ configuration "library" {
 }
 
 configuration "library-nonet" {
-	dependency "vibe-d:http" version=">=0.7.30 <0.10.0" optional=true
+	dependency "vibe-d:http" version=">=0.9.0 <0.10.0" optional=true
 	targetType "library"
 	excludedSourceFiles "source/app.d"
 }
 
 configuration "dynamic-library-nonet" {
-	dependency "vibe-d:http" version=">=0.7.30 <0.10.0" optional=true
+	dependency "vibe-d:http" version=">=0.9.0 <0.10.0" optional=true
 	targetType "dynamicLibrary"
 	excludedSourceFiles "source/app.d"
 }

--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -8,7 +8,6 @@
 module dub.internal.vibecompat.inet.path;
 
 version (Have_vibe_core) public import vibe.core.path;
-else version (Have_vibe_d_core) public import vibe.inet.path;
 else:
 
 import std.algorithm;

--- a/source/dub/internal/vibecompat/inet/url.d
+++ b/source/dub/internal/vibecompat/inet/url.d
@@ -9,7 +9,7 @@ module dub.internal.vibecompat.inet.url;
 
 public import dub.internal.vibecompat.inet.path;
 
-version (Have_vibe_d_core) public import vibe.inet.url;
+version (Have_vibe_d_inet) public import vibe.inet.url;
 else:
 
 import std.algorithm;


### PR DESCRIPTION
Make sure a recent enough Vibe.d is used so we can update the vibecompat code.
Additionally, since the split of Vibe.d into package, and the splitting of
vibe-core into its own project, the version specification was never triggered,
so it was corrected in this commit (the version spec was correct for older Vibe.d).