### PR TITLE
Remove unused selective imports.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -15,14 +15,12 @@ import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
-import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;
 import std.conv;
 import std.exception;
 import std.process;
-import std.typecons : Flag;
 
 
 /** Returns a compiler handler for a given binary name.

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -12,7 +12,6 @@ import dub.compilers.utils;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.inet.path;
-import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -14,8 +14,7 @@ import std.algorithm : all, canFind, filter, map, sort;
 import std.array : appender, array, join;
 import std.conv : to;
 import std.exception : enforce;
-import std.typecons : Nullable;
-import std.string : format, indexOf, lastIndexOf;
+import std.string : format, lastIndexOf;
 
 
 /** Resolves dependency graph with multiple configurations per package.


### PR DESCRIPTION
This is a subset of #1948, which was stalled because of the danger of removing seemingly unused imports when coverage is < 100%. Refer to https://github.com/dlang/dub/pull/1948#issuecomment-630777513.

This PR removes private imports of symbols that do not occur elsewhere in the file, so they are safe to be removed.