### PR TITLE
CI: Switch to macOS-11 as 10.15 will be removed Aug 30th

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         # Latest stable version, update at will
-        os: [ macOS-10.15, ubuntu-18.04, windows-2019 ]
+        os: [ macOS-11, ubuntu-18.04, windows-2019 ]
         dc: [ dmd-latest, ldc-latest, dmd-master, ldc-master ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We've just been hit by a brownout.