### PR TITLE
Remove unused imports.

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -16,10 +16,8 @@ import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;
-import std.conv;
 import std.exception;
 import std.file;
-import std.process;
 import std.typecons;
 
 // Determines whether the specified process is running under WOW64 or an Intel64 of x64 processor.

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -16,7 +16,6 @@ import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;
-import std.conv;
 import std.exception;
 import std.file;
 import std.process;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -16,10 +16,8 @@ import dub.recipe.packagerecipe : ToolchainRequirements;
 
 import std.algorithm;
 import std.array;
-import std.conv;
 import std.exception;
 import std.file;
-import std.process;
 import std.typecons;
 
 


### PR DESCRIPTION
Manually checked that no symbols from these imports are used.

`dmd.d` does use `std.conv: text`, but it already imports it locally.