### PR TITLE
Trivial: Deprecate Dub.remove(Package, bool)

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -863,6 +863,7 @@ class Dub {
 	}
 
 	/// Compatibility overload. Use the version without a `force_remove` argument instead.
+	deprecated("Use `remove(pack)` directly instead, the boolean has no effect")
 	void remove(in Package pack, bool force_remove)
 	{
 		remove(pack);


### PR DESCRIPTION
The corresponding PackageManager function is long deprecated,
but the Dub wrapper was not deprecated.