### PR TITLE
Refactor imports.

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -11,17 +11,14 @@ import dub.internal.utils;
 import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.data.json;
-import dub.internal.vibecompat.inet.url;
+import dub.internal.vibecompat.inet.path;
 import dub.package_;
 import dub.semver;
 
 import std.algorithm;
 import std.array;
 import std.exception;
-import std.regex;
 import std.string;
-import std.typecons;
-static import std.compiler;
 
 
 /** Encapsulates the name of a package along with its dependency specification.


### PR DESCRIPTION
`dub.internal.vibecompat.inet.url` is not directly used, but publicly imported `dub.internal.vibecompat.inet.path` is.

`splitter` is a used symbol, but it resolves to `std.string.splitter` (forcing use of `std.regex.splitter` gives a template instantiation error, so that is clearly not used). No other symbols from `std.regex` are used; checked manually.

No use of `std.typecons` symbols could be found.

`std.compiler` was statically imported, which was trivial to check.