### PR TITLE
move command variable substitution to execution

### DIFF
--- a/changelog/command-variables.dd
+++ b/changelog/command-variables.dd
@@ -1,0 +1,20 @@
+Command environment variable substitution changed
+
+Now users can use the documented predefined variables inside custom command
+directives without the need for a wrapper shell script.
+
+Before this would have failed:
+```json
+"preBuildCommands": ["$DC -run foo.d"]
+```
+unless DC was defined as environment variable outside DUB.
+
+It was before possible to run a script that used the $DC environment variable or
+on POSIX escape the `$` with `$$DC` to make the shell substitute the variable.
+These workarounds are no longer needed now.
+
+API change: none of the different command directives are no longer substituted
+with the process environment variables. You now access the raw commands as
+provided by the user in the recipe. `dub describe` has been adjusted and now
+also processes the predefined environment variables as well as the process
+environment variables.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1536,7 +1536,7 @@ class DescribeCommand : PackageBuildCommand {
 			"target-type, target-path, target-name, working-directory, " ~
 			"copy-files, string-import-files, pre-generate-commands, " ~
 			"post-generate-commands, pre-build-commands, post-build-commands, " ~
-			"requirements",
+			"pre-run-commands, post-run-commands, requirements",
 		];
 	}
 

--- a/source/dub/description.d
+++ b/source/dub/description.d
@@ -90,12 +90,12 @@ struct PackageDescription {
 	string[] debugVersions; /// D debug version identifiers to set
 	string[] importPaths;
 	string[] stringImportPaths;
-	string[] preGenerateCommands; /// commands executed before creating the description
-	string[] postGenerateCommands; /// commands executed after creating the description
-	string[] preBuildCommands; /// Commands to execute prior to every build
-	string[] postBuildCommands; /// Commands to execute after every build
-	string[] preRunCommands; /// Commands to execute prior to every run
-	string[] postRunCommands; /// Commands to execute after every run
+	string[] preGenerateCommands; /// Commands executed before creating the description, with variables not substituted.
+	string[] postGenerateCommands; /// Commands executed after creating the description, with variables not substituted.
+	string[] preBuildCommands; /// Commands to execute prior to every build, with variables not substituted.
+	string[] postBuildCommands; /// Commands to execute after every build, with variables not substituted.
+	string[] preRunCommands; /// Commands to execute prior to every run, with variables not substituted.
+	string[] postRunCommands; /// Commands to execute after every run, with variables not substituted.
 	string[string] environments;
 	string[string] buildEnvironments;
 	string[string] runEnvironments;

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -175,8 +175,7 @@ class BuildGenerator : ProjectGenerator {
 		// run post-build commands
 		if (!cached && buildsettings.postBuildCommands.length) {
 			logInfo("Running post-build commands...");
-			runBuildCommands(buildsettings.postBuildCommands, pack, m_project, settings, buildsettings,
-				[buildsettings.environments, buildsettings.buildEnvironments, buildsettings.postBuildEnvironments]);
+			runBuildCommands(CommandType.postBuild, buildsettings.postBuildCommands, pack, m_project, settings, buildsettings);
 		}
 
 		return cached;
@@ -214,8 +213,7 @@ class BuildGenerator : ProjectGenerator {
 
 		if( buildsettings.preBuildCommands.length ){
 			logInfo("Running pre-build commands...");
-			runBuildCommands(buildsettings.preBuildCommands, pack, m_project, settings, buildsettings,
-				[buildsettings.environments, buildsettings.buildEnvironments, buildsettings.preBuildEnvironments]);
+			runBuildCommands(CommandType.preBuild, buildsettings.preBuildCommands, pack, m_project, settings, buildsettings);
 		}
 
 		// override target path
@@ -335,8 +333,7 @@ class BuildGenerator : ProjectGenerator {
 
 		if( buildsettings.preBuildCommands.length ){
 			logInfo("Running pre-build commands...");
-			runBuildCommands(buildsettings.preBuildCommands, pack, m_project, settings, buildsettings,
-				[buildsettings.environments, buildsettings.buildEnvironments, buildsettings.preBuildEnvironments]);
+			runBuildCommands(CommandType.preBuild, buildsettings.preBuildCommands, pack, m_project, settings, buildsettings);
 		}
 
 		buildWithCompiler(settings, buildsettings);
@@ -580,8 +577,7 @@ class BuildGenerator : ProjectGenerator {
 	{
 		if (buildsettings.preRunCommands.length) {
 			logInfo("Running pre-run commands...");
-			runBuildCommands(buildsettings.preRunCommands, pack, proj, settings, buildsettings,
-				[buildsettings.environments, buildsettings.runEnvironments, buildsettings.preRunEnvironments]);
+			runBuildCommands(CommandType.preRun, buildsettings.preRunCommands, pack, proj, settings, buildsettings);
 		}
 	}
 
@@ -590,8 +586,7 @@ class BuildGenerator : ProjectGenerator {
 	{
 		if (buildsettings.postRunCommands.length) {
 			logInfo("Running post-run commands...");
-			runBuildCommands(buildsettings.postRunCommands, pack, proj, settings, buildsettings,
-				[buildsettings.environments, buildsettings.runEnvironments, buildsettings.postRunEnvironments]);
+			runBuildCommands(CommandType.postRun, buildsettings.postRunCommands, pack, proj, settings, buildsettings);
 		}
 	}
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -986,6 +986,8 @@ class Project {
 			case "post-generate-commands":
 			case "pre-build-commands":
 			case "post-build-commands":
+			case "pre-run-commands":
+			case "post-run-commands":
 			case "environments":
 			case "build-environments":
 			case "run-environments":

--- a/test/issue2192-environment-variables.sh
+++ b/test/issue2192-environment-variables.sh
@@ -14,3 +14,8 @@ if [ -s "$CURR_DIR/issue2192-environment-variables/package.txt" ]; then
 else
 	die $LINENO 'Expected generated package.txt file is missing.'
 fi
+
+OUTPUT=$($DUB describe --root "$CURR_DIR/issue2192-environment-variables" --skip-registry=all --data=pre-build-commands --data-list)
+if [ "$OUTPUT" != "echo 'issue2192-environment-variables' > package.txt" ]; then
+	die $LINENO 'describe did not contain subtituted values or the correct package name'
+fi

--- a/test/issue2192-environment-variables.sh
+++ b/test/issue2192-environment-variables.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+if [ -n "${DUB_PACKAGE-}" ]; then
+  die $LINENO '$DUB_PACKAGE must not be set when running this test!'
+fi
+
+if ! { $DUB build --force --root "$CURR_DIR/issue2192-environment-variables" --skip-registry=all; }; then
+	die $LINENO 'Failed to build package with built-in environment variables.'
+fi
+
+if [ -s "$CURR_DIR/issue2192-environment-variables/package.txt" ]; then
+	rm "$CURR_DIR/issue2192-environment-variables/package.txt"
+else
+	die $LINENO 'Expected generated package.txt file is missing.'
+fi

--- a/test/issue2192-environment-variables/dub.sdl
+++ b/test/issue2192-environment-variables/dub.sdl
@@ -1,0 +1,2 @@
+name "issue2192-environment-variables"
+preBuildCommands "echo '$DUB_PACKAGE' > package.txt"

--- a/test/issue2192-environment-variables/source/lib.d
+++ b/test/issue2192-environment-variables/source/lib.d
@@ -1,0 +1,1 @@
+module lib;


### PR DESCRIPTION
This is needed as commands that need to be run need to have generator
settings available before running to avoid inconsistencies with
environment variables passed to the actually ran program and variables
used in substitution.

Fixes https://github.com/dlang/dub/issues/2192

Fixes pre/postGenerateCommands inconsistently using dub environments
(execution was substituted including buildEnvironments, but shell cmd
did not get the build variables for substitution) - now both get
the build variables. Solved by removing code duplication. (env building)

Now exposes some previously private project.d processVars functions, substitution in dub describe is now done there. Exposes pre-run-commands/post-run-commands in dub describe (were implemented already, just missing in validation switch)

Brings in line the DUB behavior with the documentation (seems more sensible than telling people, that they need to make a wrapper script to actually use the environment variables or hope for shell substitution on the current platform using `$$`)

e.g. previously this was bugged:
```json
"preBuildCommands": ["$DC -run foo.d"]
```
which would say invalid variable if it wasn't an existing environment variable or with the workaround
```json
"preBuildCommands": ["$$DC -run foo.d"]
```
it would work on POSIX platforms, but not on Windows because CMD needs %DC% and powershell probably needs different syntax altogether.

Now $DC is actually replaced by DUB and the `$$` hack no longer needs to be used.