### PR TITLE
Extend 'linker dflags' detection for DMD

### DIFF
--- a/changelog/dmd-linker-dflags.dd
+++ b/changelog/dmd-linker-dflags.dd
@@ -1,0 +1,3 @@
+More 'linker dflags' with DMD
+
+`-betterC`, `-L…` and `-Xcc=…` `dflags` are now used for linking too.

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -355,11 +355,12 @@ config    /etc/dmd.conf
 	private static bool isLinkerDFlag(string arg)
 	{
 		switch (arg) {
-			default:
-				if (arg.startsWith("-defaultlib=")) return true;
-				return false;
-			case "-g", "-gc", "-m32", "-m64", "-shared", "-lib", "-m32mscoff":
+			case "-g", "-gc", "-m32", "-m64", "-shared", "-lib", "-m32mscoff", "-betterC":
 				return true;
+			default:
+				return arg.startsWith("-L")
+				    || arg.startsWith("-Xcc=")
+				    || arg.startsWith("-defaultlib=");
 		}
 	}
 }


### PR DESCRIPTION
`-betterC`, `-L…` and `-Xcc=…` influence linking.