### PR TITLE
Don't generate a dub.selections.json file for "dub test"

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -956,6 +956,7 @@ abstract class PackageBuildCommand : Command {
 		bool m_nodeps;
 		bool m_forceRemove = false;
 		bool m_single;
+		bool m_test = false;
 		bool m_filterVersions = false;
 	}
 
@@ -1049,7 +1050,7 @@ abstract class PackageBuildCommand : Command {
 			dub.project.reinit();
 			if (!dub.project.hasAllDependencies) {
 				logDiagnostic("Checking for missing dependencies.");
-				if (m_single) dub.upgrade(UpgradeOptions.select | UpgradeOptions.noSaveSelections);
+				if (m_single || m_test) dub.upgrade(UpgradeOptions.select | UpgradeOptions.noSaveSelections);
 				else dub.upgrade(UpgradeOptions.select);
 			}
 		}
@@ -1370,6 +1371,8 @@ class TestCommand : PackageBuildCommand {
 			`run the unit tests.`
 		];
 		this.acceptsAppArgs = true;
+
+		m_test = true;
 	}
 
 	override void prepare(scope CommandArgs args)

--- a/test/test-no-save-selections.sh
+++ b/test/test-no-save-selections.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+rm -f 1-staticLib-simple/dub.selections.json
+
+if ! ${DUB} test --root 1-staticLib-simple; then
+    die $LINENO 'The test command failed.'
+fi
+
+if [ -f "1-staticLib-simple/dub.selections.json" ]; then
+    die $LINENO 'The test command has unexpectedly generated a dub.selections.json file.'
+fi


### PR DESCRIPTION
See #1245 - @ljmf00, I think for for library targets writing selections is a debatable choice, but for "dub test" I can't really find any pro argument, while writing selections is very frequently annoying in practice.