### PR TITLE
Make 'bare' option honor the 'root' option & deprecate changing `rootPath`

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -238,8 +238,7 @@ struct CommandLineHandler
 		Dub dub;
 
 		if (options.bare) {
-			dub = new Dub(NativePath(getcwd()));
-			dub.rootPath = NativePath(options.root_path);
+			dub = new Dub(NativePath(options.root_path));
 			dub.defaultPlacementLocation = options.placementLocation;
 
 			return dub;
@@ -559,7 +558,7 @@ struct CommonOptions {
 			"  all: Only search registries specified with --registry",
 			]);
 		args.getopt("annotate", &annotate, ["Do not perform any action, just print what would be done"]);
-		args.getopt("bare", &bare, ["Read only packages contained in the current directory"]);
+		args.getopt("bare", &bare, ["Read only packages contained in the root directory"]);
 		args.getopt("v|verbose", &verbose, ["Print diagnostic output"]);
 		args.getopt("vverbose", &vverbose, ["Print debug output"]);
 		args.getopt("q|quiet", &quiet, ["Only print warnings and errors"]);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -326,6 +326,8 @@ class Dub {
 	*/
 	@property NativePath rootPath() const { return m_rootPath; }
 	/// ditto
+	deprecated("Changing the root path is deprecated as it has non-obvious pitfalls " ~
+			   "(e.g. settings aren't reloaded). Instantiate a new `Dub` instead")
 	@property void rootPath(NativePath root_path)
 	{
 		m_rootPath = root_path;


### PR DESCRIPTION
As explained in the first commit, having `--root` behave any different than `make -C` or `git -C` is IMO a mistake.