### PR TITLE
Revert "Default `dub init` to SDL"

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -863,7 +863,7 @@ class HelpCommand : Command {
 class InitCommand : Command {
 	private{
 		string m_templateType = "minimal";
-		PackageFormat m_format = PackageFormat.sdl;
+		PackageFormat m_format = PackageFormat.json;
 		bool m_nonInteractive;
 	}
 	this() @safe pure nothrow


### PR DESCRIPTION
Reverts dlang/dub#2361

we (D administration and dub developers) should probably first all agree on a plan to take.