### PR TITLE
Fix #2348 Crash when describing postBuildCommands

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -208,7 +208,7 @@ class BuildGenerator : ProjectGenerator {
 		if (!cached && buildsettings.postBuildCommands.length) {
 			logInfo("Post-build", Color.light_green, "Running commands");
 			runBuildCommands(CommandType.postBuild, buildsettings.postBuildCommands, pack, m_project, settings, buildsettings,
-							 [["DUB_BUILD_PATH" : target_path.parentPath.toNativeString.absolutePath]]);
+							 [["DUB_BUILD_PATH" : target_path is NativePath.init ? "" : target_path.parentPath.toNativeString.absolutePath]]);
 		}
 
 		return cached;

--- a/test/issue2348-postbuildcommands.script.d
+++ b/test/issue2348-postbuildcommands.script.d
@@ -1,0 +1,30 @@
+/+ dub.sdl:
+name "issue2348"
+buildType "test" {
+    buildOptions "syntaxOnly"
+    postBuildCommands "echo xxx"
+}
++/
+module issue2348;
+
+import std.process;
+import std.stdio;
+import std.algorithm;
+import std.path;
+
+int main()
+{
+	const dub = environment.get("DUB", buildPath(__FILE_FULL_PATH__.dirName.dirName, "bin", "dub.exe"));
+	const cmd = [dub, "build", "--build=test", "--single", __FILE_FULL_PATH__];
+	const result = execute(cmd, null, Config.none, size_t.max, __FILE_FULL_PATH__.dirName);
+	if (result.status || result.output.canFind("Failed"))
+	{
+		writefln("\n> %-(%s %)", cmd);
+		writeln("===========================================================");
+		writeln(result.output);
+		writeln("===========================================================");
+		writeln("Last command failed with exit code ", result.status, '\n');
+		return 1;
+	}
+	return 0;
+}


### PR DESCRIPTION
This PR will cause DUB_BUILD_PATH to be set to an empty string instead of a crash for syntaxOnly builds.