### PR TITLE
Refactor imports (inet.url -> inet.path).

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -19,7 +19,7 @@ import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.data.json;
-import dub.internal.vibecompat.inet.url;
+import dub.internal.vibecompat.inet.path;
 
 import std.algorithm;
 import std.array;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -14,7 +14,7 @@ import dub.internal.utils;
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.data.json;
-import dub.internal.vibecompat.inet.url;
+import dub.internal.vibecompat.inet.path;
 import dub.package_;
 import dub.packagemanager;
 import dub.generators.generator;

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -13,7 +13,7 @@ import dub.dependency;
 
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
-import dub.internal.vibecompat.inet.url;
+import dub.internal.vibecompat.inet.path;
 
 import std.algorithm : findSplit, sort;
 import std.array : join, split;


### PR DESCRIPTION
inet.path is publicly imported from inet.url, but only symbols from inet.path are used.