### PR TITLE
Exclude macOS - dmd-latest on GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
         # Latest stable version, update at will
         os: [ macOS-10.15, ubuntu-18.04, windows-2019 ]
         dc: [ dmd-latest, ldc-latest, dmd-master, ldc-master ]
+        exclude:
+        - os: macOS-10.15
+          dc: dmd-latest
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Tests are failing for unknown reasons (maybe cache)