### PR TITLE
Fix #2383

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -193,6 +193,7 @@ docs/
 %1$s.lib
 %1$s-test-*
 *.exe
+*.pdb
 *.o
 *.obj
 *.lst


### PR DESCRIPTION
Fix #2383

> The pdb file is now copied on Windows, but .gitignore does not include this.
> *.exe is already written in .gitignore, I think *.pdb should be as well.
> see also: https://dlang.org/changelog/2.099.0.html#pdb