### PR TITLE
CLI: refactor common GeneratorSettings init

### DIFF
--- a/test/4-describe-with-cli-data-list.sh
+++ b/test/4-describe-with-cli-data-list.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+cd "$CURR_DIR"/describe-project
+
+temp_file=$(mktemp $(basename $0).XXXXXX)
+settings_file="$CURR_DIR/describe-project/dub.settings.json"
+
+echo '{
+    "defaultEnvironments": {
+        "TestEnv": "Value"
+    }
+}' > "$settings_file"
+
+function cleanup {
+    rm $settings_file
+    rm $temp_file
+}
+
+trap cleanup EXIT
+
+if ! $DUB describe --compiler=$DC \
+    --filter-versions -d=customDebugVersion -b=custombuild --build-mode=allAtOnce \
+    --data-list \
+    --data=environments \
+    --data=debug-versions \
+    --data=libs \
+    --data=options \
+    > "$temp_file"; then
+    die $LINENO 'Printing project data failed!'
+fi
+
+# Create the expected output path file to compare against.
+expected_file="$CURR_DIR/expected-describe-with-cli-data-list-output"
+# --data=environments
+echo "TestEnv=Value" > "$expected_file"
+echo >> "$expected_file"
+# --data=debug-versions
+echo "someDebugVerIdent" >> "$expected_file"
+echo "anotherDebugVerIdent" >> "$expected_file"
+echo "customDebugVersion" >> "$expected_file"
+echo >> "$expected_file"
+# --data=libs
+echo "somelib" >> "$expected_file"
+echo "anotherlib" >> "$expected_file"
+echo "customlib" >> "$expected_file"
+echo >> "$expected_file"
+# --data=options
+echo "releaseMode" >> "$expected_file"
+echo "debugInfo" >> "$expected_file"
+echo "warnings" >> "$expected_file"
+echo "deprecationErrors" >> "$expected_file"
+echo "betterC" >> "$expected_file"
+
+if ! diff "$expected_file" "$temp_file"; then
+    die $LINENO 'The project data did not match the expected output!'
+fi
+

--- a/test/describe-project/dub.json
+++ b/test/describe-project/dub.json
@@ -43,4 +43,11 @@
     "subConfigurations": {
         "describe-dependency-1": "my-dependency-1-config"
     },
+    "buildTypes": {
+        "custombuild": {
+            "libs": ["customlib"],
+            "buildOptions": ["betterC"],
+            "buildRequirements": ["disallowDeprecations"]
+        }
+    }
 }


### PR DESCRIPTION
I originally did this change to have the DescribeCommand properly filled, but I couldn't find a test case where it mattered, so this is effectively just code style now.

While reviewing myself no side effects from populating m_defaultConfig inside the commandline.d file were found: DustmiteCommand, GenerateCommand, TestCommand, LintCommand and DescribeCommand either don't use it, override it back or have used it before and no longer determine it manually now.

- changes from manually creating GeneratorSettings to using defaultGeneratorSettings:
	- GenerateCommand.execute: no changes
	- TestCommand.execute: no changes
	- DescribeCommand.execute: now set: buildMode, buildSettings, (previously only the nogc flag was copied) single
	- DustmiteCommand.execute: now set: buildMode, filterVersions, single

There is a slim possibility of the m_defaultConfig population changing applications behavior for applications that depend on DUB as a library, have extended `PackageBuildCommand` and relied on m_defaultConfig initializing to `null` with the setupPackage function call. It now initializes to the actual default dub configuration.

I don't think this edge case is blocking this PR though, as before the common use pattern with that m_defaultConfig was for setting GeneratorSettings like this:

```d
gensettings.config = m_buildConfig.length ? m_buildConfig : m_defaultConfig;
```

Where there is now a valid explicitly defined default config instead of implicitly default `null` value.

Workaround for API users if this behavior changes anything significant:
before:
```d
setupPackage(...);
```
after:
```d
setupPackage(...);
m_defaultConfig = null;
```

It has a little performance penalty, but as the setupPackage function is just intended for setting up, it should be fine.