### PR TITLE
Fix dub_test_root imports for non-all-at-once compilations

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1634,7 +1634,7 @@ class DescribeCommand : PackageBuildCommand {
 		// With a requested `unittest` config, switch to the special test runner
 		// config (which doesn't require an existing `unittest` configuration).
 		if (config == "unittest") {
-			const test_config = dub.project.addTestRunnerConfiguration(settings, false);
+			const test_config = dub.project.addTestRunnerConfiguration(settings, !dub.dryRun);
 			if (test_config) settings.config = test_config;
 		}
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -319,6 +319,7 @@ class Dub {
 		m_defaultPostRunEnvironments = m_config.defaultPostRunEnvironments;
 	}
 
+	@property bool dryRun() const { return m_dryRun; }
 	@property void dryRun(bool v) { m_dryRun = v; }
 
 	/** Returns the root path (usually the current working directory).

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -329,11 +329,8 @@ class Project {
 		tcinfo.sourceFiles[""] ~= escapedMainFile;
 		tcinfo.mainSourceFile = escapedMainFile;
 		if (!settings.tempBuild) {
-			// Add the directory containing dub_test_root.d to the import paths.
-			// The directory needs to exist, e.g., for `dub describe`, so don't add if it doesn't
-			// exist *and* we are not about to generate the module.
-			if (generate_main || existsFile(mainfile.parentPath))
-				tcinfo.importPaths[""] ~= NativePath(escapedMainFile).parentPath.toNativeString();
+			// add the directory containing dub_test_root.d to the import paths
+			tcinfo.importPaths[""] ~= NativePath(escapedMainFile).parentPath.toNativeString();
 		}
 
 		if (generate_main && (settings.force || !existsFile(mainfile))) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -322,12 +322,14 @@ class Project {
 			mainfile = getTempFile("dub_test_root", ".d");
 		else {
 			import dub.generators.build : computeBuildName;
-			mainfile = rootPackage.path ~ format(".dub/code/%s_dub_test_root.d", computeBuildName(config, settings, import_modules));
+			mainfile = rootPackage.path ~ format(".dub/code/%s/dub_test_root.d", computeBuildName(config, settings, import_modules));
 		}
 
 		auto escapedMainFile = mainfile.toNativeString().replace("$", "$$");
 		tcinfo.sourceFiles[""] ~= escapedMainFile;
 		tcinfo.mainSourceFile = escapedMainFile;
+		if (!settings.tempBuild)
+			tcinfo.importPaths[""] ~= NativePath(escapedMainFile).parentPath.toNativeString();
 
 		if (generate_main && (settings.force || !existsFile(mainfile))) {
 			import std.file : mkdirRecurse;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -328,8 +328,13 @@ class Project {
 		auto escapedMainFile = mainfile.toNativeString().replace("$", "$$");
 		tcinfo.sourceFiles[""] ~= escapedMainFile;
 		tcinfo.mainSourceFile = escapedMainFile;
-		if (!settings.tempBuild)
-			tcinfo.importPaths[""] ~= NativePath(escapedMainFile).parentPath.toNativeString();
+		if (!settings.tempBuild) {
+			// Add the directory containing dub_test_root.d to the import paths.
+			// The directory needs to exist, e.g., for `dub describe`, so don't add if it doesn't
+			// exist *and* we are not about to generate the module.
+			if (generate_main || existsFile(mainfile.parentPath))
+				tcinfo.importPaths[""] ~= NativePath(escapedMainFile).parentPath.toNativeString();
+		}
 
 		if (generate_main && (settings.force || !existsFile(mainfile))) {
 			import std.file : mkdirRecurse;

--- a/test/cache-generated-test-config.sh
+++ b/test/cache-generated-test-config.sh
@@ -12,15 +12,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls .dub/code/*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls .dub/code/*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 ## test with empty DFLAGS environment variable
 DFLAGS="" ${DUB} test --compiler=${DC}
@@ -30,15 +30,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 DFLAGS="" ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 ## test with DFLAGS environment variable
 DFLAGS="-g" ${DUB} test --compiler=${DC}
@@ -48,15 +48,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 DFLAGS="-g" ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 
 

--- a/test/dub_test_root.sh
+++ b/test/dub_test_root.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Make sure the auto-generated 'dub_test_root' module is importable for
+# non-all-at-once compilations too.
+
+set -euo pipefail
+
+TMPDIR=$(mktemp -d "$(basename "$0").XXXXXX")
+
+function cleanup {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+cd "$TMPDIR"
+
+echo 'name "foo"' > dub.sdl
+
+mkdir -p source
+echo 'import dub_test_root : allModules;' > source/foo.d
+
+$DUB test --build-mode=singleFile

--- a/test/issue1856-build-unittest.sh
+++ b/test/issue1856-build-unittest.sh
@@ -17,7 +17,7 @@ targetType "library"
 +/
 void foo() {}
 EOF
-$DUB describe --single "$TMPDIR/no_ut.d" --config=unittest | grep -q '"targetName": "no_ut-test-library"'
+$DUB describe --single "$TMPDIR/no_ut.d" --config=unittest | grep '"targetName": "no_ut-test-library"'
 $DUB build    --single "$TMPDIR/no_ut.d" --config=unittest --build=unittest
 "$TMPDIR/no_ut-test-library"
 
@@ -32,7 +32,7 @@ configuration "unittest" {
 +/
 void foo() {}
 EOF
-$DUB describe --single "$TMPDIR/partial_ut.d" --config=unittest | grep -q '"targetName": "partial_ut-test-unittest"'
+$DUB describe --single "$TMPDIR/partial_ut.d" --config=unittest | grep '"targetName": "partial_ut-test-unittest"'
 $DUB build    --single "$TMPDIR/partial_ut.d" --config=unittest --build=unittest
 "$TMPDIR/bin/partial_ut-test-unittest"
 
@@ -48,7 +48,7 @@ configuration "unittest" {
 +/
 void foo() {}
 EOF
-$DUB describe --single "$TMPDIR/partial_ut2.d" --config=unittest | grep -q '"targetName": "ut"'
+$DUB describe --single "$TMPDIR/partial_ut2.d" --config=unittest | grep '"targetName": "ut"'
 $DUB build    --single "$TMPDIR/partial_ut2.d" --config=unittest --build=unittest
 "$TMPDIR/bin/ut"
 
@@ -64,6 +64,6 @@ configuration "unittest" {
 +/
 void main() {}
 EOF
-$DUB describe --single "$TMPDIR/full_ut.d" --config=unittest | grep -q '"targetName": "full_ut"'
+$DUB describe --single "$TMPDIR/full_ut.d" --config=unittest | grep '"targetName": "full_ut"'
 $DUB build    --single "$TMPDIR/full_ut.d" --config=unittest --build=unittest
 "$TMPDIR/bin/full_ut"


### PR DESCRIPTION
Which requires a regular `dub_test_root.d` filename *and* adding the containing directory to the importPaths.