### PR TITLE
Remove `Dub.updatePackageSearchPath`

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -170,7 +170,14 @@ class Dub {
 		if (ccps.length)
 			m_packageManager.customCachePaths = ccps;
 
-		updatePackageSearchPath();
+		// TODO: Move this environment read out of the ctor
+		if (auto p = environment.get("DUBPATH")) {
+			version(Windows) enum pathsep = ";";
+			else enum pathsep = ":";
+			NativePath[] paths = p.split(pathsep)
+				.map!(p => NativePath(p))().array();
+			m_packageManager.searchPath = paths;
+		}
 	}
 
 	unittest
@@ -364,7 +371,6 @@ class Dub {
 	void loadPackage(NativePath path)
 	{
 		m_projectPath = path;
-		updatePackageSearchPath();
 		m_project = new Project(m_packageManager, m_projectPath);
 	}
 
@@ -372,7 +378,6 @@ class Dub {
 	void loadPackage(Package pack)
 	{
 		m_projectPath = pack.path;
-		updatePackageSearchPath();
 		m_project = new Project(m_packageManager, pack);
 	}
 
@@ -467,7 +472,8 @@ class Dub {
 	{
 		if (!path.absolute) path = NativePath(getcwd()) ~ path;
 		m_overrideSearchPath = path;
-		updatePackageSearchPath();
+		m_packageManager.disableDefaultSearchPaths = true;
+		m_packageManager.searchPath = [m_overrideSearchPath];
 	}
 
 	/** Gets the default configuration for a particular build platform.
@@ -1267,25 +1273,6 @@ class Dub {
 		settings.run = true;
 
 		return settings;
-	}
-
-	private void updatePackageSearchPath()
-	{
-		// TODO: Remove once `overrideSearchPath` is removed
-		if (!m_overrideSearchPath.empty) {
-			m_packageManager._disableDefaultSearchPaths = true;
-			m_packageManager.searchPath = [m_overrideSearchPath];
-			return;
-		}
-
-		auto p = environment.get("DUBPATH");
-		NativePath[] paths;
-
-		version(Windows) enum pathsep = ";";
-		else enum pathsep = ":";
-		if (p.length) paths ~= p.split(pathsep).map!(p => NativePath(p))().array();
-		m_packageManager._disableDefaultSearchPaths = false;
-		m_packageManager.searchPath = paths;
 	}
 
 	private void determineDefaultCompiler()

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -103,15 +103,6 @@ class PackageManager {
 	deprecated("Instantiate a PackageManager instance with the single-argument constructor: `new PackageManager(path)`")
 	@property void disableDefaultSearchPaths(bool val)
 	{
-		this._disableDefaultSearchPaths(val);
-	}
-
-	// Non deprecated instance of the previous symbol,
-	// as `Dub.updatePackageSearchPath` calls it and while nothing in Dub app
-	// itself relies on it, just removing the call from `updatePackageSearchPath`
-	// could break the library use case.
-	package(dub) void _disableDefaultSearchPaths(bool val)
-	{
 		if (val == m_disableDefaultSearchPaths) return;
 		m_disableDefaultSearchPaths = val;
 		refresh(true);


### PR DESCRIPTION
This function was essentially two functions: One when an override was set,
another one for the common case. However, the function is private,
and the number of call sites is limited, so it's better to inline
the call at the caller site. Once that was done, it became obvious
it only ever has an effect once, when the Dub instance is constructed,
as we don't modify this environment variable.
Thus, we can inline it in the constructor, and remove the dead branches.