### PR TITLE
Draft: Dependency resolution is faulty

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1261,7 +1261,7 @@ class BuildCommand : GenerateCommand {
 			// the user provided a version manually
 			dep = Dependency(packageParts.version_);
 		} else {
-			if (packageParts.name._pid.startsWith(":") ||
+			if (packageParts.name.pid.startsWith(":") ||
 				dub.packageManager.getFirstPackage(packageParts.name))
 				// found locally
 				return 0;

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2758,15 +2758,15 @@ private PackageAndVersion splitPackageName(string package_name)
 unittest
 {
 	// https://github.com/dlang/dub/issues/1681
-	assert(splitPackageName("") == PackageAndVersion("", null));
+	assert(splitPackageName("") == PackageAndVersion(PackageName(""), null));
 
-	assert(splitPackageName("foo") == PackageAndVersion("foo", null));
-	assert(splitPackageName("foo=1.0.1") == PackageAndVersion("foo", "1.0.1"));
-	assert(splitPackageName("foo@1.0.1") == PackageAndVersion("foo", "1.0.1"));
-	assert(splitPackageName("foo@==1.0.1") == PackageAndVersion("foo", "==1.0.1"));
-	assert(splitPackageName("foo@>=1.0.1") == PackageAndVersion("foo", ">=1.0.1"));
-	assert(splitPackageName("foo@~>1.0.1") == PackageAndVersion("foo", "~>1.0.1"));
-	assert(splitPackageName("foo@<1.0.1") == PackageAndVersion("foo", "<1.0.1"));
+	assert(splitPackageName("foo") == PackageAndVersion(PackageName("foo"), null));
+	assert(splitPackageName("foo=1.0.1") == PackageAndVersion(PackageName("foo"), "1.0.1"));
+	assert(splitPackageName("foo@1.0.1") == PackageAndVersion(PackageName("foo"), "1.0.1"));
+	assert(splitPackageName("foo@==1.0.1") == PackageAndVersion(PackageName("foo"), "==1.0.1"));
+	assert(splitPackageName("foo@>=1.0.1") == PackageAndVersion(PackageName("foo"), ">=1.0.1"));
+	assert(splitPackageName("foo@~>1.0.1") == PackageAndVersion(PackageName("foo"), "~>1.0.1"));
+	assert(splitPackageName("foo@<1.0.1") == PackageAndVersion(PackageName("foo"), "<1.0.1"));
 }
 
 private ulong canFindVersionSplitter(string package_name)

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1261,7 +1261,7 @@ class BuildCommand : GenerateCommand {
 			// the user provided a version manually
 			dep = Dependency(packageParts.version_);
 		} else {
-			if (packageParts.name._pn.startsWith(":") ||
+			if (packageParts.name._pid.startsWith(":") ||
 				dub.packageManager.getFirstPackage(packageParts.name))
 				// found locally
 				return 0;

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -7,6 +7,7 @@
 */
 module dub.compilers.utils;
 
+import dub.dependency : PackageName;
 import dub.compilers.buildsettings;
 import dub.platform : BuildPlatform, archCheck, compilerCheck, platformCheck;
 import dub.internal.vibecompat.core.log;
@@ -147,7 +148,7 @@ void resolveLibs(ref BuildSettings settings, const scope ref BuildPlatform platf
 	(`BuildRequirements`). This function will output warning messages to
 	assist the user in making the best choice.
 */
-void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, string package_name, string config_name)
+void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, PackageName package_name, string config_name)
 {
 	import std.algorithm : any, endsWith, startsWith;
 	import std.range : empty;

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -7,7 +7,7 @@
 */
 module dub.compilers.utils;
 
-import dub.dependency : PackageName;
+import dub.dependency : PackageId;
 import dub.compilers.buildsettings;
 import dub.platform : BuildPlatform, archCheck, compilerCheck, platformCheck;
 import dub.internal.vibecompat.core.log;
@@ -148,7 +148,7 @@ void resolveLibs(ref BuildSettings settings, const scope ref BuildPlatform platf
 	(`BuildRequirements`). This function will output warning messages to
 	assist the user in making the best choice.
 */
-void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, PackageName package_name, string config_name)
+void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, PackageId package_id, string config_name)
 {
 	import std.algorithm : any, endsWith, startsWith;
 	import std.range : empty;
@@ -205,8 +205,8 @@ void warnOnSpecialCompilerFlags(string[] compiler_flags, BuildOptions options, P
 		if (got_preamble) return;
 		got_preamble = true;
 		logWarn("");
-		if (config_name.empty) logWarn("## Warning for package %s ##", package_name);
-		else logWarn("## Warning for package %s, configuration %s ##", package_name, config_name);
+		if (config_name.empty) logWarn("## Warning for package %s ##", package_id);
+		else logWarn("## Warning for package %s, configuration %s ##", package_id, config_name);
 		logWarn("");
 		logWarn("The following compiler flags have been specified in the package description");
 		logWarn("file. They are handled by DUB and direct use in packages is discouraged.");

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -27,10 +27,13 @@ struct PackageId				// TODO move to dub.package_.
 {
 	this(string pid) @safe pure nothrow @nogc
 	{
-		_pid = pid;
+		this._pid = pid;
 	}
-	// TODO: remove _pid to pid?
-	string _pid;					// TODO: make private?
+	@property string pid() const @safe pure nothrow @nogc
+	{
+		return _pid;
+	}
+	string _pid;
 	alias _pid this;
 }
 

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -482,7 +482,7 @@ struct Dependency {
 	bool matches(ref const(Version) v) const {
 		if (this.matchesAny) return true;
 		if (this.isSCM) return true;
-		//logDebug(" try match: %s with: %s", v, this);
+		//logDebug("Trying match: %s with: %s", v, this);
 		// Master only matches master
 		if(m_versA.isBranch) {
 			enforce(m_versA == m_versB);

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -23,7 +23,7 @@ import std.string;
 /**
    Package name.
 */
-struct PackageName				// TODO move to dub.package_.
+struct PackageId				// TODO move to dub.package_.
 {
 	string _pn;
 	alias _pn this;
@@ -33,7 +33,7 @@ struct PackageName				// TODO move to dub.package_.
 */
 struct PackageDependency {
 	/// Name of the referenced package.
-	PackageName name;
+	PackageId name;
 
 	/// Dependency specification used to select a particular version of the package.
 	Dependency spec;

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -25,8 +25,13 @@ import std.string;
 */
 struct PackageId				// TODO move to dub.package_.
 {
-	string _pn;
-	alias _pn this;
+	this(string pid) @safe pure nothrow @nogc
+	{
+		_pid = pid;
+	}
+	// TODO: remove _pid to pid?
+	string _pid;					// TODO: make private?
+	alias _pid this;
 }
 
 /** Encapsulates the name of a package along with its dependency specification.

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -20,12 +20,20 @@ import std.array;
 import std.exception;
 import std.string;
 
+/**
+   Package name.
+*/
+struct PackageName				// TODO move to dub.package_.
+{
+	string _pn;
+	alias _pn this;
+}
 
 /** Encapsulates the name of a package along with its dependency specification.
 */
 struct PackageDependency {
 	/// Name of the referenced package.
-	string name;
+	PackageName name;
 
 	/// Dependency specification used to select a particular version of the package.
 	Dependency spec;

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -340,7 +340,7 @@ enum DependencyType {
 private PackageId basePackageName(PackageId p)
 {
 	import std.algorithm.searching : findSplit;
-	return typeof(return)(p._pid.findSplit(":")[0]);
+	return typeof(return)(p.pid.findSplit(":")[0]);
 }
 
 unittest {

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -340,7 +340,7 @@ enum DependencyType {
 private PackageId basePackageName(PackageId p)
 {
 	import std.algorithm.searching : findSplit;
-	return typeof(return)(p._pn.findSplit(":")[0]);
+	return typeof(return)(p._pid.findSplit(":")[0]);
 }
 
 unittest {

--- a/source/dub/description.d
+++ b/source/dub/description.d
@@ -64,14 +64,14 @@ struct ProjectDescription {
 */
 struct PackageDescription {
 	string path; /// Path to the package
-	string name; /// Qualified name of the package
+	PackageName name; /// Qualified name of the package
 	Version version_; /// Version of the package
 	string description;
 	string homepage;
 	string[] authors;
 	string copyright;
 	string license;
-	string[] dependencies;
+	PackageName[] dependencies;
 
 	bool active; /// Does this package take part in the build?
 	string configuration; /// The configuration that is built
@@ -115,12 +115,12 @@ struct PackageDescription {
 	Describes the settings necessary to build a certain binary target.
 */
 struct TargetDescription {
-	string rootPackage; /// Main package associated with this target, this is also the name of the target.
-	string[] packages; /// All packages contained in this target (e.g. for target type "sourceLibrary")
+	PackageName rootPackage; /// Main package associated with this target, this is also the name of the target.
+	PackageName[] packages; /// All packages contained in this target (e.g. for target type "sourceLibrary")
 	string rootConfiguration; /// Build configuration of the target's root package used for building
 	BuildSettings buildSettings; /// Final build settings to use when building the target
-	string[] dependencies; /// List of all dependencies of this target (package names)
-	string[] linkDependencies; /// List of all link-dependencies of this target (target names)
+	PackageName[] dependencies; /// List of all dependencies of this target (package names)
+	PackageName[] linkDependencies; /// List of all link-dependencies of this target (target names)
 }
 
 /**

--- a/source/dub/description.d
+++ b/source/dub/description.d
@@ -19,7 +19,7 @@ import dub.internal.vibecompat.data.serialization;
 	and configuration that has been selected.
 */
 struct ProjectDescription {
-	PackageName rootPackage; /// Name of the root package being built
+	PackageId rootPackage; /// Name of the root package being built
 	string configuration; /// Name of the selected build configuration
 	string buildType; /// Name of the selected build type
 	string compiler; /// Canonical name of the compiler used (e.g. "dmd", "gdc" or "ldc")
@@ -64,14 +64,14 @@ struct ProjectDescription {
 */
 struct PackageDescription {
 	string path; /// Path to the package
-	PackageName name; /// Qualified name of the package
+	PackageId name; /// Qualified name of the package
 	Version version_; /// Version of the package
 	string description;
 	string homepage;
 	string[] authors;
 	string copyright;
 	string license;
-	PackageName[] dependencies;
+	PackageId[] dependencies;
 
 	bool active; /// Does this package take part in the build?
 	string configuration; /// The configuration that is built
@@ -115,12 +115,12 @@ struct PackageDescription {
 	Describes the settings necessary to build a certain binary target.
 */
 struct TargetDescription {
-	PackageName rootPackage; /// Main package associated with this target, this is also the name of the target.
-	PackageName[] packages; /// All packages contained in this target (e.g. for target type "sourceLibrary")
+	PackageId rootPackage; /// Main package associated with this target, this is also the name of the target.
+	PackageId[] packages; /// All packages contained in this target (e.g. for target type "sourceLibrary")
 	string rootConfiguration; /// Build configuration of the target's root package used for building
 	BuildSettings buildSettings; /// Final build settings to use when building the target
-	PackageName[] dependencies; /// List of all dependencies of this target (package names)
-	PackageName[] linkDependencies; /// List of all link-dependencies of this target (target names)
+	PackageId[] dependencies; /// List of all dependencies of this target (package names)
+	PackageId[] linkDependencies; /// List of all link-dependencies of this target (target names)
 }
 
 /**

--- a/source/dub/description.d
+++ b/source/dub/description.d
@@ -19,7 +19,7 @@ import dub.internal.vibecompat.data.serialization;
 	and configuration that has been selected.
 */
 struct ProjectDescription {
-	string rootPackage; /// Name of the root package being built
+	PackageName rootPackage; /// Name of the root package being built
 	string configuration; /// Name of the selected build configuration
 	string buildType; /// Name of the selected build type
 	string compiler; /// Canonical name of the compiler used (e.g. "dmd", "gdc" or "ldc")

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1718,10 +1718,10 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 	{
 		import std.array : appender;
 		auto ret = appender!(TreeNodes[]);
-		auto pack = getPackage(node.pack, node.config);
+		auto pack = getPackage(node.package_name, node.config);
 		if (!pack) {
 			// this can hapen when the package description contains syntax errors
-			logDebug("Invalid package in dependency tree: %s %s", node.pack, node.config);
+			logDebug("Invalid package in dependency tree: %s %s", node.package_name, node.config);
 			return null;
 		}
 		auto basepack = pack.basePackage;
@@ -1747,7 +1747,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 					enforce(d.spec.path.empty || absdeppath == desireddeppath || absdeppath == altdeppath,
 						format("Dependency from %s to %s uses wrong path: %s vs. %s",
-							node.pack, subpack.name, absdeppath.toNativeString(), desireddeppath.toNativeString()));
+							node.package_name, subpack.name, absdeppath.toNativeString(), desireddeppath.toNativeString()));
 				}
 				ret ~= TreeNodes(d.name, node.config);
 				continue;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -573,7 +573,7 @@ class Dub {
 
 		foreach (p; versions.byKey) {
 			auto ver = versions[p]; // Workaround for DMD 2.070.0 AA issue (crashes in aaApply2 if iterating by key+value)
-			assert(!p._pn.canFind(":"), "Resolved packages contain a sub package!?: "~p);
+			assert(!p._pid.canFind(":"), "Resolved packages contain a sub package!?: "~p);
 			Package pack;
 			if (!ver.path.empty) {
 				try pack = m_packageManager.getOrLoadPackage(ver.path);
@@ -1851,7 +1851,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 		auto prerelease = (m_options & UpgradeOptions.preRelease) != 0;
 
-		auto rootpack = PackageId(name._pn.split(":")[0]);
+		auto rootpack = PackageId(name._pid.split(":")[0]);
 
 		foreach (ps; m_dub.m_packageSuppliers) {
 			if (rootpack == name) {

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -573,7 +573,7 @@ class Dub {
 
 		foreach (p; versions.byKey) {
 			auto ver = versions[p]; // Workaround for DMD 2.070.0 AA issue (crashes in aaApply2 if iterating by key+value)
-			assert(!p._pid.canFind(":"), "Resolved packages contain a sub package!?: "~p);
+			assert(!p.pid.canFind(":"), "Resolved packages contain a sub package!?: "~p);
 			Package pack;
 			if (!ver.path.empty) {
 				try pack = m_packageManager.getOrLoadPackage(ver.path);
@@ -1851,7 +1851,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 		auto prerelease = (m_options & UpgradeOptions.preRelease) != 0;
 
-		auto rootpack = PackageId(name._pid.split(":")[0]);
+		auto rootpack = PackageId(name.pid.split(":")[0]);
 
 		foreach (ps; m_dub.m_packageSuppliers) {
 			if (rootpack == name) {

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -7,6 +7,7 @@
 */
 module dub.generators.build;
 
+import dub.dependency : PackageName;
 import dub.compilers.compiler;
 import dub.compilers.utils;
 import dub.generators.generator;
@@ -189,8 +190,8 @@ class BuildGenerator : ProjectGenerator {
 
 		NativePath target_path;
 		if (settings.tempBuild) {
-			string packageName = pack.basePackage is null ? pack.name : pack.basePackage.name;
-			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
+			PackageName package_name = pack.basePackage is null ? pack.name : pack.basePackage.name;
+			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", package_name, pack.version_, build_id);
 		}
 		else target_path = pack.path ~ format(".dub/build/%s/", build_id);
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -7,7 +7,7 @@
 */
 module dub.generators.build;
 
-import dub.dependency : PackageName;
+import dub.dependency : PackageId;
 import dub.compilers.compiler;
 import dub.compilers.utils;
 import dub.generators.generator;
@@ -190,8 +190,8 @@ class BuildGenerator : ProjectGenerator {
 
 		NativePath target_path;
 		if (settings.tempBuild) {
-			PackageName package_name = pack.basePackage is null ? pack.name : pack.basePackage.name;
-			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", package_name, pack.version_, build_id);
+			PackageId package_id = pack.basePackage is null ? pack.name : pack.basePackage.name;
+			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", package_id, pack.version_, build_id);
 		}
 		else target_path = pack.path ~ format(".dub/build/%s/", build_id);
 

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -7,6 +7,7 @@
 */
 module dub.generators.generator;
 
+import dub.dependency : PackageName;
 import dub.compilers.compiler;
 import dub.generators.cmake;
 import dub.generators.build;
@@ -61,14 +62,14 @@ class ProjectGenerator
 			This list includes dependencies that are not the root of a binary
 			target.
 		*/
-		string[] dependencies;
+		PackageName[] dependencies;
 
 		/** List of all binary dependencies.
 
 			This list includes all dependencies that are the root of a binary
 			target.
 		*/
-		string[] linkDependencies;
+		PackageName[] linkDependencies;
 	}
 
 	private struct EnvironmentVariables
@@ -134,7 +135,7 @@ class ProjectGenerator
 
 		if (!settings.config.length) settings.config = m_project.getDefaultConfiguration(settings.platform);
 
-		string[string] configs = m_project.getPackageConfigs(settings.platform, settings.config);
+		string[PackageName] configs = m_project.getPackageConfigs(settings.platform, settings.config);
 		TargetInfo[string] targets;
 		EnvironmentVariables[string] envs;
 
@@ -945,6 +946,7 @@ void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	}
 
 	auto depNames = proj.dependencies.map!((a) => a.name).array();
+
 	storeRecursiveInvokations(env, proj.rootPackage.name ~ depNames);
 	runCommands(commands, env, pack.path().toString());
 }
@@ -960,7 +962,7 @@ private bool isRecursiveInvocation(string pack)
         .canFind(pack);
 }
 
-private void storeRecursiveInvokations(string[string] env, string[] packs)
+private void storeRecursiveInvokations(string[string] env, PackageName[] packs)
 {
 	import std.algorithm : canFind, splitter;
 	import std.range : chain;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -7,7 +7,7 @@
 */
 module dub.generators.generator;
 
-import dub.dependency : PackageName;
+import dub.dependency : PackageId;
 import dub.compilers.compiler;
 import dub.generators.cmake;
 import dub.generators.build;
@@ -62,14 +62,14 @@ class ProjectGenerator
 			This list includes dependencies that are not the root of a binary
 			target.
 		*/
-		PackageName[] dependencies;
+		PackageId[] dependencies;
 
 		/** List of all binary dependencies.
 
 			This list includes all dependencies that are the root of a binary
 			target.
 		*/
-		PackageName[] linkDependencies;
+		PackageId[] linkDependencies;
 	}
 
 	private struct EnvironmentVariables
@@ -135,7 +135,7 @@ class ProjectGenerator
 
 		if (!settings.config.length) settings.config = m_project.getDefaultConfiguration(settings.platform);
 
-		string[PackageName] configs = m_project.getPackageConfigs(settings.platform, settings.config);
+		string[PackageId] configs = m_project.getPackageConfigs(settings.platform, settings.config);
 		TargetInfo[string] targets;
 		EnvironmentVariables[string] envs;
 
@@ -962,7 +962,7 @@ private bool isRecursiveInvocation(string pack)
         .canFind(pack);
 }
 
-private void storeRecursiveInvokations(string[string] env, PackageName[] packs)
+private void storeRecursiveInvokations(string[string] env, PackageId[] packs)
 {
 	import std.algorithm : canFind, splitter;
 	import std.range : chain;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -341,7 +341,7 @@ class ProjectGenerator
 
 			// get specified dependencies, e.g. vibe-d ~0.8.1
 			auto deps = pack.getDependencies(targets[pack.name].config);
-			logDebug("deps: %s -> %(%s, %)", pack.name, deps.byKey);
+			logDebug("Dependency is %s -> %(%s, %)", pack.name, deps.byKey);
 			foreach (depname; deps.keys.sort())
 			{
 				auto depspec = deps[depname];
@@ -503,7 +503,7 @@ class ProjectGenerator
 				{
 					NativePath op;
 					if (f != o && NativePath(f).head == (op = NativePath(o)).head) {
-						logDebug("string import %s overridden by %s", f, o);
+						logDebug("String import %s overridden by %s", f, o);
 						f = o;
 						any_override = true;
 					}
@@ -938,7 +938,7 @@ void runBuildCommands(in string[] commands, in Package pack, in Project proj,
 	env["DUB_ROOT_PACKAGE_TARGET_TYPE"] = to!string(rootPackageBuildSettings.targetType);
 	env["DUB_ROOT_PACKAGE_TARGET_PATH"] = rootPackageBuildSettings.targetPath;
 	env["DUB_ROOT_PACKAGE_TARGET_NAME"] = rootPackageBuildSettings.targetName;
-	
+
 	foreach (aa; extraVars) {
 		foreach (k, v; aa)
 			env[k] = v;

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -7,6 +7,7 @@
 */
 module dub.generators.visuald;
 
+import dub.dependency : PackageName;
 import dub.compilers.compiler;
 import dub.generators.generator;
 import dub.internal.utils;
@@ -438,7 +439,7 @@ class VisualDGenerator : ProjectGenerator {
 			} // foreach(architecture)
 		}
 
-		void performOnDependencies(const Package main, string[string] configs, void delegate(const Package pack) op)
+		void performOnDependencies(const Package main, string[PackageName] configs, void delegate(const Package pack) op)
 		{
 			foreach (p; m_project.getTopologicalPackageList(false, main, configs)) {
 				if (p is main) continue;

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -208,7 +208,7 @@ class VisualDGenerator : ProjectGenerator {
 			ret.formattedWrite("  <Folder name=\"%s\">", getPackageFileName(packname));
 			typeof(NativePath.init.head)[] lastFolder;
 			foreach(source; sortedSources(sourceFiles.values)) {
-				logDebug("source looking at %s", source.structurePath);
+				logDebug("Source looking at %s", source.structurePath);
 				auto cur = source.structurePath.parentPath.bySegment.array;
 				if(lastFolder != cur) {
 					size_t same = 0;

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -7,7 +7,7 @@
 */
 module dub.generators.visuald;
 
-import dub.dependency : PackageName;
+import dub.dependency : PackageId;
 import dub.compilers.compiler;
 import dub.generators.generator;
 import dub.internal.utils;
@@ -439,7 +439,7 @@ class VisualDGenerator : ProjectGenerator {
 			} // foreach(architecture)
 		}
 
-		void performOnDependencies(const Package main, string[PackageName] configs, void delegate(const Package pack) op)
+		void performOnDependencies(const Package main, string[PackageId] configs, void delegate(const Package pack) op)
 		{
 			foreach (p; m_project.getTopologicalPackageList(false, main, configs)) {
 				if (p is main) continue;

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -38,7 +38,7 @@ import std.string;
 			package recipe and the file format used to store it prior to
 			writing it to disk.
 */
-void initPackage(NativePath root_path, string[PackageName] deps, string type,
+void initPackage(NativePath root_path, string[PackageId] deps, string type,
 	PackageFormat format, scope RecipeCallback recipe_callback = null)
 {
 	import std.conv : to;
@@ -112,7 +112,7 @@ void main()
 
 private void initVibeDPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
-	auto vibed = PackageName("vibe-d");
+	auto vibed = PackageId("vibe-d");
 	if (vibed !in p.buildSettings.dependencies)
 		p.buildSettings.dependencies[vibed] = Dependency("~>0.9");
 	p.description = "A simple vibe.d server application.";

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -38,7 +38,7 @@ import std.string;
 			package recipe and the file format used to store it prior to
 			writing it to disk.
 */
-void initPackage(NativePath root_path, string[string] deps, string type,
+void initPackage(NativePath root_path, string[PackageName] deps, string type,
 	PackageFormat format, scope RecipeCallback recipe_callback = null)
 {
 	import std.conv : to;
@@ -112,8 +112,9 @@ void main()
 
 private void initVibeDPackage(NativePath root_path, ref PackageRecipe p, scope void delegate() pre_write_callback)
 {
-	if ("vibe-d" !in p.buildSettings.dependencies)
-		p.buildSettings.dependencies["vibe-d"] = Dependency("~>0.9");
+	auto vibed = PackageName("vibe-d");
+	if (vibed !in p.buildSettings.dependencies)
+		p.buildSettings.dependencies[vibed] = Dependency("~>0.9");
 	p.description = "A simple vibe.d server application.";
 	pre_write_callback();
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -162,7 +162,7 @@ class Package {
 				.format(root.toNativeString(),
 					packageInfoFiles.map!(f => cast(string)f.filename).join("/")));
 
-		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : null);
+		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : PackageName(null));
 
 		auto ret = new Package(recipe, root, parent, version_override);
 		ret.m_infoFile = recipe_file;
@@ -174,9 +174,9 @@ class Package {
 		The qualified name includes any possible parent package if this package
 		is a sub package.
 	*/
-	@property string name()
+	@property PackageName name()
 	const {
-		if (m_parentPackage) return m_parentPackage.name ~ ":" ~ m_info.name;
+		if (m_parentPackage) return typeof(return)(m_parentPackage.name ~ ":" ~ m_info.name);
 		else return m_info.name;
 	}
 
@@ -504,7 +504,7 @@ class Package {
 
 		See_Also: `getDependencies`
 	*/
-	bool hasDependency(string dependency_name, string config)
+	bool hasDependency(PackageName dependency_name, string config)
 	const {
 		if (dependency_name in m_info.buildSettings.dependencies) return true;
 		foreach (ref c; m_info.configurations)
@@ -522,9 +522,8 @@ class Package {
 
 		See_Also: `hasDependency`
 	*/
-	const(Dependency[string]) getDependencies(string config)
-	const {
-		Dependency[string] ret;
+	Dependency[PackageName] getDependencies(string config) const {
+		Dependency[PackageName] ret;
 		foreach (k, v; m_info.buildSettings.dependencies)
 			ret[k] = v;
 		foreach (ref conf; m_info.configurations)

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -162,7 +162,7 @@ class Package {
 				.format(root.toNativeString(),
 					packageInfoFiles.map!(f => cast(string)f.filename).join("/")));
 
-		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : PackageName(null));
+		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : PackageId(null));
 
 		auto ret = new Package(recipe, root, parent, version_override);
 		ret.m_infoFile = recipe_file;
@@ -174,7 +174,7 @@ class Package {
 		The qualified name includes any possible parent package if this package
 		is a sub package.
 	*/
-	@property PackageName name()
+	@property PackageId name()
 	const {
 		if (m_parentPackage) return typeof(return)(m_parentPackage.name ~ ":" ~ m_info.name);
 		else return m_info.name;
@@ -504,7 +504,7 @@ class Package {
 
 		See_Also: `getDependencies`
 	*/
-	bool hasDependency(PackageName dependency_name, string config)
+	bool hasDependency(PackageId dependency_name, string config)
 	const {
 		if (dependency_name in m_info.buildSettings.dependencies) return true;
 		foreach (ref c; m_info.configurations)
@@ -522,8 +522,8 @@ class Package {
 
 		See_Also: `hasDependency`
 	*/
-	Dependency[PackageName] getDependencies(string config) const {
-		Dependency[PackageName] ret;
+	Dependency[PackageId] getDependencies(string config) const {
+		Dependency[PackageId] ret;
 		foreach (k, v; m_info.buildSettings.dependencies)
 			ret[k] = v;
 		foreach (ref conf; m_info.configurations)

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -156,7 +156,7 @@ class PackageManager {
 		Returns:
 			The matching package or null if no match was found.
 	*/
-	Package getPackage(PackageName name, Version ver, bool enable_overrides = true)
+	Package getPackage(PackageId name, Version ver, bool enable_overrides = true)
 	{
 		if (enable_overrides) {
 			foreach (ref repo; m_repositories)
@@ -180,13 +180,13 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getPackage(PackageName name, string ver, bool enable_overrides = true)
+	Package getPackage(PackageId name, string ver, bool enable_overrides = true)
 	{
 		return getPackage(name, Version(ver), enable_overrides);
 	}
 
 	/// ditto
-	Package getPackage(PackageName name, Version ver, NativePath path)
+	Package getPackage(PackageId name, Version ver, NativePath path)
 	{
 		foreach (p; getPackageIterator(name))
 			if (p.version_ == ver && p.path.startsWith(path))
@@ -195,13 +195,13 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getPackage(PackageName name, string ver, NativePath path)
+	Package getPackage(PackageId name, string ver, NativePath path)
 	{
 		return getPackage(name, Version(ver), path);
 	}
 
 	/// ditto
-	Package getPackage(PackageName name, NativePath path)
+	Package getPackage(PackageId name, NativePath path)
 	{
 		foreach( p; getPackageIterator(name) )
 			if (p.path.startsWith(path))
@@ -212,7 +212,7 @@ class PackageManager {
 
 	/** Looks up the first package matching the given name.
 	*/
-	Package getFirstPackage(PackageName name)
+	Package getFirstPackage(PackageId name)
 	{
 		foreach (ep; getPackageIterator(name))
 			return ep;
@@ -221,7 +221,7 @@ class PackageManager {
 
 	/** Looks up the latest package matching the given name.
 	*/
-	Package getLatestPackage(PackageName name)
+	Package getLatestPackage(PackageId name)
 	{
 		Package pkg;
 		foreach (ep; getPackageIterator(name))
@@ -270,7 +270,7 @@ class PackageManager {
 			The package loaded from the given SCM repository or null if the
 			package couldn't be loaded.
 	*/
-	Package loadSCMPackage(PackageName name, Dependency dependency)
+	Package loadSCMPackage(PackageId name, Dependency dependency)
 	in { assert(!dependency.repository.empty); }
 	do {
         Package pack;
@@ -286,7 +286,7 @@ class PackageManager {
         return pack;
 	}
 
-    private Package loadGitPackage(PackageName name, string versionSpec, string remote)
+    private Package loadGitPackage(PackageId name, string versionSpec, string remote)
     {
 		import dub.internal.git : cloneRepository;
 
@@ -313,7 +313,7 @@ class PackageManager {
 
 	/** Searches for the latest version of a package matching the given dependency.
 	*/
-	Package getBestPackage(PackageName name, Dependency version_spec, bool enable_overrides = true)
+	Package getBestPackage(PackageId name, Dependency version_spec, bool enable_overrides = true)
 	{
 		Package ret;
 		foreach (p; getPackageIterator(name))
@@ -328,7 +328,7 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getBestPackage(PackageName name, string version_spec)
+	Package getBestPackage(PackageId name, string version_spec)
 	{
 		return getBestPackage(name, Dependency(version_spec));
 	}
@@ -346,9 +346,9 @@ class PackageManager {
 				package is found. Otherwise will throw an exception.
 
 	*/
-	Package getSubPackage(Package base_package, PackageName sub_name, bool silent_fail)
+	Package getSubPackage(Package base_package, PackageId sub_name, bool silent_fail)
 	{
-		foreach (p; getPackageIterator(PackageName(base_package.name~":"~sub_name)))
+		foreach (p; getPackageIterator(PackageId(base_package.name~":"~sub_name)))
 			if (p.parentPackage is base_package)
 				return p;
 		enforce(silent_fail, "Sub package \""~base_package.name~":"~sub_name~"\" doesn't exist.");
@@ -411,7 +411,7 @@ class PackageManager {
 
 		Returns: A delegate suitable for use with `foreach` is returned.
 	*/
-	int delegate(int delegate(ref Package)) getPackageIterator(PackageName name)
+	int delegate(int delegate(ref Package)) getPackageIterator(PackageId name)
 	{
 		int iterator(int delegate(ref Package) del)
 		{
@@ -467,14 +467,14 @@ class PackageManager {
 	{
 		import std.range : walkLength;
 
-		auto package_name = package_info["name"].get!string;
+		auto package_id = package_info["name"].get!string;
 		auto package_version = package_info["version"].get!string;
 
 		logDebug("Placing package '%s' version '%s' to location '%s' from file '%s'",
-			package_name, package_version, destination.toNativeString(), zip_file_path.toNativeString());
+			package_id, package_version, destination.toNativeString(), zip_file_path.toNativeString());
 
 		if( existsFile(destination) ){
-			throw new Exception(format("%s (%s) needs to be removed from '%s' prior placement.", package_name, package_version, destination));
+			throw new Exception(format("%s (%s) needs to be removed from '%s' prior placement.", package_id, package_version, destination));
 		}
 
 		// open zip file

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -734,9 +734,9 @@ class PackageManager {
 		void scanPackageFolder(NativePath path)
 		{
 			if( path.existsDirectory() ){
-				logDebug("iterating dir %s", path.toNativeString());
+				logDebug("Iterating directory %s", path.toNativeString());
 				try foreach( pdir; iterateDirectory(path) ){
-					logDebug("iterating dir %s entry %s", path.toNativeString(), pdir.name);
+					logDebug("Iterating directory %s entry %s", path.toNativeString(), pdir.name);
 					if (!pdir.isDirectory) continue;
 
 					auto pack_path = path ~ (pdir.name ~ "/");

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -156,7 +156,7 @@ class PackageManager {
 		Returns:
 			The matching package or null if no match was found.
 	*/
-	Package getPackage(string name, Version ver, bool enable_overrides = true)
+	Package getPackage(PackageName name, Version ver, bool enable_overrides = true)
 	{
 		if (enable_overrides) {
 			foreach (ref repo; m_repositories)
@@ -180,13 +180,13 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getPackage(string name, string ver, bool enable_overrides = true)
+	Package getPackage(PackageName name, string ver, bool enable_overrides = true)
 	{
 		return getPackage(name, Version(ver), enable_overrides);
 	}
 
 	/// ditto
-	Package getPackage(string name, Version ver, NativePath path)
+	Package getPackage(PackageName name, Version ver, NativePath path)
 	{
 		foreach (p; getPackageIterator(name))
 			if (p.version_ == ver && p.path.startsWith(path))
@@ -195,13 +195,13 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getPackage(string name, string ver, NativePath path)
+	Package getPackage(PackageName name, string ver, NativePath path)
 	{
 		return getPackage(name, Version(ver), path);
 	}
 
 	/// ditto
-	Package getPackage(string name, NativePath path)
+	Package getPackage(PackageName name, NativePath path)
 	{
 		foreach( p; getPackageIterator(name) )
 			if (p.path.startsWith(path))
@@ -212,7 +212,7 @@ class PackageManager {
 
 	/** Looks up the first package matching the given name.
 	*/
-	Package getFirstPackage(string name)
+	Package getFirstPackage(PackageName name)
 	{
 		foreach (ep; getPackageIterator(name))
 			return ep;
@@ -221,7 +221,7 @@ class PackageManager {
 
 	/** Looks up the latest package matching the given name.
 	*/
-	Package getLatestPackage(string name)
+	Package getLatestPackage(PackageName name)
 	{
 		Package pkg;
 		foreach (ep; getPackageIterator(name))
@@ -270,7 +270,7 @@ class PackageManager {
 			The package loaded from the given SCM repository or null if the
 			package couldn't be loaded.
 	*/
-	Package loadSCMPackage(string name, Dependency dependency)
+	Package loadSCMPackage(PackageName name, Dependency dependency)
 	in { assert(!dependency.repository.empty); }
 	do {
         Package pack;
@@ -286,7 +286,7 @@ class PackageManager {
         return pack;
 	}
 
-    private Package loadGitPackage(string name, string versionSpec, string remote)
+    private Package loadGitPackage(PackageName name, string versionSpec, string remote)
     {
 		import dub.internal.git : cloneRepository;
 
@@ -313,7 +313,7 @@ class PackageManager {
 
 	/** Searches for the latest version of a package matching the given dependency.
 	*/
-	Package getBestPackage(string name, Dependency version_spec, bool enable_overrides = true)
+	Package getBestPackage(PackageName name, Dependency version_spec, bool enable_overrides = true)
 	{
 		Package ret;
 		foreach (p; getPackageIterator(name))
@@ -328,7 +328,7 @@ class PackageManager {
 	}
 
 	/// ditto
-	Package getBestPackage(string name, string version_spec)
+	Package getBestPackage(PackageName name, string version_spec)
 	{
 		return getBestPackage(name, Dependency(version_spec));
 	}
@@ -346,9 +346,9 @@ class PackageManager {
 				package is found. Otherwise will throw an exception.
 
 	*/
-	Package getSubPackage(Package base_package, string sub_name, bool silent_fail)
+	Package getSubPackage(Package base_package, PackageName sub_name, bool silent_fail)
 	{
-		foreach (p; getPackageIterator(base_package.name~":"~sub_name))
+		foreach (p; getPackageIterator(PackageName(base_package.name~":"~sub_name)))
 			if (p.parentPackage is base_package)
 				return p;
 		enforce(silent_fail, "Sub package \""~base_package.name~":"~sub_name~"\" doesn't exist.");
@@ -411,7 +411,7 @@ class PackageManager {
 
 		Returns: A delegate suitable for use with `foreach` is returned.
 	*/
-	int delegate(int delegate(ref Package)) getPackageIterator(string name)
+	int delegate(int delegate(ref Package)) getPackageIterator(PackageName name)
 	{
 		int iterator(int delegate(ref Package) del)
 		{

--- a/source/dub/packagesuppliers/fallback.d
+++ b/source/dub/packagesuppliers/fallback.d
@@ -28,9 +28,9 @@ package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 	}
 
 	// Workaround https://issues.dlang.org/show_bug.cgi?id=2525
-	abstract override Version[] getVersions(string package_id);
-	abstract override void fetchPackage(NativePath path, string package_id, Dependency dep, bool pre_release);
-	abstract override Json fetchPackageRecipe(string package_id, Dependency dep, bool pre_release);
+	abstract override Version[] getVersions(PackageName package_name);
+	abstract override void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release);
+	abstract override Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release);
 	abstract override SearchResult[] searchPackages(string query);
 }
 

--- a/source/dub/packagesuppliers/fallback.d
+++ b/source/dub/packagesuppliers/fallback.d
@@ -28,9 +28,9 @@ package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 	}
 
 	// Workaround https://issues.dlang.org/show_bug.cgi?id=2525
-	abstract override Version[] getVersions(PackageName package_name);
-	abstract override void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release);
-	abstract override Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release);
+	abstract override Version[] getVersions(PackageId package_id);
+	abstract override void fetchPackage(NativePath path, PackageId package_id, Dependency dep, bool pre_release);
+	abstract override Json fetchPackageRecipe(PackageId package_id, Dependency dep, bool pre_release);
 	abstract override SearchResult[] searchPackages(string query);
 }
 

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -1,5 +1,6 @@
 module dub.packagesuppliers.filesystem;
 
+public import dub.dependency : PackageName;
 import dub.packagesuppliers.packagesupplier;
 
 /**
@@ -20,17 +21,17 @@ class FileSystemPackageSupplier : PackageSupplier {
 
 	override @property string description() { return "file repository at "~m_path.toNativeString(); }
 
-	Version[] getVersions(string package_id)
+	Version[] getVersions(PackageName package_name)
 	{
 		import std.algorithm.sorting : sort;
 		import std.file : dirEntries, DirEntry, SpanMode;
 		import std.conv : to;
 		Version[] ret;
-		foreach (DirEntry d; dirEntries(m_path.toNativeString(), package_id~"*", SpanMode.shallow)) {
+		foreach (DirEntry d; dirEntries(m_path.toNativeString(), package_name~"*", SpanMode.shallow)) {
 			NativePath p = NativePath(d.name);
 			logDebug("Entry: %s", p);
 			enforce(to!string(p.head)[$-4..$] == ".zip");
-			auto vers = p.head.name[package_id.length+1..$-4];
+			auto vers = p.head.name[package_name.length+1..$-4];
 			logDebug("Version: %s", vers);
 			ret ~= Version(vers);
 		}
@@ -38,7 +39,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, PackageName packageId, Dependency dep, bool pre_release)
 	{
 		import dub.internal.vibecompat.core.file : copyFile, existsFile;
 		enforce(path.absolute);
@@ -48,7 +49,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		copyFile(filename, path);
 	}
 
-	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(PackageName packageId, Dependency dep, bool pre_release)
 	{
 		import std.array : split;
 		import std.path : stripExtension;
@@ -71,7 +72,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return null;
 	}
 
-	private NativePath bestPackageFile(string packageId, Dependency dep, bool pre_release)
+	private NativePath bestPackageFile(PackageName packageId, Dependency dep, bool pre_release)
 	{
 		import std.algorithm.iteration : filter;
 		import std.array : array;

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -39,17 +39,17 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, PackageName packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release)
 	{
 		import dub.internal.vibecompat.core.file : copyFile, existsFile;
 		enforce(path.absolute);
-		logInfo("Storing package '"~packageId~"', version requirements: %s", dep);
-		auto filename = bestPackageFile(packageId, dep, pre_release);
+		logInfo("Storing package '"~package_name~"', version requirements: %s", dep);
+		auto filename = bestPackageFile(package_name, dep, pre_release);
 		enforce(existsFile(filename));
 		copyFile(filename, path);
 	}
 
-	Json fetchPackageRecipe(PackageName packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release)
 	{
 		import std.array : split;
 		import std.path : stripExtension;
@@ -57,7 +57,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		import dub.recipe.io : parsePackageRecipe;
 		import dub.recipe.json : toJson;
 
-		auto filePath = bestPackageFile(packageId, dep, pre_release);
+		auto filePath = bestPackageFile(package_name, dep, pre_release);
 		string packageFileName;
 		string packageFileContent = packageInfoFileFromZip(filePath, packageFileName);
 		auto recipe = parsePackageRecipe(packageFileContent, packageFileName);
@@ -72,16 +72,16 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return null;
 	}
 
-	private NativePath bestPackageFile(PackageName packageId, Dependency dep, bool pre_release)
+	private NativePath bestPackageFile(PackageName package_name, Dependency dep, bool pre_release)
 	{
 		import std.algorithm.iteration : filter;
 		import std.array : array;
 		import std.format : format;
 		NativePath toPath(Version ver) {
-			return m_path ~ (packageId ~ "-" ~ ver.toString() ~ ".zip");
+			return m_path ~ (package_name ~ "-" ~ ver.toString() ~ ".zip");
 		}
-		auto versions = getVersions(packageId).filter!(v => dep.matches(v)).array;
-		enforce(versions.length > 0, format("No package %s found matching %s", packageId, dep));
+		auto versions = getVersions(package_name).filter!(v => dep.matches(v)).array;
+		enforce(versions.length > 0, format("No package %s found matching %s", package_name, dep));
 		foreach_reverse (ver; versions) {
 			if (pre_release || !ver.isPreRelease)
 				return toPath(ver);

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -32,10 +32,10 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 
 	override @property string description() { return "maven repository at "~m_mavenUrl.toString(); }
 
-	Version[] getVersions(PackageName package_name)
+	Version[] getVersions(PackageId package_id)
 	{
 		import std.algorithm.sorting : sort;
-		auto md = getMetadata(package_name);
+		auto md = getMetadata(package_id);
 		if (md.type == Json.Type.null_)
 			return null;
 		Version[] ret;
@@ -47,15 +47,15 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, PackageId package_id, Dependency dep, bool pre_release)
 	{
 		import std.format : format;
-		auto md = getMetadata(package_name);
-		Json best = getBestPackage(md, package_name, dep, pre_release);
+		auto md = getMetadata(package_id);
+		Json best = getBestPackage(md, package_id, dep, pre_release);
 		if (best.type == Json.Type.null_)
 			return;
 		auto vers = best["version"].get!string;
-		auto url = m_mavenUrl~NativePath("%s/%s/%s-%s.zip".format(package_name, vers, package_name, vers));
+		auto url = m_mavenUrl~NativePath("%s/%s/%s-%s.zip".format(package_id, vers, package_id, vers));
 
 		try {
 			retryDownload(url, path, 3, httpTimeout);
@@ -63,58 +63,58 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		}
 		catch(HTTPStatusException e) {
 			if (e.status == 404) throw e;
-			else logDebug("Failed to download package %s from %s", package_name, url);
+			else logDebug("Failed to download package %s from %s", package_id, url);
 		}
 		catch(Exception e) {
-			logDebug("Failed to download package %s from %s", package_name, url);
+			logDebug("Failed to download package %s from %s", package_id, url);
 		}
-		throw new Exception("Failed to download package %s from %s".format(package_name, url));
+		throw new Exception("Failed to download package %s from %s".format(package_id, url));
 	}
 
-	Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(PackageId package_id, Dependency dep, bool pre_release)
 	{
-		auto md = getMetadata(package_name);
-		return getBestPackage(md, package_name, dep, pre_release);
+		auto md = getMetadata(package_id);
+		return getBestPackage(md, package_id, dep, pre_release);
 	}
 
-	private Json getMetadata(PackageName package_name)
+	private Json getMetadata(PackageId package_id)
 	{
 		import dub.internal.undead.xml;
 
 		auto now = Clock.currTime(UTC());
-		if (auto pentry = package_name in m_metadataCache) {
+		if (auto pentry = package_id in m_metadataCache) {
 			if (pentry.cacheTime + m_maxCacheTime > now)
 				return pentry.data;
-			m_metadataCache.remove(package_name);
+			m_metadataCache.remove(package_id);
 		}
 
-		auto url = m_mavenUrl~NativePath(package_name~"/maven-metadata.xml");
+		auto url = m_mavenUrl~NativePath(package_id~"/maven-metadata.xml");
 
-		logDebug("Downloading maven metadata for %s", package_name);
+		logDebug("Downloading maven metadata for %s", package_id);
 		string xmlData;
 
 		try
 			xmlData = cast(string)retryDownload(url, 3, httpTimeout);
 		catch(HTTPStatusException e) {
 			if (e.status == 404) {
-				logDebug("Maven metadata %s not found at %s (404): %s", package_name, description, e.msg);
+				logDebug("Maven metadata %s not found at %s (404): %s", package_id, description, e.msg);
 				return Json(null);
 			}
 			else throw e;
 		}
 
-		auto json = Json(["name": Json(package_name), "versions": Json.emptyArray]);
+		auto json = Json(["name": Json(package_id), "versions": Json.emptyArray]);
 		auto xml = new DocumentParser(xmlData);
 
 		xml.onStartTag["versions"] = (ElementParser xml) {
 			 xml.onEndTag["version"] = (in Element e) {
-				json["versions"] ~= serializeToJson(["name": package_name, "version": e.text]);
+				json["versions"] ~= serializeToJson(["name": package_id, "version": e.text]);
 			 };
 			 xml.parse();
 		};
 		xml.parse();
 
-		m_metadataCache[package_name] = CacheEntry(json, now);
+		m_metadataCache[package_id] = CacheEntry(json, now);
 		return json;
 	}
 
@@ -122,11 +122,11 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 	{
 		// Only exact search is supported
 		// This enables retrival of dub packages on dub run
-		auto md = getMetadata(PackageName(query));
+		auto md = getMetadata(PackageId(query));
 		if (md.type == Json.Type.null_)
 			return [];
-		auto json = getBestPackage(md, PackageName(query), Dependency(">=0.0.0"), true);
-		return [SearchResult(PackageName(json["name"].opt!string),
+		auto json = getBestPackage(md, PackageId(query), Dependency(">=0.0.0"), true);
+		return [SearchResult(PackageId(json["name"].opt!string),
 							 "",
 							 json["version"].opt!string)];
 	}

--- a/source/dub/packagesuppliers/packagesupplier.d
+++ b/source/dub/packagesuppliers/packagesupplier.d
@@ -1,6 +1,6 @@
 module dub.packagesuppliers.packagesupplier;
 
-public import dub.dependency : Dependency, Version;
+public import dub.dependency : PackageName, Dependency, Version;
 public import dub.internal.vibecompat.core.file : NativePath;
 public import dub.internal.vibecompat.data.json : Json;
 
@@ -12,7 +12,7 @@ public import dub.internal.vibecompat.data.json : Json;
 */
 interface PackageSupplier {
 	/// Represents a single package search result.
-	static struct SearchResult { string name, description, version_; }
+	static struct SearchResult { PackageName name; string description, version_; }
 
 	/// Returns a human-readable representation of the package supplier.
 	@property string description();
@@ -22,28 +22,28 @@ interface PackageSupplier {
 		Throws: Throws an exception if the package name is not known, or if
 			an error occurred while retrieving the version list.
 	*/
-	Version[] getVersions(string package_id);
+	Version[] getVersions(PackageName package_name);
 
 	/** Downloads a package and stores it as a ZIP file.
 
 		Params:
 			path = Absolute path of the target ZIP file
-			package_id = Name of the package to retrieve
+			package_name = Name of the package to retrieve
 			dep: Version constraint to match against
 			pre_release: If true, matches the latest pre-release version.
 				Otherwise prefers stable versions.
 	*/
-	void fetchPackage(NativePath path, string package_id, Dependency dep, bool pre_release);
+	void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release);
 
 	/** Retrieves only the recipe of a particular package.
 
 		Params:
-			package_id = Name of the package of which to retrieve the recipe
+			package_name = Name of the package of which to retrieve the recipe
 			dep: Version constraint to match against
 			pre_release: If true, matches the latest pre-release version.
 				Otherwise prefers stable versions.
 	*/
-	Json fetchPackageRecipe(string package_id, Dependency dep, bool pre_release);
+	Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release);
 
 	/** Searches for packages matching the given search query term.
 
@@ -59,7 +59,7 @@ interface PackageSupplier {
 //       a package recipe instead of one (first get version list, then the
 //       package recipe)
 
-package Json getBestPackage(Json metadata, string packageId, Dependency dep, bool pre_release)
+package Json getBestPackage(Json metadata, PackageName packageId, Dependency dep, bool pre_release)
 {
 	import std.exception : enforce;
 	if (metadata.type == Json.Type.null_)

--- a/source/dub/packagesuppliers/packagesupplier.d
+++ b/source/dub/packagesuppliers/packagesupplier.d
@@ -59,7 +59,7 @@ interface PackageSupplier {
 //       a package recipe instead of one (first get version list, then the
 //       package recipe)
 
-package Json getBestPackage(Json metadata, PackageName packageId, Dependency dep, bool pre_release)
+package Json getBestPackage(Json metadata, PackageName package_name, Dependency dep, bool pre_release)
 {
 	import std.exception : enforce;
 	if (metadata.type == Json.Type.null_)
@@ -77,6 +77,6 @@ package Json getBestPackage(Json metadata, PackageName packageId, Dependency dep
 		} else if (!cur.isPreRelease && cur > bestver) best = json;
 		bestver = Version(cast(string)best["version"]);
 	}
-	enforce(best != null, "No package candidate found for "~packageId~" "~dep.toString());
+	enforce(best != null, "No package candidate found for "~package_name~" "~dep.toString());
 	return best;
 }

--- a/source/dub/packagesuppliers/packagesupplier.d
+++ b/source/dub/packagesuppliers/packagesupplier.d
@@ -1,6 +1,6 @@
 module dub.packagesuppliers.packagesupplier;
 
-public import dub.dependency : PackageName, Dependency, Version;
+public import dub.dependency : PackageId, Dependency, Version;
 public import dub.internal.vibecompat.core.file : NativePath;
 public import dub.internal.vibecompat.data.json : Json;
 
@@ -12,7 +12,7 @@ public import dub.internal.vibecompat.data.json : Json;
 */
 interface PackageSupplier {
 	/// Represents a single package search result.
-	static struct SearchResult { PackageName name; string description, version_; }
+	static struct SearchResult { PackageId name; string description, version_; }
 
 	/// Returns a human-readable representation of the package supplier.
 	@property string description();
@@ -22,28 +22,28 @@ interface PackageSupplier {
 		Throws: Throws an exception if the package name is not known, or if
 			an error occurred while retrieving the version list.
 	*/
-	Version[] getVersions(PackageName package_name);
+	Version[] getVersions(PackageId package_id);
 
 	/** Downloads a package and stores it as a ZIP file.
 
 		Params:
 			path = Absolute path of the target ZIP file
-			package_name = Name of the package to retrieve
+			package_id = Name of the package to retrieve
 			dep: Version constraint to match against
 			pre_release: If true, matches the latest pre-release version.
 				Otherwise prefers stable versions.
 	*/
-	void fetchPackage(NativePath path, PackageName package_name, Dependency dep, bool pre_release);
+	void fetchPackage(NativePath path, PackageId package_id, Dependency dep, bool pre_release);
 
 	/** Retrieves only the recipe of a particular package.
 
 		Params:
-			package_name = Name of the package of which to retrieve the recipe
+			package_id = Name of the package of which to retrieve the recipe
 			dep: Version constraint to match against
 			pre_release: If true, matches the latest pre-release version.
 				Otherwise prefers stable versions.
 	*/
-	Json fetchPackageRecipe(PackageName package_name, Dependency dep, bool pre_release);
+	Json fetchPackageRecipe(PackageId package_id, Dependency dep, bool pre_release);
 
 	/** Searches for packages matching the given search query term.
 
@@ -59,7 +59,7 @@ interface PackageSupplier {
 //       a package recipe instead of one (first get version list, then the
 //       package recipe)
 
-package Json getBestPackage(Json metadata, PackageName package_name, Dependency dep, bool pre_release)
+package Json getBestPackage(Json metadata, PackageId package_id, Dependency dep, bool pre_release)
 {
 	import std.exception : enforce;
 	if (metadata.type == Json.Type.null_)
@@ -77,6 +77,6 @@ package Json getBestPackage(Json metadata, PackageName package_name, Dependency 
 		} else if (!cur.isPreRelease && cur > bestver) best = json;
 		bestver = Version(cast(string)best["version"]);
 	}
-	enforce(best != null, "No package candidate found for "~package_name~" "~dep.toString());
+	enforce(best != null, "No package candidate found for "~package_id~" "~dep.toString());
 	return best;
 }

--- a/source/dub/packagesuppliers/registry.d
+++ b/source/dub/packagesuppliers/registry.d
@@ -33,10 +33,10 @@ class RegistryPackageSupplier : PackageSupplier {
 
 	override @property string description() { return "registry at "~m_registryUrl.toString(); }
 
-	Version[] getVersions(string package_id)
+	Version[] getVersions(PackageName package_name)
 	{
 		import std.algorithm.sorting : sort;
-		auto md = getMetadata(package_id);
+		auto md = getMetadata(package_name);
 		if (md.type == Json.Type.null_)
 			return null;
 		Version[] ret;
@@ -48,7 +48,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	auto genPackageDownloadUrl(string packageId, Dependency dep, bool pre_release)
+	auto genPackageDownloadUrl(PackageName packageId, Dependency dep, bool pre_release)
 	{
 		import std.array : replace;
 		import std.format : format;
@@ -64,7 +64,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, PackageName packageId, Dependency dep, bool pre_release)
 	{
 		import std.format : format;
 		auto url = genPackageDownloadUrl(packageId, dep, pre_release);
@@ -84,13 +84,13 @@ class RegistryPackageSupplier : PackageSupplier {
 		throw new Exception("Failed to download package %s from %s".format(packageId, url));
 	}
 
-	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(PackageName packageId, Dependency dep, bool pre_release)
 	{
 		auto md = getMetadata(packageId);
 		return getBestPackage(md, packageId, dep, pre_release);
 	}
 
-	private Json getMetadata(string packageId)
+	private Json getMetadata(PackageName packageId)
 	{
 		auto now = Clock.currTime(UTC());
 		if (auto pentry = packageId in m_metadataCache) {
@@ -127,8 +127,9 @@ class RegistryPackageSupplier : PackageSupplier {
 		string data;
 		data = cast(string)retryDownload(url);
 		return data.parseJson.opt!(Json[])
-			.map!(j => SearchResult(j["name"].opt!string, j["description"].opt!string, j["version"].opt!string))
+			.map!(j => SearchResult(PackageName(j["name"].opt!string),
+									j["description"].opt!string,
+									j["version"].opt!string))
 			.array;
 	}
 }
-

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -45,7 +45,7 @@ class Project {
 		Package[][Package] m_dependees;
 		SelectedVersions m_selections;
 		PackageName[] m_missingDependencies;
-		string[PackageName] m_overriddenConfigs;
+		string[PackageName] m_overriddenConfigs; // TODO ConfigName[PackageName]
 	}
 
 	/** Loads a project.
@@ -220,7 +220,7 @@ class Project {
 				dependency
 			config = Name of the configuration to force
 	*/
-	void overrideConfiguration(PackageName package_name, string config)
+	void overrideConfiguration(PackageName package_name, string config) // TODO ConfigName
 	{
 		// writeln("overrideConfiguration(package_name:", package_name, " config:", config, ")");
 		auto p = getDependency(package_name, true);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -222,7 +222,7 @@ class Project {
 	*/
 	void overrideConfiguration(string package_, string config)
 	{
-		writeln("overrideConfiguration(package_:", package_, " config:", config, ")");
+		// writeln("overrideConfiguration(package_:", package_, " config:", config, ")");
 		auto p = getDependency(package_, true);
 		enforce(p !is null,
 			format("Package '%s', marked for configuration override, is not present in dependency graph.", package_));
@@ -238,7 +238,7 @@ class Project {
 	*/
 	void validate()
 	{
-		writeln("validate() entered...");
+		// writeln("validate() entered...");
 		// some basic package lint
 		m_rootPackage.warnOnSpecialCompilerFlags();
 		string nameSuggestion() {
@@ -301,7 +301,7 @@ class Project {
 		// check for version specification mismatches
 		bool[Package] visited;
 		void validateDependenciesRec(Package pack) {
-			writeln("validateDependenciesRec(pack.name:", pack.name, ")");
+			// writeln("validateDependenciesRec(pack.name:", pack.name, ")");
 			// perform basic package linting
 			pack.simpleLint();
 
@@ -322,13 +322,13 @@ class Project {
 			}
 		}
 		validateDependenciesRec(m_rootPackage);
-		writeln("validateDependenciesRec() done");
+		// writeln("validateDependenciesRec() done");
 	}
 
 	/// Reloads dependencies.
 	void reinit()
 	{
-		writeln("reinit() entered...");
+		// writeln("reinit() entered...");
 		m_dependencies = null;
 		m_missingDependencies = [];
 		m_packageManager.refresh(false);
@@ -428,7 +428,7 @@ class Project {
 		}
 		collectDependenciesRec(m_rootPackage);
 		m_missingDependencies.sort();
-		writeln("reinit() done");
+		// writeln("reinit() done");
 	}
 
 	/// Returns the name of the root package.
@@ -440,7 +440,7 @@ class Project {
 	/// Returns a map with the configuration for all packages in the dependency tree.
 	string[string] getPackageConfigs(in BuildPlatform platform, string config, bool allow_non_library = true)
 	const {
-		writeln("getPackageConfigs(platform:", platform.platform, ", config:", config, ", allow_non_library:", allow_non_library, "entered)");
+		// writeln("getPackageConfigs(platform:", platform.platform, ", config:", config, ", allow_non_library:", allow_non_library, "entered)");
 		struct Vertex { string pack, config; }
 		struct Edge { size_t from, to; }
 
@@ -579,9 +579,9 @@ class Project {
 					determineDependencyConfigs(p, c, depth + 1);
 		}
 		if (config.length) createConfig(m_rootPackage.name, config);
-		writeln("determineAllConfigs root entered...");
+		// writeln("determineAllConfigs root entered...");
 		determineAllConfigs(m_rootPackage);
-		writeln("determineAllConfigs root done");
+		// writeln("determineAllConfigs root done");
 		writeln("configs:", configs);
 
 		// TODO why is Vertex("extra-lxd", "") and Vertex("symmetry.mongo-queries", "") there
@@ -594,7 +594,7 @@ class Project {
 			foreach (i, ref c; configs) {
 				if (c == Vertex.init) continue; // ignore deleted configurations
 				if (!isReachableByAllParentPacks(i)) {
-					logDebug("%s %s NOT REACHABLE by all of (%s):", c.pack, c.config, parents[c.pack]);
+					writefln("%s %s NOT REACHABLE by all of (%s):", c.pack, c.config, parents[c.pack]);
 					removeConfig(i);
 					changed = true;
 				}
@@ -606,7 +606,7 @@ class Project {
 					size_t cnt = 0;
 					foreach (i, ref c; configs)
 						if (c.pack == p.name && ++cnt > 1) {
-							logDebug("NON-PRIMARY: %s %s", c.pack, c.config);
+							writefln("NON-PRIMARY: %s %s", c.pack, c.config);
 							removeConfig(i);
 						}
 					if (cnt > 1) {

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -7,7 +7,7 @@
 */
 module dub.recipe.io;
 
-import dub.dependency : PackageName;
+import dub.dependency : PackageId;
 import dub.recipe.packagerecipe;
 import dub.internal.vibecompat.inet.path;
 
@@ -23,12 +23,12 @@ import dub.internal.vibecompat.inet.path;
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe readPackageRecipe(string filename, PackageName parent_name = PackageName.init)
+PackageRecipe readPackageRecipe(string filename, PackageId parent_name = PackageId.init)
 {
 	return readPackageRecipe(NativePath(filename), parent_name);
 }
 /// ditto
-PackageRecipe readPackageRecipe(NativePath filename, PackageName parent_name = PackageName.init)
+PackageRecipe readPackageRecipe(NativePath filename, PackageId parent_name = PackageId.init)
 {
 	import dub.internal.utils : stripUTF8Bom;
 	import dub.internal.vibecompat.core.file : openFile, FileMode;
@@ -54,14 +54,14 @@ PackageRecipe readPackageRecipe(NativePath filename, PackageName parent_name = P
 			to determine the file format from the file extension
 		parent_name = Optional name of the parent package (if this is a sub
 		package)
-		default_package_name = Optional default package name (if no package name
+		default_package_id = Optional default package name (if no package name
 		is found in the recipe this value will be used)
 
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe parsePackageRecipe(string contents, string filename, PackageName parent_name = PackageName.init,
-								 string default_package_name = null)
+PackageRecipe parsePackageRecipe(string contents, string filename, PackageId parent_name = PackageId.init,
+								 string default_package_id = null)
 {
 	import std.algorithm : endsWith;
 	import dub.internal.vibecompat.data.json;
@@ -70,7 +70,7 @@ PackageRecipe parsePackageRecipe(string contents, string filename, PackageName p
 
 	PackageRecipe ret;
 
-	ret.name = default_package_name;
+	ret.name = default_package_id;
 
 	if (filename.endsWith(".json")) parseJson(ret, parseJsonString(contents, filename), parent_name);
 	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent_name, filename);

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -7,6 +7,7 @@
 */
 module dub.recipe.io;
 
+import dub.dependency : PackageName;
 import dub.recipe.packagerecipe;
 import dub.internal.vibecompat.inet.path;
 
@@ -22,12 +23,12 @@ import dub.internal.vibecompat.inet.path;
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe readPackageRecipe(string filename, string parent_name = null)
+PackageRecipe readPackageRecipe(string filename, PackageName parent_name = PackageName.init)
 {
 	return readPackageRecipe(NativePath(filename), parent_name);
 }
 /// ditto
-PackageRecipe readPackageRecipe(NativePath filename, string parent_name = null)
+PackageRecipe readPackageRecipe(NativePath filename, PackageName parent_name = PackageName.init)
 {
 	import dub.internal.utils : stripUTF8Bom;
 	import dub.internal.vibecompat.core.file : openFile, FileMode;
@@ -59,7 +60,7 @@ PackageRecipe readPackageRecipe(NativePath filename, string parent_name = null)
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe parsePackageRecipe(string contents, string filename, string parent_name = null,
+PackageRecipe parsePackageRecipe(string contents, string filename, PackageName parent_name = PackageName.init,
 								 string default_package_name = null)
 {
 	import std.algorithm : endsWith;

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -116,7 +116,7 @@ Json toJson(const scope ref PackageRecipe recipe)
 
 private void parseSubPackages(ref PackageRecipe recipe, PackageId parent_package_id, Json[] subPackagesJson)
 {
-	enforce(!parent_package_id._pn.canFind(":"),
+	enforce(!parent_package_id._pid.canFind(":"),
 			format("'subPackages' found in '%s'. This is only supported in the main package file for '%s'.",
 		parent_package_id, getBasePackageName(parent_package_id)));
 

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -116,7 +116,7 @@ Json toJson(const scope ref PackageRecipe recipe)
 
 private void parseSubPackages(ref PackageRecipe recipe, PackageId parent_package_id, Json[] subPackagesJson)
 {
-	enforce(!parent_package_id._pid.canFind(":"),
+	enforce(!parent_package_id.pid.canFind(":"),
 			format("'subPackages' found in '%s'. This is only supported in the main package file for '%s'.",
 		parent_package_id, getBasePackageName(parent_package_id)));
 

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -32,7 +32,7 @@ import std.process : environment;
 */
 string[] getSubPackagePath(PackageId package_id) @safe pure // TODO QualifiedPackageName as input
 {
-	return package_id._pn.split(":");
+	return package_id._pid.split(":");
 }
 
 /**
@@ -42,7 +42,7 @@ string[] getSubPackagePath(PackageId package_id) @safe pure // TODO QualifiedPac
 */
 PackageId getBasePackageName(PackageId package_id) @safe pure
 {
-	return typeof(return)(package_id._pn.findSplit(":")[0]);
+	return typeof(return)(package_id._pid.findSplit(":")[0]);
 }
 
 /**
@@ -53,7 +53,7 @@ PackageId getBasePackageName(PackageId package_id) @safe pure
 */
 PackageId getSubPackageName(PackageId package_id) @safe pure
 {
-	return typeof(return)(package_id._pn.findSplit(":")[2]);
+	return typeof(return)(package_id._pid.findSplit(":")[2]);
 }
 
 alias P = PackageId;

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -56,14 +56,16 @@ PackageName getSubPackageName(PackageName package_name) @safe pure
 	return typeof(return)(package_name._pn.findSplit(":")[2]);
 }
 
+alias P = PackageName;
+
 @safe unittest
 {
-	assert(getSubPackagePath("packa:packb:packc") == ["packa", "packb", "packc"]);
-	assert(getSubPackagePath("pack") == ["pack"]);
-	assert(getBasePackageName("packa:packb:packc") == "packa");
-	assert(getBasePackageName("pack") == "pack");
-	assert(getSubPackageName("packa:packb:packc") == "packb:packc");
-	assert(getSubPackageName("pack") == "");
+	assert(getSubPackagePath(P("packa:packb:packc")) == ["packa", "packb", "packc"]);
+	assert(getSubPackagePath(P("pack")) == ["pack"]);
+	assert(getBasePackageName(P("packa:packb:packc")) == "packa");
+	assert(getBasePackageName(P("pack")) == "pack");
+	assert(getSubPackageName(P("packa:packb:packc")) == "packb:packc");
+	assert(getSubPackageName(P("pack")) == "");
 }
 
 /**

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -30,9 +30,9 @@ import std.process : environment;
 	example, "packa:packb:packc" references a package named "packc" that is a
 	sub package of "packb", which in turn is a sub package of "packa".
 */
-string[] getSubPackagePath(string package_name) @safe pure
+string[] getSubPackagePath(PackageName package_name) @safe pure // TODO QualifiedPackageName as input
 {
-	return package_name.split(":");
+	return package_name._pn.split(":");
 }
 
 /**
@@ -40,9 +40,9 @@ string[] getSubPackagePath(string package_name) @safe pure
 
 	In case of a top level package, the qualified name is returned unmodified.
 */
-string getBasePackageName(string package_name) @safe pure
+PackageName getBasePackageName(PackageName package_name) @safe pure
 {
-	return package_name.findSplit(":")[0];
+	return typeof(return)(package_name._pn.findSplit(":")[0]);
 }
 
 /**
@@ -51,9 +51,9 @@ string getBasePackageName(string package_name) @safe pure
 	This is the part of the package name excluding the base package
 	name. See also $(D getBasePackageName).
 */
-string getSubPackageName(string package_name) @safe pure
+PackageName getSubPackageName(PackageName package_name) @safe pure
 {
-	return package_name.findSplit(":")[2];
+	return typeof(return)(package_name._pn.findSplit(":")[2]);
 }
 
 @safe unittest
@@ -73,7 +73,7 @@ string getSubPackageName(string package_name) @safe pure
 	For higher level package handling, see the $(D Package) class.
 */
 struct PackageRecipe {
-	string name;
+	PackageName name;
 	string version_;
 	string description;
 	string homepage;
@@ -81,7 +81,7 @@ struct PackageRecipe {
 	string copyright;
 	string license;
 	string[] ddoxFilterArgs;
-	string ddoxTool;
+	PackageName ddoxTool;
 	BuildSettingsTemplate buildSettings;
 	ConfigurationInfo[] configurations;
 	BuildSettingsTemplate[string] buildTypes;
@@ -175,15 +175,15 @@ struct ConfigurationInfo {
 /// It contains functions to create a specific BuildSetting, targeted at
 /// a certain BuildPlatform.
 struct BuildSettingsTemplate {
-	Dependency[string] dependencies;
-	BuildSettingsTemplate[string] dependencyBuildSettings;
+	Dependency[PackageName] dependencies;
+	BuildSettingsTemplate[PackageName] dependencyBuildSettings;
 	string systemDependencies;
 	TargetType targetType = TargetType.autodetect;
 	string targetPath;
 	string targetName;
 	string workingDirectory;
 	string mainSourceFile;
-	string[string] subConfigurations;
+	string[PackageName] subConfigurations;
 	string[][string] dflags;
 	string[][string] lflags;
 	string[][string] libs;
@@ -333,7 +333,7 @@ struct BuildSettingsTemplate {
 		}
 	}
 
-	void warnOnSpecialCompilerFlags(string package_name, string config_name)
+	void warnOnSpecialCompilerFlags(PackageName package_name, string config_name)
 	{
 		auto nodef = false;
 		auto noprop = false;
@@ -360,7 +360,7 @@ struct BuildSettingsTemplate {
 	}
 }
 
-package(dub) void checkPlatform(const scope ref ToolchainRequirements tr, BuildPlatform platform, string package_name)
+package(dub) void checkPlatform(const scope ref ToolchainRequirements tr, BuildPlatform platform, PackageName package_name)
 {
 	import dub.compilers.utils : dmdLikeVersionToSemverLike;
 	import std.algorithm.iteration : map;

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -32,7 +32,7 @@ import std.process : environment;
 */
 string[] getSubPackagePath(PackageId package_id) @safe pure // TODO QualifiedPackageName as input
 {
-	return package_id._pid.split(":");
+	return package_id.pid.split(":");
 }
 
 /**
@@ -42,7 +42,7 @@ string[] getSubPackagePath(PackageId package_id) @safe pure // TODO QualifiedPac
 */
 PackageId getBasePackageName(PackageId package_id) @safe pure
 {
-	return typeof(return)(package_id._pid.findSplit(":")[0]);
+	return typeof(return)(package_id.pid.findSplit(":")[0]);
 }
 
 /**
@@ -53,7 +53,7 @@ PackageId getBasePackageName(PackageId package_id) @safe pure
 */
 PackageId getSubPackageName(PackageId package_id) @safe pure
 {
-	return typeof(return)(package_id._pid.findSplit(":")[2]);
+	return typeof(return)(package_id.pid.findSplit(":")[2]);
 }
 
 alias P = PackageId;

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -92,7 +92,7 @@ Tag toSDL(const scope ref PackageRecipe recipe)
 {
 	Tag ret = new Tag;
 	void add(T)(string field, T value) { ret.add(new Tag(null, field, [Value(value)])); }
-	add("name", recipe.name._pid);
+	add("name", recipe.name.pid);
 	if (recipe.version_.length) add("version", recipe.version_);
 	if (recipe.description.length) add("description", recipe.description);
 	if (recipe.homepage.length) add("homepage", recipe.homepage);
@@ -109,7 +109,7 @@ Tag toSDL(const scope ref PackageRecipe recipe)
 	}
 	if (recipe.ddoxFilterArgs.length)
 		ret.add(new Tag("x", "ddoxFilterArgs", recipe.ddoxFilterArgs.map!(a => Value(a)).array));
-	if (recipe.ddoxTool.length) ret.add(new Tag("x", "ddoxTool", [Value(recipe.ddoxTool._pid)]));
+	if (recipe.ddoxTool.length) ret.add(new Tag("x", "ddoxTool", [Value(recipe.ddoxTool.pid)]));
 	ret.add(recipe.buildSettings.toSDL());
 	foreach(config; recipe.configurations)
 		ret.add(config.toSDL());
@@ -267,7 +267,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 		if (!d.path.empty) attribs ~= new Attribute(null, "path", Value(d.path.toString()));
 		else attribs ~= new Attribute(null, "version", Value(d.versionSpec));
 		if (d.optional) attribs ~= new Attribute(null, "optional", Value(true));
-		auto t = new Tag(null, "dependency", [Value(pack._pid)], attribs);
+		auto t = new Tag(null, "dependency", [Value(pack.pid)], attribs);
 		if (pack in bs.dependencyBuildSettings)
 			t.add(bs.dependencyBuildSettings[pack].toSDL());
 		ret ~= t;
@@ -278,7 +278,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 	if (bs.targetName.length) add("targetName", bs.targetName);
 	if (bs.workingDirectory.length) add("workingDirectory", bs.workingDirectory);
 	if (bs.mainSourceFile.length) add("mainSourceFile", bs.mainSourceFile);
-	foreach (pack, conf; bs.subConfigurations) ret ~= new Tag(null, "subConfiguration", [Value(pack._pid), Value(conf)]);
+	foreach (pack, conf; bs.subConfigurations) ret ~= new Tag(null, "subConfiguration", [Value(pack.pid), Value(conf)]);
 	foreach (suffix, arr; bs.dflags) adda("dflags", suffix, arr);
 	foreach (suffix, arr; bs.lflags) adda("lflags", suffix, arr);
 	foreach (suffix, arr; bs.libs) adda("libs", suffix, arr);

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -20,12 +20,12 @@ import std.conv;
 import std.string : startsWith;
 
 
-void parseSDL(ref PackageRecipe recipe, string sdl, string parent_name, string filename)
+void parseSDL(ref PackageRecipe recipe, string sdl, PackageName parent_name, string filename)
 {
 	parseSDL(recipe, parseSource(sdl, filename), parent_name);
 }
 
-void parseSDL(ref PackageRecipe recipe, Tag sdl, string parent_name)
+void parseSDL(ref PackageRecipe recipe, Tag sdl, PackageName parent_name)
 {
 	Tag[] subpacks;
 	Tag[] configs;
@@ -59,7 +59,7 @@ void parseSDL(ref PackageRecipe recipe, Tag sdl, string parent_name)
 	}
 
 	enforceSDL(recipe.name.length > 0, "The package \"name\" field is missing or empty.", sdl);
-	string full_name = parent_name.length ? parent_name ~ ":" ~ recipe.name : recipe.name;
+	auto full_name = PackageName(parent_name.length ? parent_name ~ ":" ~ recipe.name : recipe.name);
 
 	// parse general build settings
 	parseBuildSettings(sdl, recipe.buildSettings, full_name);
@@ -125,13 +125,13 @@ Tag toSDL(const scope ref PackageRecipe recipe)
 	return ret;
 }
 
-private void parseBuildSettings(Tag settings, ref BuildSettingsTemplate bs, string package_name)
+private void parseBuildSettings(Tag settings, ref BuildSettingsTemplate bs, PackageName package_name)
 {
 	foreach (setting; settings.all.tags)
 		parseBuildSetting(setting, bs, package_name);
 }
 
-private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, string package_name)
+private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, PackageName package_name)
 {
 	switch (setting.fullName) {
 		default: break;
@@ -181,7 +181,7 @@ private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, string
 	}
 }
 
-private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package_name)
+private void parseDependency(Tag t, ref BuildSettingsTemplate bs, PackageName package_name)
 {
 	enforceSDL(t.values.length != 0, "Missing dependency name.", t);
 	enforceSDL(t.values.length == 1, "Multiple dependency names.", t);
@@ -219,7 +219,7 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package
 	bs.dependencyBuildSettings[pkg] = dbs;
 }
 
-private void parseConfiguration(Tag t, ref ConfigurationInfo ret, string package_name)
+private void parseConfiguration(Tag t, ref ConfigurationInfo ret, PackageName package_name)
 {
 	ret.name = t.stringTagValue(true);
 	foreach (f; t.tags) {
@@ -330,7 +330,7 @@ private Tag toSDL(const ref ToolchainRequirements tr)
 	return new Tag(null, "toolchainRequirements", null, attrs);
 }
 
-private string expandPackageName(string name, string parent_name, Tag tag)
+private string expandPackageName(string name, PackageName parent_name, Tag tag)
 {
 	import std.algorithm : canFind;
 	import std.string : format;

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -92,7 +92,7 @@ Tag toSDL(const scope ref PackageRecipe recipe)
 {
 	Tag ret = new Tag;
 	void add(T)(string field, T value) { ret.add(new Tag(null, field, [Value(value)])); }
-	add("name", recipe.name._pn);
+	add("name", recipe.name._pid);
 	if (recipe.version_.length) add("version", recipe.version_);
 	if (recipe.description.length) add("description", recipe.description);
 	if (recipe.homepage.length) add("homepage", recipe.homepage);
@@ -109,7 +109,7 @@ Tag toSDL(const scope ref PackageRecipe recipe)
 	}
 	if (recipe.ddoxFilterArgs.length)
 		ret.add(new Tag("x", "ddoxFilterArgs", recipe.ddoxFilterArgs.map!(a => Value(a)).array));
-	if (recipe.ddoxTool.length) ret.add(new Tag("x", "ddoxTool", [Value(recipe.ddoxTool._pn)]));
+	if (recipe.ddoxTool.length) ret.add(new Tag("x", "ddoxTool", [Value(recipe.ddoxTool._pid)]));
 	ret.add(recipe.buildSettings.toSDL());
 	foreach(config; recipe.configurations)
 		ret.add(config.toSDL());
@@ -267,7 +267,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 		if (!d.path.empty) attribs ~= new Attribute(null, "path", Value(d.path.toString()));
 		else attribs ~= new Attribute(null, "version", Value(d.versionSpec));
 		if (d.optional) attribs ~= new Attribute(null, "optional", Value(true));
-		auto t = new Tag(null, "dependency", [Value(pack._pn)], attribs);
+		auto t = new Tag(null, "dependency", [Value(pack._pid)], attribs);
 		if (pack in bs.dependencyBuildSettings)
 			t.add(bs.dependencyBuildSettings[pack].toSDL());
 		ret ~= t;
@@ -278,7 +278,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 	if (bs.targetName.length) add("targetName", bs.targetName);
 	if (bs.workingDirectory.length) add("workingDirectory", bs.workingDirectory);
 	if (bs.mainSourceFile.length) add("mainSourceFile", bs.mainSourceFile);
-	foreach (pack, conf; bs.subConfigurations) ret ~= new Tag(null, "subConfiguration", [Value(pack._pn), Value(conf)]);
+	foreach (pack, conf; bs.subConfigurations) ret ~= new Tag(null, "subConfiguration", [Value(pack._pid), Value(conf)]);
 	foreach (suffix, arr; bs.dflags) adda("dflags", suffix, arr);
 	foreach (suffix, arr; bs.lflags) adda("lflags", suffix, arr);
 	foreach (suffix, arr; bs.libs) adda("libs", suffix, arr);


### PR DESCRIPTION
In my search to understand why dependency resolution goes wrong for a company internal build I've added these debug prints in `dub.project`.

Observations:

- The function `getDependency()` is called about 150k times. That doesn't seem sane.

- Problems are likely caused by faulty dependency resolution logic in `getPackageConfigs()`.

- Problems seem to lie in the code section

```d
		writeln("configs:", configs);
		// successively remove configurations until only one configuration per package is left
		bool changed;
		do {
			// remove all configs that are not reachable by all parent packages
			changed = false;
			foreach (i, ref c; configs) {
				if (c == Vertex.init) continue; // ignore deleted configurations
				if (!isReachableByAllParentPacks(i)) {
					logDebug("%s %s NOT REACHABLE by all of (%s):", c.pack, c.config, parents[c.pack]);
					removeConfig(i);
					changed = true;
				}
			}

			// when all edges are cleaned up, pick one package and remove all but one config
			if (!changed) {
				foreach (p; getTopologicalPackageList()) {
					size_t cnt = 0;
					foreach (i, ref c; configs)
						if (c.pack == p.name && ++cnt > 1) {
							logDebug("NON-PRIMARY: %s %s", c.pack, c.config);
							removeConfig(i);
						}
					if (cnt > 1) {
						changed = true;
						break;
					}
				}
			}
		} while (changed);
		writeln("adjusted configs:", configs);
```

. The debug print before shows seems sane before whereas the debug print after shows

```
adjusted configs:[Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", ""), Vertex("", "")]
```

Two of the debug prints shows two instances of Vertex having its config field be empty string `""`. Could this be the source of problem?

- Graph representation at the top of `getPackageConfigs()` should use plain pointers to nodes and vertices as D is a GC-backed language.