### PR TITLE
getDefaultConfiguration(): Accept a const BuildPlatform argument

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -504,7 +504,7 @@ class Dub {
 		This forwards to `Project.getDefaultConfiguration` and requires a
 		project to be loaded.
 	*/
-	string getDefaultConfiguration(BuildPlatform platform, bool allow_non_library_configs = true) const { return m_project.getDefaultConfiguration(platform, allow_non_library_configs); }
+	string getDefaultConfiguration(in BuildPlatform platform, bool allow_non_library_configs = true) const { return m_project.getDefaultConfiguration(platform, allow_non_library_configs); }
 
 	/** Attempts to upgrade the dependency selection of the loaded project.
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -32,7 +32,7 @@ string getObjSuffix(const scope ref BuildPlatform platform)
     return platform.isWindows() ? ".obj" : ".o";
 }
 
-string computeBuildName(string config, GeneratorSettings settings, const string[][] hashing...)
+string computeBuildName(string config, in GeneratorSettings settings, const string[][] hashing...)
 {
 	import std.digest;
 	import std.digest.md;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -231,7 +231,7 @@ class Project {
 		Returns:
 			Name of the added test runner configuration, or null for base configurations with target type `none`
 	*/
-	string addTestRunnerConfiguration(GeneratorSettings settings, bool generate_main = true, string base_config = "", NativePath custom_main_file = NativePath())
+	string addTestRunnerConfiguration(in GeneratorSettings settings, bool generate_main = true, string base_config = "", NativePath custom_main_file = NativePath())
 	{
 		if (base_config.length == 0) {
 			// if a custom main file was given, favor the first library configuration, so that it can be applied
@@ -244,7 +244,7 @@ class Project {
 			if (!base_config.length) base_config = getDefaultConfiguration(settings.platform, true);
 		}
 
-		BuildSettings lbuildsettings = settings.buildSettings;
+		BuildSettings lbuildsettings = settings.buildSettings.dup;
 		addBuildSettings(lbuildsettings, settings, base_config, null, true);
 
 		if (lbuildsettings.targetType == TargetType.none) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -194,7 +194,7 @@ class Project {
 				possible configuration instead of the first "executable"
 				configuration.
 	*/
-	string getDefaultConfiguration(BuildPlatform platform, bool allow_non_library_configs = true)
+	string getDefaultConfiguration(in BuildPlatform platform, bool allow_non_library_configs = true)
 	const {
 		auto cfgs = getPackageConfigs(platform, null, allow_non_library_configs);
 		return cfgs[m_rootPackage.name];


### PR DESCRIPTION
Like `Package.getDefaultConfiguration()` already does. Fixes a minor annoyance for reggae.