### PR TITLE
Fix --data-list error message with dub describe

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -983,11 +983,11 @@ class Project {
 			case "post-build-environments":
 			case "pre-run-environments":
 			case "post-run-environments":
-				enforce(false, "--data="~requestedData~" can only be used with --data-list or --data-0.");
+				enforce(false, "--data="~requestedData~" can only be used with `--data-list` or `--data-list --data-0`.");
 				break;
 
 			case "requirements":
-				enforce(false, "--data=requirements can only be used with --data-list or --data-0. Use --data=options instead.");
+				enforce(false, "--data=requirements can only be used with `--data-list` or `--data-list --data-0`. Use --data=options instead.");
 				break;
 
 			default: break;


### PR DESCRIPTION
It said you can also use --data-0, but that actually will not make it work. You need to still specify --data-list and optionally add -data-0 to make it 0 separated instead of line separated.