### PR TITLE
feat(semver): add support for versions with leading zeros

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -829,7 +829,7 @@ struct Version {
 	{
 		enforce(vers.length > 1, "Version strings must not be empty.");
 		if (vers[0] != branchPrefix && !vers.isGitHash && vers.ptr !is UNKNOWN_VERS.ptr)
-			enforce(vers.isValidVersion(), "Invalid SemVer format: " ~ vers);
+			enforce(vers.isValidVersion(true), "Invalid SemVer format: " ~ vers);
 		m_version = vers;
 	}
 

--- a/source/dub/semver.d
+++ b/source/dub/semver.d
@@ -24,7 +24,7 @@ import std.conv;
 /**
 	Validates a version string according to the SemVer specification.
 */
-bool isValidVersion(string ver)
+bool isValidVersion(string ver, bool allow_leading_zeros = false)
 pure @nogc {
 	// NOTE: this is not by spec, but to ensure sane input
 	if (ver.length > 256) return false;
@@ -32,19 +32,19 @@ pure @nogc {
 	// a
 	auto sepi = ver.indexOf('.');
 	if (sepi < 0) return false;
-	if (!isValidNumber(ver[0 .. sepi])) return false;
+	if (!isValidNumber(ver[0 .. sepi], allow_leading_zeros)) return false;
 	ver = ver[sepi+1 .. $];
 
 	// c
 	sepi = ver.indexOf('.');
 	if (sepi < 0) return false;
-	if (!isValidNumber(ver[0 .. sepi])) return false;
+	if (!isValidNumber(ver[0 .. sepi], allow_leading_zeros)) return false;
 	ver = ver[sepi+1 .. $];
 
 	// c
 	sepi = ver.indexOfAny("-+");
 	if (sepi < 0) sepi = ver.length;
-	if (!isValidNumber(ver[0 .. sepi])) return false;
+	if (!isValidNumber(ver[0 .. sepi], allow_leading_zeros)) return false;
 	ver = ver[sepi .. $];
 
 	// prerelease tail
@@ -74,6 +74,9 @@ unittest {
 	assert(!isValidVersion("01.9.0"));
 	assert(!isValidVersion("1.09.0"));
 	assert(!isValidVersion("1.9.00"));
+	assert(isValidVersion("01.9.0", true));
+	assert(isValidVersion("1.09.0", true));
+	assert(isValidVersion("1.9.00", true));
 	assert(isValidVersion("1.0.0-alpha"));
 	assert(isValidVersion("1.0.0-alpha.1"));
 	assert(isValidVersion("1.0.0-0.3.7"));
@@ -393,15 +396,15 @@ pure @nogc {
 	return true;
 }
 
-private bool isValidNumber(string str)
+private bool isValidNumber(string str, bool allow_leading_zeros = false)
 pure @nogc {
 	if (str.length < 1) return false;
 	foreach (ch; str)
 		if (ch < '0' || ch > '9')
 			return false;
 
-	// don't allow leading zeros
-	if (str[0] == '0' && str.length > 1) return false;
+	if (!allow_leading_zeros && str[0] == '0' && str.length > 1)
+		return false;
 
 	return true;
 }


### PR DESCRIPTION
DMD version scheme uses leading zeros and it is currently unable to use the
official package manager with the official reference compiler correctly with
versioning. This patch relaxes the semver requirements and allow leading zeros
on versions. This change doesn't affect the dependency resolver nor introduce
any breaking change.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>