### PR TITLE
SelectedVersions: Add Repository to overload set

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -612,7 +612,7 @@ class Dub {
 			if (!pack) fetch(p, ver, defaultPlacementLocation, fetchOpts, "getting selected version");
 			if ((options & UpgradeOptions.select) && p != m_project.rootPackage.name) {
 				if (!ver.repository.empty) {
-					m_project.selections.selectVersionWithRepository(p, ver.repository);
+					m_project.selections.selectVersion(p, ver.repository);
 				} else if (ver.path.empty) {
 					m_project.selections.selectVersion(p, ver.version_);
 				} else {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1764,7 +1764,7 @@ final class SelectedVersions {
 	}
 
 	/// Selects a certain Git reference for a specific package.
-	void selectVersionWithRepository(string package_id, Repository repository)
+	void selectVersion(string package_id, Repository repository)
 	{
 		const dependency = Dependency(repository);
 		if (auto ps = package_id in m_selections) {
@@ -1775,10 +1775,10 @@ final class SelectedVersions {
 		m_dirty = true;
 	}
 
-	deprecated("Move `spec` inside of the `repository` parameter")
+	deprecated("Move `spec` inside of the `repository` parameter and call `selectVersion`")
 	void selectVersionWithRepository(string package_id, Repository repository, string spec)
 	{
-		this.selectVersionWithRepository(package_id, Repository(repository.remote(), spec));
+		this.selectVersion(package_id, Repository(repository.remote(), spec));
 	}
 
 	/// Removes the selection for a particular package.


### PR DESCRIPTION
Before it was an independent function because it had a different set of parameters,
but now that it has been unified, we can put it in the overload set.
No deprecation since the previous change that deprecated selectVersionWithRepository
hasn't been released yet.