### PR TITLE
Default `dub init` to SDL

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -863,7 +863,7 @@ class HelpCommand : Command {
 class InitCommand : Command {
 	private{
 		string m_templateType = "minimal";
-		PackageFormat m_format = PackageFormat.json;
+		PackageFormat m_format = PackageFormat.sdl;
 		bool m_nonInteractive;
 	}
 	this() @safe pure nothrow


### PR DESCRIPTION
Átila wants to throw out dub.json, so this is the first step to discouraging dub.json