### PR TITLE
Draft: Reduce memory usage of Json

### DIFF
--- a/source/dub/internal/vibecompat/data/json.d
+++ b/source/dub/internal/vibecompat/data/json.d
@@ -67,7 +67,6 @@ struct Json {
 			int line;
 		version (VibeJsonFieldNames)
 			string m_name;
-		pragma(msg, __FILE__, "(", __LINE__, ",1): Debug: ", Json.sizeof);
 	}
 
 	/** Represents the run time type of a JSON value.


### PR DESCRIPTION
This reduces `Json.sizeof` from 64 to 40 bytes.

The memory usage could be reduced further by making use of an `Algebraic` data type or another more efficient json library.

Optionally, a `Json` node could be represented using a dual-pointer; one pointing to the tree and one to the current node. That would enable efficient storage of the filename inside the tree part.

For even denser tree representations, mir-ion provides a solution.

The `m_fileName` is only used in three diagnostics calls to `enforceJson`. Need a decision about whether we should drop that field or not. If it should be kept we need to find a way to propagate it without storing it in the node. That's trivial to solve except for `Node.opIndex` and `Node.opCast`.