### PR TITLE
Move environment read outside of DependencyResolver

### DIFF
--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -85,7 +85,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		// versions as possible
 		ResolveContext context;
 		context.configs[rootbase] = [ResolveConfig(root.config, true)];
-		long loop_counter = no_loop_limit ? long.max : 1_000_000;
+		ulong loop_counter = no_loop_limit ? ulong.max : 1_000_000;
 		constrain(root, context, loop_counter);
 
 		// remove any non-default optional dependencies
@@ -148,7 +148,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 	/** Starting with a single node, fills `context` with a minimized set of
 		configurations that form valid solutions.
 	*/
-	private void constrain(TreeNode n, ref ResolveContext context, ref long max_iterations)
+	private void constrain(TreeNode n, ref ResolveContext context, ref ulong max_iterations)
 	{
 		auto base = n.pack.basePackageName;
 		assert(base in context.configs);
@@ -204,7 +204,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		propagate.
 	*/
 	private void constrainDependencies(TreeNode n, TreeNodes[] dependencies, size_t depidx,
-		ref ResolveContext context, ref long max_iterations)
+		ref ResolveContext context, ref ulong max_iterations)
 	{
 		if (depidx >= dependencies.length) return;
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1457,6 +1457,11 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 	this(Dub dub, UpgradeOptions options, Package root, SelectedVersions selected_versions)
 	{
+		if (environment.get("DUB_NO_RESOLVE_LIMIT") !is null)
+			super(ulong.max);
+		else
+		    super(1_000_000);
+
 		m_dub = dub;
 		m_options = options;
 		m_rootPackage = root;


### PR DESCRIPTION
I saw some (other) unittests failing because of my environment, so trying to make Dub more pure to test it better.