### PR TITLE
dub.internal.vibecompat.core.log: Always log to stderr

### DIFF
--- a/source/dub/internal/vibecompat/core/log.d
+++ b/source/dub/internal/vibecompat/core/log.d
@@ -72,12 +72,9 @@ nothrow {
 		fiberid ^= fiberid >> 32;
 
 		if (level >= s_minLevel) {
-			File output;
-			if (level == LogLevel.info) () @trusted { output = stdout; } ();
-			else () @trusted { output = stderr; } ();
-			if (output.isOpen) {
-				output.writeln(txt.data);
-				output.flush();
+			if (stderr.isOpen) {
+				stderr.writeln(txt.data);
+				stderr.flush();
 			}
 		}
 	} catch( Exception e ){


### PR DESCRIPTION
Program output should generally go to stdout, and messages intended for humans should go to stderr. For example, a program that consumes and emits JSON data could produce JSON on stdout, and any informational messages pertaining it (such as parsing warnings or errors) to stderr.

Dub selects the output stream depending on log level. However, this is not particularly useful. This also corrupts the output of programs executed via dub.

Fix this by always sending log messages to stderr.