### PR TITLE
Adapt determinePlatform to the new defaults for Win32

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -182,7 +182,9 @@ interface Compiler {
 		// cmdline option does not lead to the same string being found among
 		// `build_platform.architecture`, as it's brittle and doesn't work with triples.
 		if (build_platform.compiler != "ldc") {
-			if (arch_override.length && !build_platform.architecture.canFind(arch_override)) {
+			if (arch_override.length && !build_platform.architecture.canFind(arch_override) &&
+				!(build_platform.compiler == "dmd" && arch_override.among("x86_omf", "x86_mscoff")) // Will be fixed in determinePlatform
+			) {
 				logWarn(`Failed to apply the selected architecture %s. Got %s.`,
 					arch_override, build_platform.architecture);
 			}

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -167,15 +167,17 @@ config    /etc/dmd.conf
 	}
 
 	version (LDC) unittest {
+		import std.conv : to;
+
 		BuildSettings settings;
 		auto compiler = new DMDCompiler;
 		auto bp = compiler.determinePlatform(settings, "ldmd2", "x86");
-		assert(bp.architecture.canFind("x86"));
-		assert(!bp.architecture.canFind("x86_omf"));
+		assert(bp.architecture.canFind("x86"), bp.architecture.to!string);
+		assert(!bp.architecture.canFind("x86_omf"), bp.architecture.to!string);
 		bp = compiler.determinePlatform(settings, "ldmd2", "");
-		version (X86) assert(bp.architecture.canFind("x86"));
-		version (X86_64) assert(bp.architecture.canFind("x86_64"));
-		assert(!bp.architecture.canFind("x86_omf"));
+		version (X86) assert(bp.architecture.canFind("x86"), bp.architecture.to!string);
+		version (X86_64) assert(bp.architecture.canFind("x86_64"), bp.architecture.to!string);
+		assert(!bp.architecture.canFind("x86_omf"), bp.architecture.to!string);
 	}
 
 	void prepareBuildSettings(ref BuildSettings settings, const scope ref BuildPlatform platform,

--- a/test/win32_default.d
+++ b/test/win32_default.d
@@ -1,0 +1,54 @@
+/+ dub.json: {
+   "name": "win32_default",
+   "configurations": [
+       {
+           "name": "Default",
+           "versions": [ "Default" ]
+       },
+       {
+           "name": "OMF",
+           "versions": [ "OMF" ]
+       },
+       {
+           "name": "MsCoff",
+           "versions": [ "MsCoff" ]
+       },
+       {
+           "name": "MsCoff64",
+           "versions": [ "MsCoff", "Is64" ]
+       }
+   ]
+} +/
+
+module dynlib.app;
+
+pragma(msg, "Frontend: ", __VERSION__);
+
+// Object format should match the expectation
+version (OMF)
+{
+    enum expSize = 4;
+    enum expFormat = "omf";
+}
+else version (MsCoff)
+{
+    // Should be a 32 bit build
+    version (Is64)  enum expSize = 8;
+    else            enum expSize = 4;
+
+    enum expFormat = "coff";
+}
+else version (Default)
+{
+    enum expSize = 4;
+    enum expFormat = __VERSION__ >= 2099 ? "coff" : "omf";
+}
+else
+{
+    static assert(false, "Missing version flag!");
+}
+
+enum actFormat = __traits(getTargetInfo, "objectFormat");
+
+static assert(actFormat == expFormat);
+static assert((int*).sizeof == expSize);

--- a/test/win32_default.script.d
+++ b/test/win32_default.script.d
@@ -1,0 +1,89 @@
+/+ dub.json: {
+   "name": "win32_default_test"
+} +/
+
+module win32_default.script;
+
+int main()
+{
+	import std.stdio;
+
+	version (Windows)
+	{
+		version (DigitalMars)
+			enum disabled = null;
+		else
+			enum disabled = "DMD as the host compiler";
+	}
+	else
+		enum disabled = "Windows";
+
+	static if (disabled)
+	{
+		writeln("Test `win32_default` requires " ~ disabled);
+		return 0;
+	}
+	else
+	{
+		import std.algorithm;
+		import std.path;
+		import std.process;
+
+		const dir = __FILE_FULL_PATH__.dirName();
+		const file = buildPath(dir, "win32_default.d");
+
+		const dub = environment.get("DUB", buildPath(dirName(dir), "bin", "dub.exe"));
+		const dmd = environment.get("DMD", "dmd");
+
+		int exitCode;
+
+		void runTest(scope const string[] cmd)
+		{
+			const result = execute(cmd);
+
+			if (result.status || result.output.canFind("Failed"))
+			{
+				writefln("\n> %-(%s %)", cmd);
+				writeln("===========================================================");
+				writeln(result.output);
+				writeln("===========================================================");
+				writeln("Last command failed with exit code ", result.status, '\n');
+				exitCode = 1;
+			}
+		}
+
+		// Test without --arch
+		runTest([
+			dub, "build",
+				"--compiler", dmd,
+				"--config", "MsCoff64",
+				"--single", file,
+		]);
+
+		// Test with different --arch
+		const string[2][] tests = [
+			[ "x86",        "Default"	],
+			[ "x86_omf",    "OMF"		],
+			[ "x86_mscoff", "MsCoff"	],
+			[ "x86_64",		"MsCoff64"	],
+		];
+
+		foreach (string[2] test; tests)
+		{
+			const arch = test[0];
+			const config = test[1];
+
+			runTest([
+				dub, "build",
+					"--compiler", dmd,
+					"--arch", arch,
+					"--config", config,
+					"--single", file,
+			]);
+		}
+
+
+
+		return exitCode;
+	}
+}


### PR DESCRIPTION
Starting with DMD 2.099, `-m32` defaults to MsCOFF instead of OMF and
`-m32omf` is required to use the OMF format + OPTLINK.

This commit changes the logic to select the appropriate logic based
on the current compiler version. Potentially using the wrong object file
format during platform probing is fine because the codegen is skipped
(dmd is invoked with `-c -o-`).
