### PR TITLE
Dependency: Move `spec` / git ref inside of `Repository`

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -612,7 +612,7 @@ class Dub {
 			if (!pack) fetch(p, ver, defaultPlacementLocation, fetchOpts, "getting selected version");
 			if ((options & UpgradeOptions.select) && p != m_project.rootPackage.name) {
 				if (!ver.repository.empty) {
-					m_project.selections.selectVersionWithRepository(p, ver.repository, ver.versionSpec);
+					m_project.selections.selectVersionWithRepository(p, ver.repository);
 				} else if (ver.path.empty) {
 					m_project.selections.selectVersion(p, ver.version_);
 				} else {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1764,15 +1764,21 @@ final class SelectedVersions {
 	}
 
 	/// Selects a certain Git reference for a specific package.
-	void selectVersionWithRepository(string package_id, Repository repository, string spec)
+	void selectVersionWithRepository(string package_id, Repository repository)
 	{
-		const dependency = Dependency(repository, spec);
+		const dependency = Dependency(repository);
 		if (auto ps = package_id in m_selections) {
 			if (ps.dep == dependency)
 				return;
 		}
 		m_selections[package_id] = Selected(dependency);
 		m_dirty = true;
+	}
+
+	deprecated("Move `spec` inside of the `repository` parameter")
+	void selectVersionWithRepository(string package_id, Repository repository, string spec)
+	{
+		this.selectVersionWithRepository(package_id, Repository(repository.remote(), spec));
 	}
 
 	/// Removes the selection for a particular package.
@@ -1853,8 +1859,8 @@ final class SelectedVersions {
 		else if (j.type == Json.Type.object && "path" in j)
 			return Dependency(NativePath(j["path"].get!string));
 		else if (j.type == Json.Type.object && "repository" in j)
-			return Dependency(Repository(j["repository"].get!string),
-				enforce("version" in j, "Expected \"version\" field in repository version object").get!string);
+			return Dependency(Repository(j["repository"].get!string,
+				enforce("version" in j, "Expected \"version\" field in repository version object").get!string));
 		else throw new Exception(format("Unexpected type for dependency: %s", j));
 	}
 

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -194,8 +194,8 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package
 	} else if ("repository" in attrs) {
 		enforceSDL("version" in attrs, "Missing version specification.", t);
 
-		dep.repository = Repository(attrs["repository"][0].value.get!string);
-		dep.versionSpec = attrs["version"][0].value.get!string;
+		dep.repository = Repository(attrs["repository"][0].value.get!string,
+                                    attrs["version"][0].value.get!string);
 	} else {
 		enforceSDL("version" in attrs, "Missing version specification.", t);
 		dep.versionSpec = attrs["version"][0].value.get!string;
@@ -672,8 +672,8 @@ unittest {
 	PackageRecipe p;
 	p.name = "test";
 
-	auto repository = Repository("git+https://some.url");
-	p.buildSettings.dependencies["package"] = Dependency(repository, "12345678");
+	auto repository = Repository("git+https://some.url", "12345678");
+	p.buildSettings.dependencies["package"] = Dependency(repository);
 	auto sdl = toSDL(p).toSDLDocument();
 	assert(sdl ==
 `name "test"


### PR DESCRIPTION
```
The `Dependency` struct is logically acting as an `enum`,
with 3 discrete possibilities. However, some of the logic is
piggybacking on the (original) version logic.
`Repository` is one of them, and by separating things,
we can make stronger assumptions in `Version` and `Dependency`.
```

Context: https://github.com/dlang/dub/pull/2302