### PR TITLE
Deprecate unused but public import.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -8,7 +8,7 @@
 module dub.compilers.compiler;
 
 public import dub.compilers.buildsettings;
-public import dub.dependency : Dependency;
+deprecated(`Please "import dub.dependency : Dependency" instead.`) public import dub.dependency : Dependency;
 public import dub.platform : BuildPlatform, matchesSpecification;
 
 import dub.internal.vibecompat.core.file;

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -8,7 +8,7 @@
 module dub.compilers.compiler;
 
 public import dub.compilers.buildsettings;
-deprecated(`Please "import dub.dependency : Dependency" instead.`) public import dub.dependency : Dependency;
+deprecated("Please `import dub.dependency : Dependency` instead") public import dub.dependency : Dependency;
 public import dub.platform : BuildPlatform, matchesSpecification;
 
 import dub.internal.vibecompat.core.file;


### PR DESCRIPTION
`Dependency` is publicly imported, but not used in this file. Mark for future removal by deprecating it.

Ref comment by @WebFreak001 in https://github.com/dlang/dub/pull/1948/files#r427248952