### PR TITLE
Add a command line option for upgrading all sub packages.

### DIFF
--- a/changelog/subpackage_upgrade.dd
+++ b/changelog/subpackage_upgrade.dd
@@ -1,0 +1,5 @@
+Upgrading all sub packages at once
+
+A new "-s" switch allows to "dub upgrade" all sub packages together with the
+base package. This aims to provide a better workflow for fully reproducible
+builds and tests.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -343,6 +343,8 @@ class Dub {
 
 	@property inout(Project) project() inout { return m_project; }
 
+	@property inout(PackageSupplier)[] packageSuppliers() inout { return m_packageSuppliers; }
+
 	/** Returns the default compiler binary to use for building D code.
 
 		If set, the "defaultCompiler" field of the DUB user or system

--- a/test/test-upgrade-subpackages.sh
+++ b/test/test-upgrade-subpackages.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. $(dirname ${BASH_SOURCE[0]})/common.sh
+
+PACK_PATH="$CURR_DIR"/path-subpackage-ref
+
+# make sure that there are no left-over selections files
+rm -f $PACK_PATH/dub.selections.json $PACK_PATH/subpack/dub.selections.json
+
+# first upgrade only the root package
+if ! ${DUB} upgrade --root $PACK_PATH; then
+    die $LINENO 'The upgrade command failed.'
+fi
+if [ ! -f $PACK_PATH/dub.selections.json ] || [ -f $PACK_PATH/subpack/dub.selections.json ]; then
+    die $LINENO 'The upgrade command did not generate the right set of dub.selections.json files.'
+fi
+
+rm -f $PACK_PATH/dub.selections.json
+
+# now upgrade with all sub packages
+if ! ${DUB} upgrade -s --root $PACK_PATH; then
+    die $LINENO 'The upgrade command failed with -s.'
+fi
+if [ ! -f $PACK_PATH/dub.selections.json ] || [ ! -f $PACK_PATH/subpack/dub.selections.json ]; then
+    die $LINENO 'The upgrade command did not generate all dub.selections.json files.'
+fi
+
+# clean up
+rm -f $PACK_PATH/dub.selections.json $PACK_PATH/subpack/dub.selections.json

--- a/test/timeout.sh
+++ b/test/timeout.sh
@@ -31,7 +31,7 @@ Content-Length: 2\r
 \r
 {}')
     for i in $(seq 0 $((${#res} - 1))); do
-        echo -n "${res:$i:1}"
+        echo -n "${res:$i:1}" || true
         sleep 1
     done
 } | nc -l $PORT >/dev/null &


### PR DESCRIPTION
This mitigates the issue of `dub test` (or even `dub build`) generating dub.selection.json for library projects by going in the opposite direction, facilitating the use of selection files for all sub packages. Added as an optional command line flag for the sake of backwards compatibility.

See also #1245 and #2284.