### PR TITLE
PackageManager must know placement dir

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -236,7 +236,7 @@ struct CommandLineHandler
 		if (options.bare) {
 			dub = new Dub(NativePath(getcwd()));
 			dub.rootPath = NativePath(options.root_path);
-			dub.defaultPlacementLocation = options.placementLocation;
+			dub.placementLocation = options.placementLocation;
 
 			return dub;
 		}
@@ -258,7 +258,7 @@ struct CommandLineHandler
 
 		dub = new Dub(options.root_path, package_suppliers, options.skipRegistry);
 		dub.dryRun = options.annotate;
-		dub.defaultPlacementLocation = options.placementLocation;
+		dub.placementLocation = options.placementLocation;
 
 		// make the CWD package available so that for example sub packages can reference their
 		// parent package.
@@ -1289,7 +1289,7 @@ class BuildCommand : GenerateCommand {
 			dep = Dependency(p.version_);
 		}
 
-		dub.fetch(packageParts.name, dep, dub.defaultPlacementLocation, FetchOptions.none);
+		dub.fetch(packageParts.name, dep, FetchOptions.none);
 		return 0;
 	}
 }
@@ -1833,8 +1833,6 @@ class FetchCommand : FetchRemoveCommand {
 		enforceUsage(free_args.length == 1, "Expecting exactly one argument.");
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
-		auto location = dub.defaultPlacementLocation;
-
 		auto name = free_args[0];
 
 		FetchOptions fetchOpts;
@@ -1842,13 +1840,13 @@ class FetchCommand : FetchRemoveCommand {
 		if (m_version.length) { // remove then --version removed
 			enforceUsage(!name.canFindVersionSplitter, "Double version spec not allowed.");
 			logWarn("The '--version' parameter was deprecated, use %s@%s. Please update your scripts.", name, m_version);
-			dub.fetch(name, Dependency(m_version), location, fetchOpts);
+			dub.fetch(name, Dependency(m_version), fetchOpts);
 		} else if (name.canFindVersionSplitter) {
 			const parts = name.splitPackageName;
-			dub.fetch(parts.name, Dependency(parts.version_), location, fetchOpts);
+			dub.fetch(parts.name, Dependency(parts.version_), fetchOpts);
 		} else {
 			try {
-				dub.fetch(name, Dependency(">=0.0.0"), location, fetchOpts);
+				dub.fetch(name, Dependency(">=0.0.0"), fetchOpts);
 				logInfo(
 					"Please note that you need to use `dub run <pkgname>` " ~
 					"or add it to dependencies of your package to actually use/run it. " ~
@@ -1857,7 +1855,7 @@ class FetchCommand : FetchRemoveCommand {
 			catch(Exception e){
 				logInfo("Getting a release version failed: %s", e.msg);
 				logInfo("Retry with ~master...");
-				dub.fetch(name, Dependency("~master"), location, fetchOpts);
+				dub.fetch(name, Dependency("~master"), fetchOpts);
 			}
 		}
 		return 0;
@@ -1905,7 +1903,7 @@ class RemoveCommand : FetchRemoveCommand {
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 
 		auto package_id = free_args[0];
-		auto location = dub.defaultPlacementLocation;
+		auto location = dub.placementLocation;
 
 		size_t resolveVersion(in Package[] packages) {
 			// just remove only package version

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -638,7 +638,7 @@ unittest { // issue #1235 - pass no library files to compiler command line when 
 
 	auto desc = parseJsonString(`{"name": "test", "targetType": "library", "sourceFiles": ["foo.d", "`~libfile~`"]}`);
 	auto pack = new Package(desc, NativePath("/tmp/fooproject"));
-	auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), false);
+	auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), PlacementLocation.user, false);
 	auto prj = new Project(pman, pack);
 
 	final static class TestCompiler : GDCCompiler {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -31,6 +31,7 @@ import std.zip;
 class PackageManager {
 	private {
 		Repository[] m_repositories;
+		size_t m_placementLocationRepositoryIdx;
 		NativePath[] m_searchPath;
 		Package[] m_packages;
 		Package[] m_temporaryPackages;
@@ -64,14 +65,34 @@ class PackageManager {
 		if (refresh_packages) refresh(true);
 	}
 
-	this(NativePath package_path, NativePath user_path, NativePath system_path, bool refresh_packages = true)
+	import dub.project: PlacementLocation;
+
+	this(NativePath package_path, NativePath user_path, NativePath system_path, in PlacementLocation placementLocation, bool refresh_packages = true)
 	{
 		m_repositories = [
 			Repository(package_path ~ ".dub/packages/"),
 			Repository(user_path ~ "packages/"),
 			Repository(system_path ~ "packages/")];
 
+		setPlacementLocation(placementLocation);
 		if (refresh_packages) refresh(true);
+	}
+
+	/** Placement location of fetched packages. */
+	void setPlacementLocation(PlacementLocation placement)
+	{
+		with(PlacementLocation)
+		final switch (placement)
+		{
+			case local: m_placementLocationRepositoryIdx = 0; break;
+			case user: m_placementLocationRepositoryIdx = 1; break;
+			case system: m_placementLocationRepositoryIdx = 2; break;
+		}
+	}
+
+	package NativePath placementLocationDir() const
+	{
+		return m_repositories[m_placementLocationRepositoryIdx].packagePath;
 	}
 
 	/** Gets/sets the list of paths to search for local packages.

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -16,7 +16,7 @@ import dub.internal.vibecompat.core.log;
 import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
 import dub.package_;
-import dub.packagemanager;
+import dub.packagemanager: PackageManager;
 import dub.generators.generator;
 
 import std.algorithm;


### PR DESCRIPTION
upd: For now if you try to replace PackageManager arguments (representing repositories dirs) you will catch inconsistency between provided dirs where dub will search packages and dirs where dub stores fetched packages.

This PR:
* Removes duplicate definition of paths to local repositories
* Adds possibility for user defined PackageManager (PR what opens this ability is coming soon)