### PR TITLE
Dependency: Trivial fixes around `opEquals` / `matches`

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -374,8 +374,9 @@ struct Dependency {
 		using `Dependency` as a key in hash or tree maps.
 	*/
 	bool opEquals(in Dependency o) const scope @safe {
-		return this.m_value == o.m_value
-			&& o.m_optional == m_optional && o.m_default == m_default;
+		if (o.m_optional != this.m_optional) return false;
+		if (o.m_default  != this.m_default)  return false;
+		return this.m_value == o.m_value;
 	}
 
 	/// ditto

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -914,7 +914,7 @@ public struct VersionRange
 	}
 
 	public bool matches (in Version v, VersionMatchMode mode = VersionMatchMode.standard)
-		const @safe
+		const scope @safe
 	{
 		if (m_versA.isBranch) {
 			enforce(this.isExactVersion());


### PR DESCRIPTION
Was working on #2280 and found a couple minor things to improve, turns out they aren't needed for that PR but still useful.