### PR TITLE
Improve `PackageOverride` API, deprecate `Dependency.versionSpec`

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2193,16 +2193,16 @@ class AddOverrideCommand : Command {
 		enforceUsage(free_args.length == 3, "Expected three arguments, not "~free_args.length.to!string);
 		auto scope_ = m_system ? PlacementLocation.system : PlacementLocation.user;
 		auto pack = free_args[0];
-		auto ver = Dependency(free_args[1]);
+		auto source = VersionRange.fromString(free_args[1]);
 		if (existsFile(NativePath(free_args[2]))) {
 			auto target = NativePath(free_args[2]);
 			if (!target.absolute) target = NativePath(getcwd()) ~ target;
-			dub.packageManager.addOverride(scope_, pack, ver, target);
-			logInfo("Added override %s %s => %s", pack, ver, target);
+			dub.packageManager.addOverride(scope_, pack, source, target);
+			logInfo("Added override %s %s => %s", pack, source, target);
 		} else {
 			auto target = Version(free_args[2]);
-			dub.packageManager.addOverride(scope_, pack, ver, target);
-			logInfo("Added override %s %s => %s", pack, ver, target);
+			dub.packageManager.addOverride(scope_, pack, source, target);
+			logInfo("Added override %s %s => %s", pack, source, target);
 		}
 		return 0;
 	}
@@ -2234,7 +2234,8 @@ class RemoveOverrideCommand : Command {
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 		enforceUsage(free_args.length == 2, "Expected two arguments, not "~free_args.length.to!string);
 		auto scope_ = m_system ? PlacementLocation.system : PlacementLocation.user;
-		dub.packageManager.removeOverride(scope_, free_args[0], Dependency(free_args[1]));
+		auto source = VersionRange.fromString(free_args[1]);
+		dub.packageManager.removeOverride(scope_, free_args[0], source);
 		return 0;
 	}
 }

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -32,6 +32,7 @@ import std.path : expandTilde, absolutePath, buildNormalizedPath;
 import std.process;
 import std.stdio;
 import std.string;
+import std.sumtype;
 import std.typecons : Tuple, tuple;
 import std.variant;
 import std.path: setExtension;
@@ -2255,10 +2256,9 @@ class ListOverridesCommand : Command {
 		{
 			if (overrides.length == 0) return;
 			logInfo("# %s", caption);
-			foreach (ovr; overrides) {
-				if (!ovr.targetPath.empty) logInfo("%s %s => %s", ovr.package_, ovr.version_, ovr.targetPath);
-				else logInfo("%s %s => %s", ovr.package_, ovr.version_, ovr.targetVersion);
-			}
+			foreach (ovr; overrides)
+				ovr.target.match!(
+					t => logInfo("%s %s => %s", ovr.package_, ovr.version_, t));
 		}
 		printList(dub.packageManager.getOverrides(PlacementLocation.user), "User wide overrides");
 		printList(dub.packageManager.getOverrides(PlacementLocation.system), "System wide overrides");

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2752,7 +2752,7 @@ private bool addDependency(Dub dub, ref PackageRecipe recipe, string depspec)
 		}
 	}
 	recipe.buildSettings.dependencies[depname] = dep;
-	logInfo("Adding dependency %s %s", depname, dep.versionSpec);
+	logInfo("Adding dependency %s %s", depname, dep.toString());
 	return true;
 }
 

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -183,27 +183,7 @@ struct Dependency {
 		return range.m_versA;
 	}
 
-	/** Sets/gets the matching version range as a specification string.
-
-		The acceptable forms for this string are as follows:
-
-		$(UL
-			$(LI `"1.0.0"` - a single version in SemVer format)
-			$(LI `"==1.0.0"` - alternative single version notation)
-			$(LI `">1.0.0"` - version range with a single bound)
-			$(LI `">1.0.0 <2.0.0"` - version range with two bounds)
-			$(LI `"~>1.0.0"` - a fuzzy version range)
-			$(LI `"~>1.0"` - a fuzzy version range with partial version)
-			$(LI `"^1.0.0"` - semver compatible version range (same version if 0.x.y, ==major >=minor.patch if x.y.z))
-			$(LI `"^1.0"` - same as ^1.0.0)
-			$(LI `"~master"` - a branch name)
-			$(LI `"*" - match any version (see also `any`))
-		)
-
-		Apart from "$(LT)" and "$(GT)", "$(GT)=" and "$(LT)=" are also valid
-		comparators.
-
-	*/
+	/// Sets/gets the matching version range as a specification string.
 	@property void versionSpec(string ves) @trusted
 	{
 		this.m_value = VersionRange.fromString(ves);
@@ -894,7 +874,31 @@ struct Version {
 	}
 }
 
-/// A range of versions that are acceptable
+/**
+ * A range of versions that are acceptable
+ *
+ * While not directly described in SemVer v2.0.0, a common set
+ * of range operators have appeared among package managers.
+ * We mostly NPM's: https://semver.npmjs.com/
+ *
+ * Hence the acceptable forms for this string are as follows:
+ *
+ * $(UL
+ *  $(LI `"1.0.0"` - a single version in SemVer format)
+ *  $(LI `"==1.0.0"` - alternative single version notation)
+ *  $(LI `">1.0.0"` - version range with a single bound)
+ *  $(LI `">1.0.0 <2.0.0"` - version range with two bounds)
+ *  $(LI `"~>1.0.0"` - a fuzzy version range)
+ *  $(LI `"~>1.0"` - a fuzzy version range with partial version)
+ *  $(LI `"^1.0.0"` - semver compatible version range (same version if 0.x.y, ==major >=minor.patch if x.y.z))
+ *  $(LI `"^1.0"` - same as ^1.0.0)
+ *  $(LI `"~master"` - a branch name)
+ *  $(LI `"*" - match any version (see also `VersionRange.Any`))
+ * )
+ *
+ * Apart from "$(LT)" and "$(GT)", "$(GT)=" and "$(LT)=" are also valid
+ * comparators.
+ */
 public struct VersionRange
 {
 	private Version m_versA;

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -179,17 +179,19 @@ struct Dependency {
 			(VersionRange v) => v,
 		);
 		enforce(range.isExactVersion(),
-				"Dependency "~this.versionSpec~" is no exact version.");
+				"Dependency "~range.toString()~" is no exact version.");
 		return range.m_versA;
 	}
 
 	/// Sets/gets the matching version range as a specification string.
+	deprecated("Create a new `Dependency` instead and provide a `VersionRange`")
 	@property void versionSpec(string ves) @trusted
 	{
 		this.m_value = VersionRange.fromString(ves);
 	}
 
 	/// ditto
+	deprecated("Use `Dependency.visit` and match `VersionRange`instead")
 	@property string versionSpec() const @safe {
 		return this.m_value.match!(
 			(const NativePath   p) => ANY_IDENT,
@@ -481,19 +483,19 @@ public auto visit (Handlers...) (auto ref Dependency dep)
 
 unittest {
 	Dependency a = Dependency(">=1.1.0"), b = Dependency(">=1.3.0");
-	assert (a.merge(b).valid() && a.merge(b).versionSpec == ">=1.3.0", a.merge(b).toString());
+	assert (a.merge(b).valid() && a.merge(b).toString() == ">=1.3.0", a.merge(b).toString());
 
 	assertThrown(Dependency("<=2.0.0 >=1.0.0"));
 	assertThrown(Dependency(">=2.0.0 <=1.0.0"));
 
 	a = Dependency(">=1.0.0 <=5.0.0"); b = Dependency(">=2.0.0");
-	assert (a.merge(b).valid() && a.merge(b).versionSpec == ">=2.0.0 <=5.0.0", a.merge(b).toString());
+	assert (a.merge(b).valid() && a.merge(b).toString() == ">=2.0.0 <=5.0.0", a.merge(b).toString());
 
 	assertThrown(a = Dependency(">1.0.0 ==5.0.0"), "Construction is invalid");
 
 	a = Dependency(">1.0.0"); b = Dependency("<2.0.0");
 	assert (a.merge(b).valid(), a.merge(b).toString());
-	assert (a.merge(b).versionSpec == ">1.0.0 <2.0.0", a.merge(b).toString());
+	assert (a.merge(b).toString() == ">1.0.0 <2.0.0", a.merge(b).toString());
 
 	a = Dependency(">2.0.0"); b = Dependency("<1.0.0");
 	assert (!(a.merge(b)).valid(), a.merge(b).toString());
@@ -649,13 +651,13 @@ unittest {
 }
 
 unittest {
-	assert(Dependency("~>1.0.4").versionSpec == "~>1.0.4");
-	assert(Dependency("~>1.4").versionSpec == "~>1.4");
-	assert(Dependency("~>2").versionSpec == "~>2");
-	assert(Dependency("~>1.0.4+1.2.3").versionSpec == "~>1.0.4");
-	assert(Dependency("^0.1.2").versionSpec == "^0.1.2");
-	assert(Dependency("^1.2.3").versionSpec == "^1.2.3");
-	assert(Dependency("^1.2").versionSpec == "~>1.2"); // equivalent; prefer ~>
+	assert(VersionRange.fromString("~>1.0.4").toString() == "~>1.0.4");
+	assert(VersionRange.fromString("~>1.4").toString() == "~>1.4");
+	assert(VersionRange.fromString("~>2").toString() == "~>2");
+	assert(VersionRange.fromString("~>1.0.4+1.2.3").toString() == "~>1.0.4");
+	assert(VersionRange.fromString("^0.1.2").toString() == "^0.1.2");
+	assert(VersionRange.fromString("^1.2.3").toString() == "^1.2.3");
+	assert(VersionRange.fromString("^1.2").toString() == "~>1.2"); // equivalent; prefer ~>
 }
 
 /**

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -300,7 +300,7 @@ class PackageManager {
         final switch (repo.kind)
         {
             case repo.Kind.git:
-                pack = loadGitPackage(name, repo.ref_, repo.remote);
+                pack = loadGitPackage(name, repo);
         }
         if (pack !is null) {
             addPackages(m_temporaryPackages, pack);
@@ -308,18 +308,18 @@ class PackageManager {
         return pack;
 	}
 
-    private Package loadGitPackage(string name, string versionSpec, string remote)
+    private Package loadGitPackage(string name, in Repository repo)
     {
 		import dub.internal.git : cloneRepository;
 
-		if (!versionSpec.startsWith("~") && !versionSpec.isGitHash) {
+		if (!repo.ref_.startsWith("~") && !repo.ref_.isGitHash) {
 			return null;
 		}
 
-		string gitReference = versionSpec.chompPrefix("~");
+		string gitReference = repo.ref_.chompPrefix("~");
 		NativePath destination = getPackagePath(
 			m_repositories[PlacementLocation.user].packagePath,
-			name, versionSpec);
+			name, repo.ref_);
 		// For libraries leaking their import path
 		destination ~= name;
 		destination.endsWithSlash = true;
@@ -330,7 +330,7 @@ class PackageManager {
 			}
 		}
 
-		if (!cloneRepository(remote, gitReference, destination.toNativeString())) {
+		if (!cloneRepository(repo.remote, gitReference, destination.toNativeString())) {
 			return null;
 		}
 

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -554,7 +554,7 @@ lflags "lf3"
 	assert(rec.buildSettings.dependencies["projectname:subpackage1"].optional == false);
 	assert(rec.buildSettings.dependencies["projectname:subpackage1"].path == NativePath("."));
 	assert(rec.buildSettings.dependencyBuildSettings["projectname:subpackage1"].dflags == ["":["-g", "-debug"]]);
-	assert(rec.buildSettings.dependencies["somedep"].versionSpec == "1.0.0");
+	assert(rec.buildSettings.dependencies["somedep"].version_.toString() == "1.0.0");
 	assert(rec.buildSettings.dependencies["somedep"].optional == true);
 	assert(rec.buildSettings.dependencies["somedep"].path.empty);
 	assert(rec.buildSettings.systemDependencies == "system dependencies");
@@ -671,7 +671,7 @@ dependency "package" repository="git+https://some.url" version="12345678"
 	parseSDL(rec, sdl, null, "testfile");
 	auto dependency = rec.buildSettings.dependencies["package"];
 	assert(!dependency.repository.empty);
-	assert(dependency.versionSpec == "12345678");
+	assert(dependency.repository.ref_ == "12345678");
 }
 
 unittest {

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -257,9 +257,18 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 
 	foreach (pack, d; bs.dependencies) {
 		Attribute[] attribs;
-		if (!d.repository.empty) attribs ~= new Attribute(null, "repository", Value(d.repository.toString()));
-		if (!d.path.empty) attribs ~= new Attribute(null, "path", Value(d.path.toString()));
-		else attribs ~= new Attribute(null, "version", Value(d.versionSpec));
+		d.visit!(
+			(const Repository	r) {
+				attribs ~= new Attribute(null, "repository", Value(r.toString()));
+				attribs ~= new Attribute(null, "version", Value(r.ref_));
+			},
+			(const NativePath	p) {
+				attribs ~= new Attribute(null, "path", Value(p.toString()));
+			},
+			(const VersionRange v) {
+				attribs ~= new Attribute(null, "version", Value(v.toString()));
+			},
+		);
 		if (d.optional) attribs ~= new Attribute(null, "optional", Value(true));
 		auto t = new Tag(null, "dependency", [Value(pack)], attribs);
 		if (pack in bs.dependencyBuildSettings)


### PR DESCRIPTION
Trying to weed out all the place that made any kind of assumption about what's a `Dependency`.
While the diff looks pretty terrible because I'm trying **very hard** not to break code for library users, the result is that `versionSpec` is no longer used within dub, and I think the resulting (non-deprecated) code is much nicer and easier to read.