### PR TITLE
Selectively import symbols from std.array.

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -20,8 +20,7 @@ import dub.packagemanager;
 import dub.project;
 
 import std.algorithm : map, filter, canFind, balancedParens;
-import std.array : array;
-import std.array;
+import std.array : array, appender, join;
 import std.exception;
 import std.file;
 import std.string;


### PR DESCRIPTION
Merged two imports from `std.array` into one. I manually verified that no other symbols from `std.array` are used anywhere in this file, so it should be safe to merge. Ref https://github.com/dlang/dub/pull/1948#issuecomment-630777513.