### PR TITLE
Move fix for issue 711 outside of JSON/SDL parser

### DIFF
--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -63,6 +63,7 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 								 string default_package_name = null)
 {
 	import std.algorithm : endsWith;
+	import dub.compilers.buildsettings : TargetType;
 	import dub.internal.vibecompat.data.json;
 	import dub.recipe.json : parseJson;
 	import dub.recipe.sdl : parseSDL;
@@ -74,7 +75,15 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 	if (filename.endsWith(".json")) parseJson(ret, parseJsonString(contents, filename), parent_name);
 	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent_name, filename);
 	else assert(false, "readPackageRecipe called with filename with unknown extension: "~filename);
-	return ret;
+
+	// Fix for issue #711: `targetType` should be inherited, or default to library
+	TargetType defaultTT = (ret.buildSettings.targetType == TargetType.autodetect) ?
+		TargetType.library : ret.buildSettings.targetType;
+	foreach (ref conf; ret.configurations)
+		if (conf.buildSettings.targetType == TargetType.autodetect)
+			conf.buildSettings.targetType = defaultTT;
+
+    return ret;
 }
 
 

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -57,13 +57,9 @@ void parseJson(ref PackageRecipe recipe, Json json, string parent_name)
 	recipe.buildSettings.parseJson(json, fullname);
 
 	if (auto pv = "configurations" in json) {
-		TargetType deftargettp = TargetType.library;
-		if (recipe.buildSettings.targetType != TargetType.autodetect)
-			deftargettp = recipe.buildSettings.targetType;
-
 		foreach (settings; *pv) {
 			ConfigurationInfo ci;
-			ci.parseJson(settings, recipe.name, deftargettp);
+			ci.parseJson(settings, recipe.name);
 			recipe.configurations ~= ci;
 		}
 	}
@@ -133,10 +129,8 @@ private void parseSubPackages(ref PackageRecipe recipe, string parent_package_na
 	}
 }
 
-private void parseJson(ref ConfigurationInfo config, Json json, string package_name, TargetType default_target_type = TargetType.library)
+private void parseJson(ref ConfigurationInfo config, Json json, string package_name)
 {
-	config.buildSettings.targetType = default_target_type;
-
 	foreach (string name, value; json) {
 		switch (name) {
 			default: break;

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -64,15 +64,9 @@ void parseSDL(ref PackageRecipe recipe, Tag sdl, string parent_name)
 	// parse general build settings
 	parseBuildSettings(sdl, recipe.buildSettings, full_name);
 
-	// determine default target type for configurations
-	auto defttype = recipe.buildSettings.targetType;
-	if (defttype == TargetType.autodetect)
-		defttype = TargetType.library;
-
 	// parse configurations
 	recipe.configurations.length = configs.length;
 	foreach (i, n; configs) {
-		recipe.configurations[i].buildSettings.targetType = defttype;
 		parseConfiguration(n, recipe.configurations[i], full_name);
 	}
 


### PR DESCRIPTION
```
Having the fix for this issue in the parser means adding non-trivial logic.
It is easier to reason about to have this logic done as a post-processing step,
replacing the `autodetect` with the actually auto-detected version.
This also paves the way to have other `targetType` as default,
e.g. the `unittest` configuration should probably not be `library`.
```

CC @s-ludwig 