### PR TITLE
Fix x86 OMF build support

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -411,7 +411,7 @@ config    /etc/dmd.conf
 	static bool isLinkerDFlag(string arg)
 	{
 		switch (arg) {
-			case "-g", "-gc", "-m32", "-m64", "-shared", "-lib", "-m32mscoff", "-betterC":
+			case "-g", "-gc", "-m32", "-m64", "-shared", "-lib", "-m32omf", "-m32mscoff", "-betterC":
 				return true;
 			default:
 				return arg.startsWith("-L")


### PR DESCRIPTION
Allowlist `-m32omf` "linker" flag

DMD currently calls lld-link instead of OptLink for OMF builds.