### PR TITLE
Create folders before copying file during generator finalization.

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -865,6 +865,7 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 				}
 				logDiagnostic("  %s to %s", src.toNativeString(), dst.toNativeString());
 				try {
+					mkdirRecurse(dst.parentPath().toNativeString());
 					hardLinkFile(src, dst, true);
 				} catch(Exception e) logWarn("Failed to copy %s to %s: %s", src.toNativeString(), dst.toNativeString(), e.msg);
 			}


### PR DESCRIPTION
Should be a simple start for my first contribution on github :)

Only tested on https://github.com/dayllenger/beamui.git so far.
   dub generate visuald :opengl
now works and project files are generated.

Other older issues with relative paths in visuald generated subprojects are still hindering it to build though.
Might have a solution for this later...

regards
/Thomas