### PR TITLE
Define  the $DUB_BUILD_PATH variable.

### DIFF
--- a/changelog/build-path-variable.dd
+++ b/changelog/build-path-variable.dd
@@ -1,0 +1,15 @@
+The `$DUB_BUILD_PATH` variable was added
+
+The `$DUB_BUILD_PATH` variable is now defined inside the `postBuildCommands`
+section. It contains the absolute path in which the package was built, and can
+be used to copy by-products of the build process to their intended locations.
+
+For example, if an executable exports symbols, you will want to make the
+resulting import library and symbols export file available somewhere. That can
+be done with a `dub.json` section like this:
+-------
+    "postBuildCommands-windows": [
+        "copy /y $DUB_BUILD_PATH\\$DUB_TARGET_NAME.lib $PACKAGE_DIR\\lib"
+        "copy /y $DUB_BUILD_PATH\\$DUB_TARGET_NAME.exp $PACKAGE_DIR\\lib"
+    ],
+-------

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -146,6 +146,8 @@ class BuildGenerator : ProjectGenerator {
 
 	private bool buildTarget(GeneratorSettings settings, BuildSettings buildsettings, in Package pack, string config, in Package[] packages, in NativePath[] additional_dep_files, out NativePath target_path)
 	{
+		import std.path : absolutePath;
+
 		auto cwd = NativePath(getcwd());
 		bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
@@ -175,7 +177,8 @@ class BuildGenerator : ProjectGenerator {
 		// run post-build commands
 		if (!cached && buildsettings.postBuildCommands.length) {
 			logInfo("Running post-build commands...");
-			runBuildCommands(CommandType.postBuild, buildsettings.postBuildCommands, pack, m_project, settings, buildsettings);
+			runBuildCommands(CommandType.postBuild, buildsettings.postBuildCommands, pack, m_project, settings, buildsettings,
+							 [["DUB_BUILD_PATH" : target_path.parentPath.toNativeString.absolutePath]]);
 		}
 
 		return cached;


### PR DESCRIPTION
The `$DUB_BUILD_PATH` variable is now defined inside the `postBuildCommands`
section. It contains the absolute path in which the package was built, and can
be used to copy by-products of the build process to their intended locations.

This has been suggested earlier https://github.com/dlang/dub/issues/1962#issuecomment-640602652 by @WebFreak001 .