### PR TITLE
Remove unused std.range import.

### DIFF
--- a/source/dub/semver.d
+++ b/source/dub/semver.d
@@ -15,7 +15,6 @@
 */
 module dub.semver;
 
-import std.range;
 import std.string;
 import std.algorithm : max;
 import std.conv;


### PR DESCRIPTION
 No symbols from `std.range` appear in the file, nor from `std.range.primitives` nor from `std.range.interfaces`.