### PR TITLE
add UnsupportedArchitectureException & UnknownCompilerException

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -19,13 +19,31 @@ import std.array;
 import std.exception;
 import std.process;
 
+/// Exception thrown in Compiler.determinePlatform if the given architecture is
+/// not supported.
+class UnsupportedArchitectureException : Exception
+{
+	this(string architecture, string file = __FILE__, size_t line = __LINE__, Throwable nextInChain = null) pure nothrow @safe
+	{
+		super("Unsupported architecture: "~architecture, file, line, nextInChain);
+	}
+}
+
+/// Exception thrown in getCompiler if no compiler matches the given name.
+class UnknownCompilerException : Exception
+{
+	this(string compilerName, string file = __FILE__, size_t line = __LINE__, Throwable nextInChain = null) pure nothrow @safe
+	{
+		super("Unknown compiler: "~compilerName, file, line, nextInChain);
+	}
+}
 
 /** Returns a compiler handler for a given binary name.
 
 	The name will be compared against the canonical name of each registered
 	compiler handler. If no match is found, the sub strings "dmd", "gdc" and
 	"ldc", in this order, will be searched within the name. If this doesn't
-	yield a match either, an exception will be thrown.
+	yield a match either, an $(LREF UnknownCompilerException) will be thrown.
 */
 Compiler getCompiler(string name)
 {
@@ -38,7 +56,7 @@ Compiler getCompiler(string name)
 	if (name.canFind("gdc")) return getCompiler("gdc");
 	if (name.canFind("ldc")) return getCompiler("ldc");
 
-	throw new Exception("Unknown compiler: "~name);
+	throw new UnknownCompilerException(name);
 }
 
 /** Registers a new compiler handler.

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -108,7 +108,7 @@ config    /etc/dmd.conf
 	{
 		string[] arch_flags;
 		switch (arch_override) {
-			default: throw new Exception("Unsupported architecture: "~arch_override);
+			default: throw new UnsupportedArchitectureException(arch_override);
 			case "":
 				// Don't use Optlink by default on Windows
 				version (Windows) {

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -67,7 +67,7 @@ class GDCCompiler : Compiler {
 	{
 		string[] arch_flags;
 		switch (arch_override) {
-			default: throw new Exception("Unsupported architecture: "~arch_override);
+			default: throw new UnsupportedArchitectureException(arch_override);
 			case "": break;
 			case "arm": arch_flags = ["-marm"]; break;
 			case "arm_thumb": arch_flags = ["-mthumb"]; break;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -88,7 +88,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 				if (arch_override.canFind('-'))
 					arch_flags = ["-mtriple="~arch_override];
 				else
-					throw new Exception("Unsupported architecture: "~arch_override);
+					throw new UnsupportedArchitectureException(arch_override);
 				break;
 		}
 		settings.addDFlags(arch_flags);


### PR DESCRIPTION
for API purposes to not be needing to rely on string prefixes.

I want this for workspace-d/serve-d/code-d to avoid a `.msg.startsWith` hack I have right now