### PR TITLE
Project.addTestRunnerConfiguration(): Don't accidentally modify base config's `buildSettings`

### DIFF
--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -218,6 +218,10 @@ struct BuildSettingsTemplate {
 	Flags!BuildOption[string] buildOptions;
 
 
+	BuildSettingsTemplate dup() const {
+		return clone(this);
+	}
+
 	/// Constructs a BuildSettings object from this template.
 	void getPlatformSettings(ref BuildSettings dst, in BuildPlatform platform, NativePath base_path)
 	const {


### PR DESCRIPTION
This most likely doesn't affect dub itself, as it only works with a single configuration at a time. The problem has surfaced with reggae though (which can use multiple dub configurations at a time) - the `mainSourceFile` was removed from the base `application` config too.