### PR TITLE
Deprecate once-called redundant getLatestPackage

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1921,7 +1921,7 @@ class FetchCommand : FetchRemoveCommand {
 			dub.fetch(parts.name, Dependency(parts.version_), location, fetchOpts);
 		} else {
 			try {
-				dub.fetch(name, Dependency(">=0.0.0"), location, fetchOpts);
+				dub.fetch(name, Dependency.any, location, fetchOpts);
 				logInfo(
 					"Please note that you need to use `dub run <pkgname>` " ~
 					"or add it to dependencies of your package to actually use/run it. " ~

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1089,9 +1089,8 @@ abstract class PackageBuildCommand : Command {
 
 		enforce(package_name.length, "No valid root package found - aborting.");
 
-		auto pack = ver == ""
-			? dub.packageManager.getLatestPackage(package_name)
-			: dub.packageManager.getBestPackage(package_name, ver);
+		auto pack = dub.packageManager.getBestPackage(
+            package_name, ver.length ? Dependency(ver) : Dependency.any);
 
 		enforce(pack, format!"Failed to find a package named '%s%s' locally."(package_name,
 			ver == "" ? "" : ("@" ~ ver)

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -687,7 +687,7 @@ class Dub {
 		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("%s is not present, getting and storing it user wide", tool);
-			tool_pack = fetch(tool, Dependency(">=0.0.0"), defaultPlacementLocation, FetchOptions.none);
+			tool_pack = fetch(tool, Dependency.any, defaultPlacementLocation, FetchOptions.none);
 		}
 
 		auto dscanner_dub = new Dub(null, m_packageSuppliers);
@@ -1192,7 +1192,7 @@ class Dub {
 		if (!template_pack) template_pack = m_packageManager.getBestPackage(packageName, "~master");
 		if (!template_pack) {
 			logInfo("%s is not present, getting and storing it user wide", packageName);
-			template_pack = fetch(packageName, Dependency(">=0.0.0"), defaultPlacementLocation, FetchOptions.none);
+			template_pack = fetch(packageName, Dependency.any, defaultPlacementLocation, FetchOptions.none);
 		}
 
 		Package initSubPackage = m_packageManager.getSubPackage(template_pack, "init-exec", false);
@@ -1273,7 +1273,7 @@ class Dub {
 		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("%s is not present, getting and storing it user wide", tool);
-			tool_pack = fetch(tool, Dependency(">=0.0.0"), defaultPlacementLocation, FetchOptions.none);
+			tool_pack = fetch(tool, Dependency.any, defaultPlacementLocation, FetchOptions.none);
 		}
 
 		auto ddox_dub = new Dub(null, m_packageSuppliers);

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -223,6 +223,7 @@ class PackageManager {
 
 	/** Looks up the latest package matching the given name.
 	*/
+	deprecated("Use `getBestPackage` with `name, Dependency.any` instead")
 	Package getLatestPackage(string name)
 	{
 		Package pkg;

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -125,7 +125,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		auto md = getMetadata(query);
 		if (md.type == Json.Type.null_)
 			return [];
-		auto json = getBestPackage(md, query, Dependency(">=0.0.0"), true);
+		auto json = getBestPackage(md, query, Dependency.any, true);
 		return [SearchResult(json["name"].opt!string, "", json["version"].opt!string)];
 	}
 }

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -63,7 +63,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		}
 		catch(HTTPStatusException e) {
 			if (e.status == 404) throw e;
-			else logDebug("Failed to download package %s from %s", packageId, url); 
+			else logDebug("Failed to download package %s from %s", packageId, url);
 		}
 		catch(Exception e) {
 			logDebug("Failed to download package %s from %s", packageId, url);
@@ -129,4 +129,3 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		return [SearchResult(json["name"].opt!string, "", json["version"].opt!string)];
 	}
 }
-


### PR DESCRIPTION
getBestPackage present a more generic interface,
as long as we feed it Dependency.any.