### PR TITLE
Support escaped forward slashes in YAML parser

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1843,7 +1843,7 @@ unittest {
 	import configy.Read;
 
     const str1 = `{
-  "registryUrls": [ "http://foo.bar" ],
+  "registryUrls": [ "http://foo.bar\/optional\/escape" ],
   "customCachePaths": [ "foo/bar", "foo/foo" ],
 
   "skipRegistry": "all",
@@ -1873,7 +1873,7 @@ unittest {
 }`;
 
 	 auto c1 = parseConfigString!UserConfiguration(str1, "/dev/null");
-	 assert(c1.registryUrls == [ "http://foo.bar" ]);
+	 assert(c1.registryUrls == [ "http://foo.bar/optional/escape" ]);
 	 assert(c1.customCachePaths == [ NativePath("foo/bar"), NativePath("foo/foo") ]);
 	 assert(c1.skipRegistry == SkipPackageSuppliers.all);
 	 assert(c1.defaultCompiler == "dmd");
@@ -1896,7 +1896,7 @@ unittest {
 
 	 auto m1 = c2.merge(c1);
 	 // c1 takes priority, so its registryUrls is first
-	 assert(m1.registryUrls == [ "http://foo.bar", "http://bar.foo" ]);
+	 assert(m1.registryUrls == [ "http://foo.bar/optional/escape", "http://bar.foo" ]);
 	 // Same with CCP
 	 assert(m1.customCachePaths == [
 		 NativePath("foo/bar"), NativePath("foo/foo"),
@@ -1911,7 +1911,7 @@ unittest {
 	 assert(m1.defaultEnvironments == c1.defaultEnvironments);
 
 	 auto m2 = c1.merge(c2);
-	 assert(m2.registryUrls == [ "http://bar.foo", "http://foo.bar" ]);
+	 assert(m2.registryUrls == [ "http://bar.foo", "http://foo.bar/optional/escape" ]);
 	 assert(m2.customCachePaths == [
 		 NativePath("bar/foo"), NativePath("bar/bar"),
 		 NativePath("foo/bar"), NativePath("foo/foo"),

--- a/source/dyaml/escapes.d
+++ b/source/dyaml/escapes.d
@@ -11,7 +11,7 @@ package:
 
 import std.meta : AliasSeq;
 alias escapes = AliasSeq!('0', 'a', 'b', 't', '\t', 'n', 'v', 'f', 'r', 'e', ' ',
-                             '\"', '\\', 'N', '_', 'L', 'P');
+                          '/', '\"', '\\', 'N', '_', 'L', 'P');
 
 /// YAML hex codes specifying the length of the hex number.
 alias escapeHexCodeList = AliasSeq!('x', 'u', 'U');
@@ -32,6 +32,7 @@ dchar fromEscape(dchar escape) @safe pure nothrow @nogc
         case 'r':  return '\x0D';
         case 'e':  return '\x1B';
         case ' ':  return '\x20';
+        case '/':  return '/';
         case '\"': return '\"';
         case '\\': return '\\';
         case 'N':  return '\x85'; //'\u0085';
@@ -90,3 +91,16 @@ uint escapeHexLength(dchar hexCode) @safe pure nothrow @nogc
     }
 }
 
+// Issue #302: Support optional escaping of forward slashes in string
+// for JSON compatibility
+@safe unittest
+{
+    import dyaml.loader : Loader;
+
+    const str = `{
+    "forward/slashes": "can\/be\/optionally\/escaped"
+}`;
+
+    auto node = Loader.fromString(str).load();
+    assert(node["forward/slashes"] == "can/be/optionally/escaped");
+}


### PR DESCRIPTION
This provides better compatibility with JSON, and is what Vibe.d does by default:
https://github.com/vibe-d/vibe.d/blob/7604eea772b1a733f7bfd16591ddc5bd37850bd9/data/vibe/data/json.d#L2555-L2563

Will need to submit the fix to D-YAML with a proper test there.
https://github.com/dlang-community/D-YAML/issues/302