### PR TITLE
Improve 'linker-D-flag' detection for ldmd2

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -352,7 +352,7 @@ config    /etc/dmd.conf
 		return args.map!(s => s.canFind(' ') ? "\""~s~"\"" : s);
 	}
 
-	private static bool isLinkerDFlag(string arg)
+	static bool isLinkerDFlag(string arg)
 	{
 		switch (arg) {
 			default:

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -333,7 +333,13 @@ config    /etc/dmd.conf
 		if (platform.platform.canFind("linux"))
 			args ~= "-L--no-as-needed"; // avoids linker errors due to libraries being specified in the wrong order by DMD
 		args ~= lflagsToDFlags(settings.lflags);
-		args ~= settings.dflags.filter!(f => isLinkerDFlag(f)).array;
+		if (platform.compiler == "ldc") {
+			// ldmd2: support the full LDC-specific list + extra "-m32mscoff", a superset of the DMD list
+			import dub.compilers.ldc : LDCCompiler;
+			args ~= settings.dflags.filter!(f => f == "-m32mscoff" || LDCCompiler.isLinkerDFlag(f)).array;
+		} else {
+			args ~= settings.dflags.filter!(f => isLinkerDFlag(f)).array;
+		}
 
 		auto res_file = getTempFile("dub-build", ".lnk");
 		std.file.write(res_file.toNativeString(), escapeArgs(args).join("\n"));

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -271,7 +271,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		return args.map!(s => s.canFind(' ') ? "\""~s~"\"" : s);
 	}
 
-	private static bool isLinkerDFlag(string arg)
+	static bool isLinkerDFlag(string arg)
 	{
 		if (arg.length > 2 && arg.startsWith("--"))
 			arg = arg[1 .. $]; // normalize to 1 leading hyphen


### PR DESCRIPTION
`ldmd2` supports all `ldc2` ones (and e.g. `-link-defaultlib-shared` is rather important).

Making these helper functions public will come in handy for reggae as well.