### PR TITLE
Fix dependency build settings flooding dflags

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -13,7 +13,8 @@ import std.array : array;
 import std.algorithm : filter, any;
 import std.path : globMatch;
 import std.typecons : BitFlags;
-
+import std.algorithm.iteration : uniq;
+import std.range : chain;
 
 /// BuildPlatform specific settings, like needed libraries or additional
 /// include paths.
@@ -105,7 +106,7 @@ struct BuildSettings {
 		addPostRunCommands(bs.postRunCommands);
 	}
 
-	void addDFlags(in string[] value...) { dflags ~= value; }
+	void addDFlags(in string[] value...) { dflags = chain(dflags, value.dup).uniq.array; }
 	void prependDFlags(in string[] value...) { prepend(dflags, value); }
 	void removeDFlags(in string[] value...) { remove(dflags, value); }
 	void addLFlags(in string[] value...) { lflags ~= value; }


### PR DESCRIPTION
from `depen-build-settings` test

```
/usr/bin/dmd -X -X -X -X -c -of.dub/build/application-debug-linux.posix-x86_64-dmd_v2.096.1-25506C1B97B12F5C72F39C8661659746/depen-build-settings.o -debug -g -w -version=Have_depen_build_settings -version=Have_depend1 -version=Have_depend2 -Isource/ -Idepend/source/ -Idepend/depend2/source/ source/app.d -vcolumns
```
this fixes the barrage of -X flags you can see here