### PR TITLE
import 'std.variant.Algebraic' properly

### DIFF
--- a/source/dub/internal/sdlang/lexer.d
+++ b/source/dub/internal/sdlang/lexer.d
@@ -17,7 +17,6 @@ import std.traits;
 import std.typecons;
 import std.uni;
 import std.utf;
-import std.variant;
 
 import dub.internal.sdlang.exception;
 import dub.internal.sdlang.symbol;

--- a/source/dub/internal/sdlang/parser.d
+++ b/source/dub/internal/sdlang/parser.d
@@ -7,6 +7,7 @@ version (Have_sdlang_d) public import sdlang.parser;
 else:
 
 import std.file;
+import std.variant : Algebraic;
 
 import dub.internal.libInputVisitor;
 
@@ -118,7 +119,7 @@ auto pullParseSource(string source, string filename=null)
 }
 
 /// The element of the InputRange returned by pullParseFile and pullParseSource:
-alias ParserEvent = std.variant.Algebraic!(
+alias ParserEvent = Algebraic!(
 	FileStartEvent,
 	FileEndEvent,
 	TagStartEvent,


### PR DESCRIPTION
I'm currently trying to solve a [DMD bug](https://github.com/dlang/dmd/pull/12215) and that has revealed one line relying on it because if you check the code you can realize there is no way to access `std.variant.Algebraic` from here because the `import std.variant;` from `lexer.d` is not `public`.
I suppose these are traces of when imports were public by default.