### PR TITLE
Cleanup http listener in vibed template

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -128,7 +128,11 @@ void main()
 	auto settings = new HTTPServerSettings;
 	settings.port = 8080;
 	settings.bindAddresses = ["::1", "127.0.0.1"];
-	listenHTTP(settings, &hello);
+	auto listener = listenHTTP(settings, &hello);
+	scope (exit)
+	{
+		listener.stopListening();
+	}
 
 	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
 	runApplication();


### PR DESCRIPTION
otherwise the demo app creates a warning e.g. after ctrl-c about open resources.