### PR TITLE
Posix: use /etc/dub/settings.json if in /usr

### DIFF
--- a/changelog/etc-dub-settings-json.dd
+++ b/changelog/etc-dub-settings-json.dd
@@ -1,0 +1,9 @@
+Posix: use /etc/dub/settings.json if DUB is installed in /usr
+
+For Linux distributions that put the dub installation in /usr, there is now a
+special case that DUB will load from /etc/dub/settings.json (absolute path) if
+the installation is inside /usr.
+
+Previously settings would have attempted to be loaded from
+`/usr/etc/dub/settings.json` if installed in `/usr/bin/dub`. This is still
+loaded if it exists, but if not `/etc/dub/settings.json` will be loaded.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -290,7 +290,15 @@ class Dub {
 		m_dirs.temp = NativePath(tempDir);
 
 		m_config = new DubConfig(jsonFromFile(m_dirs.systemSettings ~ "settings.json", true), m_config);
-		m_config = new DubConfig(jsonFromFile(NativePath(thisExePath).parentPath ~ "../etc/dub/settings.json", true), m_config);
+
+		auto dubFolderPath = NativePath(thisExePath).parentPath;
+		m_config = new DubConfig(jsonFromFile(dubFolderPath ~ "../etc/dub/settings.json", true), m_config);
+		version (Posix) {
+			if (dubFolderPath.absolute && dubFolderPath.startsWith(NativePath("usr"))) {
+				m_config = new DubConfig(jsonFromFile(NativePath("/etc/dub/settings.json"), true), m_config);
+			}
+		}
+
 		m_config = new DubConfig(jsonFromFile(m_dirs.userSettings ~ "settings.json", true), m_config);
 
 		if (!root_path.empty)


### PR DESCRIPTION
Fix #1472

/etc/dub/settings.json overrides /usr/etc/dub/settings.json (as
suggested by the `man hier` manpage)