### PR TITLE
Remove unused imports from compiler.d.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -11,15 +11,12 @@ public import dub.compilers.buildsettings;
 public import dub.dependency : Dependency;
 public import dub.platform : BuildPlatform, matchesSpecification;
 
-import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
-import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
 import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;
-import std.conv;
 import std.exception;
 import std.process;
 import std.typecons : Flag;


### PR DESCRIPTION
No symbols from `dub.internal.vibecompat.core.file` are used in this file, nor from `dub.internal.vibecompat.inet.url` which is publicly imported. `dub.internal.vibecompat.inet.url` publicly imports `dub.internal.vibecompat.inet.path`, but that is also imported privately here.

No symbols from `dub.internal.vibecompat.data.json` are used in this file, nor from `dub.internal.vibecompat.data.serialization` which it publicly imports.

No symbols from `std.conv` are used in this file.