### PR TITLE
Removes dynamicLibrary being built as staticLibrary for targets other than OMF.

### DIFF
--- a/changelog/actual-dynamiclibrary.dd
+++ b/changelog/actual-dynamiclibrary.dd
@@ -1,0 +1,7 @@
+Builds dynamicLibrary targets as dynamic libraries instead of static libraries.
+
+Dub will no longer build dynamicLibrary targetType's as staticLibrary.
+
+Except for x86_omf. This has been disabled due to numerous issues that will lead this to not doing what is expected of it.
+
+No compiler or linker flags have been added at this time, you will need to specify the relevant flag to get the compiler to link dynamically against Phobos.

--- a/test/1-dynLib-simple/dub.json
+++ b/test/1-dynLib-simple/dub.json
@@ -1,4 +1,5 @@
 {
     "name": "dynlib-simple",
-    "targetType": "dynamicLibrary"
+    "targetType": "dynamicLibrary",
+    "dflags-ldc": ["-link-defaultlib-shared"]
 }

--- a/test/1-dynLib-simple/source/dynlib/app.d
+++ b/test/1-dynLib-simple/source/dynlib/app.d
@@ -1,7 +1,7 @@
 module dynlib.app;
 import std.stdio;
 
-void entry()
+export void entry()
 {
     writeln(__FUNCTION__);
 }

--- a/test/2-dynLib-dep/dub.json
+++ b/test/2-dynLib-dep/dub.json
@@ -2,5 +2,6 @@
     "name": "dynlib-dep",
     "dependencies": {
         "dynlib-simple": { "path": "../1-dynLib-simple/" }
-    }
+    },
+    "dflags-ldc": ["-link-defaultlib-shared"]
 }


### PR DESCRIPTION
Succeeds #2149

Closes #571 and closes #2206

#2149 has a lot of information about why this isn't everything needed to get dynamicLibrary behavior being completely correct or user friendly.
But this is the best we can do right now due to compiler/linker state.