### PR TITLE
Do not call Project.reinit from commandline

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1050,7 +1050,6 @@ abstract class PackageBuildCommand : Command {
 
 		if (!m_nodeps) {
 			// retrieve missing packages
-			dub.project.reinit();
 			if (!dub.project.hasAllDependencies) {
 				logDiagnostic("Checking for missing dependencies.");
 				if (m_single) dub.upgrade(UpgradeOptions.select | UpgradeOptions.noSaveSelections);


### PR DESCRIPTION
reinit is called directly when Project is instantiated. It calls PackageManager.refresh,
which re-reads all packages stored in the package directory.
If we want to make dub smarter and faster, we need to stop scanning all the packages
on disk when we have a resolved dependency tree, and move to a lazy/on-demand approach.
The first step would be to remove this call. See also #2388.