### PR TITLE
Only show package.d warning once

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -671,6 +671,7 @@ class Dub {
 			string[] import_modules;
 			if (settings.single)
 				lbuildsettings.importPaths ~= NativePath(mainfil).parentPath.toNativeString;
+			bool firstTimePackage = true;
 			foreach (file; lbuildsettings.sourceFiles) {
 				if (file.endsWith(".d")) {
 					auto fname = NativePath(file).head.name;
@@ -683,7 +684,10 @@ class Dub {
 						continue;
 					}
 					if (fname == "package.d") {
-						logWarn("Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847");
+						if (firstTimePackage) {
+							firstTimePackage = false;
+							logWarn("Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847");
+						}
 						continue;
 					}
 					import_modules ~= dub.internal.utils.determineModuleName(lbuildsettings, NativePath(file), m_project.rootPackage.path);


### PR DESCRIPTION
Every time I `dub test` my command line is flooded with multiple lines of the exact same warning "Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847". 
The bug in dmd is now fixed, so ideally this PR gets superseded by a fix in dub.
I'm totally unfamiliar with the dub codebase though, so in the meanwhile this should be a simple improvement.