### PR TITLE
sdl/json: Do not create dummy dependencyBuildSettings entry

### DIFF
--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -182,7 +182,10 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 					{
 						BuildSettingsTemplate dbs;
 						dbs.parseJson(verspec, package_name);
-						bs.dependencyBuildSettings[pkg] = dbs;
+						// Only create an entry if there's an actual BuildSetting
+						// defined by the user.
+						if (dbs !is BuildSettingsTemplate.init)
+							bs.dependencyBuildSettings[pkg] = dbs;
 					}
 				}
 				break;

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -217,7 +217,9 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package
 
 	BuildSettingsTemplate dbs;
 	parseBuildSettings(t, dbs, package_name);
-	bs.dependencyBuildSettings[pkg] = dbs;
+	// Don't create unneeded entries
+	if (dbs !is BuildSettingsTemplate.init)
+		bs.dependencyBuildSettings[pkg] = dbs;
 }
 
 private void parseConfiguration(Tag t, ref ConfigurationInfo ret, string package_name)


### PR DESCRIPTION
Because if a user provide an object as a dependency,
such as `{ "path": "foo/bar", "optional": true }`,
we would create a dummy entry in the AA.