### PR TITLE
Configy: Replace parseField with parseAs

### DIFF
--- a/source/configy/Attributes.d
+++ b/source/configy/Attributes.d
@@ -292,8 +292,8 @@ public auto converter (FT) (FT func)
 public interface ConfigParser (T)
 {
     import dyaml.node;
-    import configy.FieldRef : FieldRef;
-    import configy.Read : Context, parseFieldImpl = parseField;
+    import configy.FieldRef : StructFieldRef;
+    import configy.Read : Context, parseField;
 
     /// Returns: the node being processed
     public inout(Node) node () inout @safe pure nothrow @nogc;
@@ -302,14 +302,12 @@ public interface ConfigParser (T)
     public string path () const @safe pure nothrow @nogc;
 
     ///
-    public final auto parseField (string FieldName) ()
+    public final auto parseAs (OtherType)
+        (auto ref OtherType defaultValue = OtherType.init)
     {
-        static assert(__traits(hasMember, T, FieldName),
-            "`" ~ FieldName ~ "` is not a field of type `" ~
-            fullyQualifiedName!T ~ "`");
-
-        alias FR = FieldRef!(T, FieldName);
-        return parseFieldImpl!(FR)(this.node(), this.path(), FR.Default, this.context());
+        alias TypeFieldRef = StructFieldRef!OtherType;
+        return this.node().parseField!(TypeFieldRef)(
+            this.path(), defaultValue, this.context());
     }
 
     /// Internal use only

--- a/source/configy/DubTest.d
+++ b/source/configy/DubTest.d
@@ -51,9 +51,9 @@ unittest
         public static Package fromYAML (scope ConfigParser!Package parser)
         {
             if (parser.node.nodeID == NodeID.mapping)
-                return Package(null, parser.parseField!"def");
+                return Package(null, parser.parseAs!PackageDef);
             else
-                return Package(parser.parseField!"path");
+                return Package(parser.parseAs!string);
         }
     }
 

--- a/source/dub/recipe/selection.d
+++ b/source/dub/recipe/selection.d
@@ -44,8 +44,6 @@ private struct SelectedDependency
 /// a `Dependency` object to client code.
 private struct YAMLSelectedDependency
 {
-    private SelectedDependency representation;
-
     public Dependency actual;
     alias actual this;
 
@@ -70,7 +68,7 @@ private struct YAMLSelectedDependency
         if (p.node.nodeID == NodeID.scalar)
             return YAMLSelectedDependency(Dependency(Version(p.node.as!string)));
 
-        auto d = p.parseField!"representation";
+        auto d = p.parseAs!SelectedDependency;
         if (d.path.length)
             return YAMLSelectedDependency(Dependency(NativePath(d.path)));
         else


### PR DESCRIPTION
This removes the need to keep the representation around and have
it stored in a field of the enclosing struct.