### PR TITLE
LDC: Use `-fvisibility=public -dllimport=all` when compiling a Windows DLL

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -150,8 +150,19 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 			settings.lflags = null;
 		}
 
-		if (settings.options & BuildOption.pic)
-			settings.addDFlags("-relocation-model=pic");
+		if (settings.options & BuildOption.pic) {
+			if (platform.isWindows()) {
+				/* This has nothing to do with PIC, but as the PIC option is exclusively
+				 * set internally for code that ends up in a dynamic library, explicitly
+				 * specify what `-shared` defaults to (`-shared` can't be used when
+				 * compiling only, without linking).
+				 * *Pre*pending the flags enables the user to override them.
+				 */
+				settings.prependDFlags("-fvisibility=public", "-dllimport=all");
+			} else {
+				settings.addDFlags("-relocation-model=pic");
+			}
+		}
 
 		assert(fields & BuildSetting.dflags);
 		assert(fields & BuildSetting.copyFiles);

--- a/test/1-dynLib-simple/dub.json
+++ b/test/1-dynLib-simple/dub.json
@@ -1,5 +1,4 @@
 {
     "name": "dynlib-simple",
-    "targetType": "dynamicLibrary",
-    "dflags-ldc": ["-link-defaultlib-shared", "--fvisibility=public"]
+    "targetType": "dynamicLibrary"
 }


### PR DESCRIPTION
As `-shared` can only be used when linking the DLL in the same cmdline too. On Windows, `-shared` changes the defaults of some important settings wrt. dllim/export, so specify those explicitly when *compiling* a DLL with dub (or some static lib dependency thereof etc.).

[extracted from #2396]