### PR TITLE
Actually copy copyFiles when building in Visual Studio.

### DIFF
--- a/changelog/visuald-copyfiles.dd
+++ b/changelog/visuald-copyfiles.dd
@@ -1,0 +1,5 @@
+copyFiles can now be used in VisualD projects.
+
+Files that are needed for the application to run can be specified in the `copyFiles` build option,
+which causes these files to be copied to the target path. The dub generator for VisualD now replicates
+this behaviour, so that this kind of applications can be successfully debugged in Visual Studio.

--- a/test/issue1053-extra-files-visuald.sh
+++ b/test/issue1053-extra-files-visuald.sh
@@ -21,6 +21,6 @@ if [ `grep -c -e "README.txt" .dub/extra_files.visualdproj` -ne 1 ]; then
 	die $LINENO 'Regression of issue #1053.'
 fi
 
-if [ `grep -e "README.txt" .dub/extra_files.visualdproj | grep -c -e "copy /Y $(InputPath) $(TargetDir)"` -ne 1 ]; then
+if [ `grep -e "README.txt" .dub/extra_files.visualdproj | grep -c -e 'copy /Y $(InputPath) $(TargetDir)'` -ne 1 ]; then
 	die $LINENO 'Copying of copyFiles seems broken for visuald.'
 fi

--- a/test/issue1053-extra-files-visuald.sh
+++ b/test/issue1053-extra-files-visuald.sh
@@ -20,3 +20,7 @@ fi
 if [ `grep -c -e "README.txt" .dub/extra_files.visualdproj` -ne 1 ]; then
 	die $LINENO 'Regression of issue #1053.'
 fi
+
+if [ `grep -e "README.txt" .dub/extra_files.visualdproj | grep -c -e "copy /Y $(InputPath) $(TargetDir)"` -ne 1 ]; then
+	die $LINENO 'Copying of copyFiles seems broken for visuald.'
+fi


### PR DESCRIPTION
From the changelog:

copyFiles can now be used in VisualD projects.
---------------------------------------------------

Files that are needed for the application to run can be specified in the `copyFiles` build option, which causes these files to be copied to the target path. The dub generator for VisualD now replicates this behaviour, so that this kind of applications can be successfully debugged in Visual Studio.
