### PR TITLE
Deprecate Dub.getPackageSuppliers, remove one env modification from UT

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -163,7 +163,7 @@ class Dub {
 
 		init(m_rootPath);
 
-		m_packageSuppliers = getPackageSuppliers(additional_package_suppliers, skip_registry);
+		m_packageSuppliers = this.computePkgSuppliers(additional_package_suppliers, skip_registry);
 		m_packageManager = new PackageManager(m_rootPath, m_dirs.localRepository, m_dirs.systemSettings);
 
 		auto ccps = m_config.customCachePaths;
@@ -251,7 +251,16 @@ class Dub {
 			skip_registry = Can be used to skip using the configured package
 				suppliers, as well as the default suppliers.
 	*/
+	deprecated("This is an implementation detail. " ~
+		"Use `packageSuppliers` to get the computed list of package " ~
+		"suppliers once a `Dub` instance has been constructed.")
 	public PackageSupplier[] getPackageSuppliers(PackageSupplier[] additional_package_suppliers, SkipPackageSuppliers skip_registry)
+	{
+		return this.computePkgSuppliers(additional_package_suppliers, skip_registry);
+	}
+
+	/// Ditto
+	private PackageSupplier[] computePkgSuppliers(PackageSupplier[] additional_package_suppliers, SkipPackageSuppliers skip_registry)
 	{
 		PackageSupplier[] ps = additional_package_suppliers;
 
@@ -277,6 +286,9 @@ class Dub {
 	}
 
 	/// ditto
+	deprecated("This is an implementation detail. " ~
+		"Use `packageSuppliers` to get the computed list of package " ~
+		"suppliers once a `Dub` instance has been constructed.")
 	public PackageSupplier[] getPackageSuppliers(PackageSupplier[] additional_package_suppliers)
 	{
 		return getPackageSuppliers(additional_package_suppliers, m_config.skipRegistry);
@@ -287,17 +299,12 @@ class Dub {
 		scope (exit) environment.remove("DUB_REGISTRY");
 		auto dub = new Dub(".", null, SkipPackageSuppliers.none);
 
-		dub.m_config.skipRegistry = typeof(dub.m_config.skipRegistry)(SkipPackageSuppliers.none);
-		assert(dub.getPackageSuppliers(null).length == 1);
-
-		dub.m_config.skipRegistry = typeof(dub.m_config.skipRegistry)(SkipPackageSuppliers.configured);
-		assert(dub.getPackageSuppliers(null).length == 0);
-
-		dub.m_config.skipRegistry = typeof(dub.m_config.skipRegistry)(SkipPackageSuppliers.standard);
-		assert(dub.getPackageSuppliers(null).length == 0);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.none).length == 1);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.configured).length == 0);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard).length == 0);
 
 		environment["DUB_REGISTRY"] = "http://example.com/";
-		assert(dub.getPackageSuppliers(null).length == 1);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard).length == 1);
 	}
 
 	@property bool dryRun() const { return m_dryRun; }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -163,7 +163,8 @@ class Dub {
 
 		init(m_rootPath);
 
-		m_packageSuppliers = this.computePkgSuppliers(additional_package_suppliers, skip_registry);
+		m_packageSuppliers = this.computePkgSuppliers(additional_package_suppliers,
+			skip_registry, environment.get("DUB_REGISTRY", null));
 		m_packageManager = new PackageManager(m_rootPath, m_dirs.localRepository, m_dirs.systemSettings);
 
 		auto ccps = m_config.customCachePaths;
@@ -256,17 +257,19 @@ class Dub {
 		"suppliers once a `Dub` instance has been constructed.")
 	public PackageSupplier[] getPackageSuppliers(PackageSupplier[] additional_package_suppliers, SkipPackageSuppliers skip_registry)
 	{
-		return this.computePkgSuppliers(additional_package_suppliers, skip_registry);
+		return this.computePkgSuppliers(additional_package_suppliers, skip_registry, environment.get("DUB_REGISTRY", null));
 	}
 
 	/// Ditto
-	private PackageSupplier[] computePkgSuppliers(PackageSupplier[] additional_package_suppliers, SkipPackageSuppliers skip_registry)
+	private PackageSupplier[] computePkgSuppliers(
+		PackageSupplier[] additional_package_suppliers, SkipPackageSuppliers skip_registry,
+		string dub_registry_var)
 	{
 		PackageSupplier[] ps = additional_package_suppliers;
 
 		if (skip_registry < SkipPackageSuppliers.all)
 		{
-			ps ~= environment.get("DUB_REGISTRY", null)
+			ps ~= dub_registry_var
 				.splitter(";")
 				.map!(url => getRegistryPackageSupplier(url))
 				.array;
@@ -296,15 +299,14 @@ class Dub {
 
 	unittest
 	{
-		scope (exit) environment.remove("DUB_REGISTRY");
 		auto dub = new Dub(".", null, SkipPackageSuppliers.none);
 
-		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.none).length == 1);
-		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.configured).length == 0);
-		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard).length == 0);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.none, null).length == 1);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.configured, null).length == 0);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard, null).length == 0);
 
-		environment["DUB_REGISTRY"] = "http://example.com/";
-		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard).length == 1);
+		assert(dub.computePkgSuppliers(null, SkipPackageSuppliers.standard, "http://example.com/")
+               .length == 1);
 	}
 
 	@property bool dryRun() const { return m_dryRun; }


### PR DESCRIPTION
Having UT modify environment variable defeats the point of UT.
Also, in this case, I want to move towards having a single point where the environment is read, which would make the logic much easier to follow, and can't do that with a function that reads it on every call (even if it's unlikely that someone relies on this specific behavior). Luckily the function itself is a breach of abstraction, so I think that deprecating it was the best way forward.