### PR TITLE
Deprecate `PackageManager.loadSCMPackage` & other `Dependency`-related refactoring

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -69,7 +69,7 @@ struct Dependency {
 	*/
 	this(string spec)
 	{
-		this.m_range = VersionRange.fromString(spec);
+		this(VersionRange.fromString(spec));
 	}
 
 	/** Constructs a new dependency specification that matches a specific

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -982,7 +982,7 @@ private struct VersionRange
 
 		string r;
 
-		if (this == Dependency.invalid.m_range) return "invalid";
+		if (this == Invalid) return "invalid";
 		if (this.isExactVersion() && m_inclusiveA && m_inclusiveB) {
 			// Special "==" case
 			if (m_versA == Version.masterBranch) return "~master";

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -528,7 +528,7 @@ class Dub {
 					try if (m_packageManager.getOrLoadPackage(path)) continue;
 					catch (Exception e) { logDebug("Failed to load path based selection: %s", e.toString().sanitize); }
 				} else if (!dep.repository.empty) {
-					if (m_packageManager.loadSCMPackage(getBasePackageName(p), dep))
+					if (m_packageManager.loadSCMPackage(getBasePackageName(p), dep.repository))
 						continue;
 				} else {
 					if (m_packageManager.getPackage(p, dep.version_)) continue;
@@ -593,7 +593,7 @@ class Dub {
 					continue;
 				}
 			} else if (!ver.repository.empty) {
-				pack = m_packageManager.loadSCMPackage(p, ver);
+				pack = m_packageManager.loadSCMPackage(p, ver.repository);
 			} else {
 				assert(ver.isExactVersion, "Resolved dependency is neither path, nor repository, nor exact version based!?");
 				pack = m_packageManager.getPackage(p, ver.version_);
@@ -1722,7 +1722,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 			return m_rootPackage.basePackage;
 
 		if (!dep.repository.empty) {
-			auto ret = m_dub.packageManager.loadSCMPackage(name, dep);
+			auto ret = m_dub.packageManager.loadSCMPackage(name, dep.repository);
 			return ret !is null && dep.matches(ret.version_) ? ret : null;
 		} else if (!dep.path.empty) {
 			try {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -8,6 +8,7 @@
 module dub.packagemanager;
 
 import dub.dependency;
+static import dub.dependency;
 import dub.internal.utils;
 import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.core.log;
@@ -273,15 +274,21 @@ class PackageManager {
 			The package loaded from the given SCM repository or null if the
 			package couldn't be loaded.
 	*/
+	deprecated("Use the overload that accepts a `dub.dependency : Repository`")
 	Package loadSCMPackage(string name, Dependency dependency)
 	in { assert(!dependency.repository.empty); }
+	do { return this.loadSCMPackage(name, dependency.repository); }
+
+	/// Ditto
+	Package loadSCMPackage(string name, dub.dependency.Repository repo)
+	in { assert(!repo.empty); }
 	do {
         Package pack;
 
-        with (dependency.repository) final switch (kind)
+        final switch (repo.kind)
         {
-            case Kind.git:
-                pack = loadGitPackage(name, dependency.versionSpec, dependency.repository.remote);
+            case repo.Kind.git:
+                pack = loadGitPackage(name, repo.ref_, repo.remote);
         }
         if (pack !is null) {
             addPackages(m_temporaryPackages, pack);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -512,7 +512,7 @@ shared static this() {
 						p = m_packageManager.getOrLoadPackage(path, NativePath.init, true);
 						p = resolveSubPackage(p, subname, true);
 					} else if (!vspec.repository.empty) {
-						p = m_packageManager.loadSCMPackage(basename, vspec);
+						p = m_packageManager.loadSCMPackage(basename, vspec.repository);
 						p = resolveSubPackage(p, subname, true);
 					} else {
 						p = m_packageManager.getBestPackage(dep.name, vspec);
@@ -528,7 +528,7 @@ shared static this() {
 				}
 
 				if (!p && !vspec.repository.empty) {
-					p = m_packageManager.loadSCMPackage(basename, vspec);
+					p = m_packageManager.loadSCMPackage(basename, vspec.repository);
 					resolveSubPackage(p, subname, false);
 				}
 


### PR DESCRIPTION
I am still working on https://github.com/dlang/dub/pull/2302 and noticed a couple things while moving to `visit`, so here goes.