### PR TITLE
Use configy library to parse dub.json file

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -286,7 +286,7 @@ struct CommandLineHandler
 
 		// make the CWD package available so that for example sub packages can reference their
 		// parent package.
-		try dub.packageManager.getOrLoadPackage(NativePath(options.root_path));
+		try dub.packageManager.getOrLoadPackage(NativePath(options.root_path), NativePath.init, false, StrictMode.Warn);
 		catch (Exception e) { logDiagnostic("No valid package found in current working directory: %s", e.msg); }
 
 		return dub;

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -21,6 +21,8 @@ import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
 
+import configy.Read : StrictMode;
+
 import std.algorithm;
 import std.array;
 import std.conv;
@@ -169,8 +171,11 @@ class Package {
 			version_override = Optional version to associate to the package
 				instead of the one declared in the package recipe, or the one
 				determined by invoking the VCS (GIT currently).
+			mode = Whether to issue errors, warning, or ignore unknown keys in dub.json
 	*/
-	static Package load(NativePath root, NativePath recipe_file = NativePath.init, Package parent = null, string version_override = "")
+	static Package load(NativePath root, NativePath recipe_file = NativePath.init,
+		Package parent = null, string version_override = "",
+		StrictMode mode = StrictMode.Ignore)
 	{
 		import dub.recipe.io;
 
@@ -181,7 +186,7 @@ class Package {
 				.format(root.toNativeString(),
 					packageInfoFiles.map!(f => cast(string)f.filename).join("/")));
 
-		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : null);
+		auto recipe = readPackageRecipe(recipe_file, parent ? parent.name : null, mode);
 
 		auto ret = new Package(recipe, root, parent, version_override);
 		ret.m_infoFile = recipe_file;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -65,7 +65,7 @@ class Project {
 			logWarn("There was no package description found for the application in '%s'.", project_path.toNativeString());
 			pack = new Package(PackageRecipe.init, project_path);
 		} else {
-			pack = package_manager.getOrLoadPackage(project_path, packageFile);
+			pack = package_manager.getOrLoadPackage(project_path, packageFile, false, StrictMode.Warn);
 		}
 
 		this(package_manager, pack);


### PR DESCRIPTION
Over the last few years, I've been working on a project that had growing configuration needs.
We started by manually parsing YAML files and using dyaml, then one day, when the application was sizeable, all the manual work was turned into a library.

The goal was simple: Using a declarative approach (using D native value types, so no `class`es) and minimizing YAML dependency. This project was separated in its own library, [configy](https://github.com/bosagora/configy/).

One of the major advantages of Configy is that it produces **good error messages**, even with user-defined types.
User-defined types with a `fromString`, string ctor, etc... can throw Exceptions, which the library then catches and wrap in an Exception that contains context information. It also contains a "strict mode" which will warn users if they use a key that isn't valid. I understand that the original intent of not erroring out on keys to preserve forward compatibility, but experience has shown that's causing more trouble than it's worth. Plus, we have `ToolchainRequirements` now.