### PR TITLE
PackageManager: Move some code to `Location` instead of nested function

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -113,12 +113,12 @@ class PackageManager {
 	*/
 	@property const(NativePath)[] completeSearchPath()
 	const {
-		auto ret = appender!(NativePath[])();
-		ret.put(cast(NativePath[])m_searchPath); // work around Phobos 17251
+		auto ret = appender!(const(NativePath)[])();
+		ret.put(m_searchPath);
 		if (!m_disableDefaultSearchPaths) {
 			foreach (ref repo; m_repositories) {
-				ret.put(cast(NativePath[])repo.searchPath);
-				ret.put(cast(NativePath)repo.packagePath);
+				ret.put(repo.searchPath);
+				ret.put(repo.packagePath);
 			}
 		}
 		return ret.data;

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -1073,12 +1073,19 @@ private enum LocalOverridesFilename = "local-overrides.json";
 
 /// A managed location (see `PlacementLocation`)
 private struct Location {
+	/// The absolute path to the root of the location
 	NativePath packagePath;
+
+	/// Configured (extra) search paths for this `Location`
 	NativePath[] searchPath;
+
+	/// List of packages at this `Location`
 	Package[] localPackages;
+
+	/// List of overrides stored at this `Location`
 	PackageOverride[] overrides;
 
-	this(NativePath path)
+	this(NativePath path) @safe pure nothrow @nogc
 	{
 		this.packagePath = path;
 	}


### PR DESCRIPTION
Currently, we have in `PackageManager` two ways to store packages and search paths:
One which is in the `m_repositories` array, where we iterate on it, and the index defines the priority, and the second one is inside `PackageManager` itself. However the first approach is never used with bare `Dub` instances.

IMO, we should just add a 4th entry to the `m_repositories` array which contains what `PackageManager` currently stores, so that we don't have this special case. Then a `--bare` `Dub` would just have one entry but work just the same.

So the first step is to remove the dependency on having 3 entries, and just have an iteration instead.