### PR TITLE
Forward flag -color to compiler calls

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -173,9 +173,17 @@ struct CommandLineHandler
 				// Use default determined in internal.logging.initLogging().
 				break;
 			case on:
+				foreach (ref grp; commandGroups)
+					foreach (ref cmd; grp.commands)
+						if (auto pc = cast(PackageBuildCommand)cmd)
+							pc.baseSettings.buildSettings.options |= BuildOption.color;
 				setLoggingColorsEnabled(true);  // enable colors, no matter what
 				break;
 			case off:
+				foreach (ref grp; commandGroups)
+					foreach (ref cmd; grp.commands)
+						if (auto pc = cast(PackageBuildCommand)cmd)
+							pc.baseSettings.buildSettings.options &= ~BuildOption.color;
 				setLoggingColorsEnabled(false); // disable colors, no matter what
 				break;
 		}

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -390,10 +390,11 @@ enum BuildOption {
 	betterC = 1<<23,              /// Compile in betterC mode (-betterC)
 	lowmem = 1<<24,               /// Compile in lowmem mode (-lowmem)
 	coverageCTFE = 1<<25,         /// Enable code coverage analysis including at compile-time (-cov=ctfe)
+	color = 1<<26,                /// Colorize output (-color)
 
 	// for internal usage
-	_docs = 1<<26,                // Write ddoc to docs
-	_ddox = 1<<27,                // Compile docs.json
+	_docs = 1<<27,                // Write ddoc to docs
+	_ddox = 1<<28,                // Compile docs.json
 }
 
 struct Flags (T) {

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -65,6 +65,7 @@ class DMDCompiler : Compiler {
 		tuple(BuildOption.profileGC, ["-profile=gc"]),
 		tuple(BuildOption.betterC, ["-betterC"]),
 		tuple(BuildOption.lowmem, ["-lowmem"]),
+		tuple(BuildOption.color, ["-color"]),
 
 		tuple(BuildOption._docs, ["-Dddocs"]),
 		tuple(BuildOption._ddox, ["-Xfdocs.json", "-Df__dummy.html"]),

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -46,6 +46,7 @@ class GDCCompiler : Compiler {
 		tuple(BuildOption.property, ["-fproperty"]),
 		//tuple(BuildOption.profileGC, ["-?"]),
 		tuple(BuildOption.betterC, ["-fno-druntime"]),
+		tuple(BuildOption.color, ["-fdiagnostics-color=always"]),
 
 		tuple(BuildOption._docs, ["-fdoc-dir=docs"]),
 		tuple(BuildOption._ddox, ["-Xfdocs.json", "-fdoc-file=__dummy.html"]),

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -47,6 +47,7 @@ class LDCCompiler : Compiler {
 		//tuple(BuildOption.profileGC, ["-?"]),
 		tuple(BuildOption.betterC, ["-betterC"]),
 		tuple(BuildOption.lowmem, ["-lowmem"]),
+		tuple(BuildOption.color, ["-enable-color"]),
 
 		tuple(BuildOption._docs, ["-Dd=docs"]),
 		tuple(BuildOption._ddox, ["-Xf=docs.json", "-Dd=__dummy_docs"]),

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -390,7 +390,7 @@ class BuildGenerator : ProjectGenerator {
 			buildsettings.importPaths,
 			settings.platform.architecture,
 			[
-				(cast(uint)buildsettings.options).to!string,
+				(cast(uint)(buildsettings.options & ~BuildOption.color)).to!string, // exclude color option from id
 				settings.platform.compilerBinary,
 				settings.platform.compiler,
 				settings.platform.compilerVersion,

--- a/test/colored-output.sh
+++ b/test/colored-output.sh
@@ -15,3 +15,14 @@ ${DUB} build --compiler=${DC} 2>&1 | { ! \grep $'^\x1b\[' -c; }
 
 # Test that --color=on enables colors in any case
 ${DUB} build --color=on --compiler=${DC} 2>&1 | \grep $'^\x1b\[' -c
+
+# Test forwarding to dmd flag -color
+
+# Test that --color=on set dmd flag -color
+${DUB} build -v --color=on --compiler=${DC} -f 2>&1 | \grep '\-color' -c
+
+# Test that --color=off set no dmd flag
+${DUB} build -v --color=off --compiler=${DC} -f 2>&1 | { ! \grep '\-color' -c; }
+
+# Test that --color=automatic set no dmd flag
+${DUB} build -v --color=automatic --compiler=${DC} -f 2>&1 | { ! \grep '\-color' -c; }


### PR DESCRIPTION
Need help determining how to forward `options.colors_mode` to setting the instance of `BuildOption.color` which should, afaict, be forwarded automatically to `DMDCompiler.s_options` and `LDCCompiler.s_options`.

Update: I think I nailed it.

Can you have a look, @Geod24?

FYI, @kinke.