### PR TITLE
fix Issue 1645: the DFLAGS env variable is not handled when --build is passed

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -402,12 +402,9 @@ class Package {
 	*/
 	void addBuildTypeSettings(ref BuildSettings settings, in BuildPlatform platform, string build_type)
 	const {
-		if (build_type == "$DFLAGS") {
-			import std.process;
-			string dflags = environment.get("DFLAGS");
-			settings.addDFlags(dflags.split());
-			return;
-		}
+		import std.process;
+		string dflags = environment.get("DFLAGS", "");
+		settings.addDFlags(dflags.split());
 
 		if (auto pbt = build_type in m_info.buildTypes) {
 			logDiagnostic("Using custom build type '%s'.", build_type);
@@ -415,6 +412,7 @@ class Package {
 		} else {
 			with(BuildOption) switch (build_type) {
 				default: throw new Exception(format("Unknown build type for %s: '%s'", this.name, build_type));
+				case "$DFLAGS": break;
 				case "plain": break;
 				case "debug": settings.addOptions(debugMode, debugInfo); break;
 				case "release": settings.addOptions(releaseMode, optimize, inline); break;

--- a/test/issue1645-dflags-build.sh
+++ b/test/issue1645-dflags-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+# If DFLAGS are not processed, dub for library would fail
+DFLAGS="-w" $DUB build --root="$CURR_DIR"/1-staticLib-simple --build=plain
+if DFLAGS="-asfdsf" $DUB build --root="$CURR_DIR"/1-staticLib-simple --build=plain 2>/dev/null; then
+  echo "Should not accept this DFLAGS";
+  false # fail
+fi
+$DUB build --root="$CURR_DIR"/1-staticLib-simple --build=plain --build=plain


### PR DESCRIPTION
Taking over https://github.com/dlang/dub/pull/1648.

Closes https://github.com/dlang/dub/issues/1645.