### PR TITLE
settings/selections: Only warn on unknown keys, add changelog

### DIFF
--- a/changelog/configy_stricter_parsing.dd
+++ b/changelog/configy_stricter_parsing.dd
@@ -1,0 +1,9 @@
+dub will now warn on unrecognized settings or selections file
+
+Previously, dub was silently accepting anything it didn't recognize
+in `[dub.]settings.json` and `dub.selections.json`. While the original
+intent was to make forward-compatibility easy, it proved detrimental
+as typos would just mean the user setting was ignored.
+
+From this release, dub will now warn about any entry in its configuration files
+or in `dub.selections.json`. After 10 releases, those warnings will turn into errors.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -267,10 +267,13 @@ class Dub {
 
 		void readSettingsFile (NativePath path_)
 		{
+			// TODO: Remove `StrictMode.Warn` after v1.40 release
+			// The default is to error, but as the previous parser wasn't
+			// complaining, we should first warn the user.
 			const path = path_.toNativeString();
 			if (path.exists)
 				this.m_config = this.m_config.merge(
-					parseConfigFile!UserConfiguration(CLIArgs(path)));
+					parseConfigFile!UserConfiguration(CLIArgs(path), StrictMode.Warn));
 		}
 
 		const dubFolderPath = NativePath(thisExePath).parentPath;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -79,7 +79,10 @@ class Project {
 
 		auto selverfile = (m_rootPackage.path ~ SelectedVersions.defaultFile).toNativeString();
 		if (existsFile(selverfile)) {
-			auto selected = parseConfigFileSimple!Selected(selverfile);
+			// TODO: Remove `StrictMode.Warn` after v1.40 release
+			// The default is to error, but as the previous parser wasn't
+			// complaining, we should first warn the user.
+			auto selected = parseConfigFileSimple!Selected(selverfile, StrictMode.Warn);
 			enforce(!selected.isNull(), "Could not read '" ~ selverfile ~ "'");
 			m_selections = new SelectedVersions(selected.get());
 		} else m_selections = new SelectedVersions;


### PR DESCRIPTION
This will give users the time to adapt, without erroring right away.