### PR TITLE
Integrate `dependencyBuildSettings` into dependencies

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -599,7 +599,7 @@ class ProjectGenerator
 		}
 
 		// apply both top level and configuration level forced dependency build settings
-		void applyDependencyBuildSettings (const BuildSettingsTemplate[string] configured_dbs)
+		void applyDependencyBuildSettings (const RecipeDependency[string] configured_dbs)
 		{
 			BuildSettings[string] dependencyBuildSettings;
 			foreach (key, value; configured_dbs)
@@ -608,15 +608,15 @@ class ProjectGenerator
 				if (auto target = key in targets)
 				{
 					// get platform specific build settings and process dub variables (BuildSettingsTemplate => BuildSettings)
-					value.getPlatformSettings(buildSettings, genSettings.platform, target.pack.path);
+					value.settings.getPlatformSettings(buildSettings, genSettings.platform, target.pack.path);
 					buildSettings.processVars(m_project, target.pack, buildSettings, genSettings, true);
 					dependencyBuildSettings[key] = buildSettings;
 				}
 			}
 			applyForcedSettings(*roottarget, targets, dependencyBuildSettings);
 		}
-		applyDependencyBuildSettings(rootPackage.recipe.buildSettings.dependencyBuildSettings);
-		applyDependencyBuildSettings(rootPackage.getBuildSettings(genSettings.config).dependencyBuildSettings);
+		applyDependencyBuildSettings(rootPackage.recipe.buildSettings.dependencies);
+		applyDependencyBuildSettings(rootPackage.getBuildSettings(genSettings.config).dependencies);
 
 		// remove targets without output
 		foreach (name; targets.keys)

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -556,12 +556,17 @@ class Package {
 	const(Dependency[string]) getDependencies(string config)
 	const {
 		Dependency[string] ret;
-		foreach (k, v; m_info.buildSettings.dependencies)
-			ret[k] = v;
+		foreach (k, v; m_info.buildSettings.dependencies) {
+			// DMD bug: Not giving `Dependency` here leads to RangeError
+			Dependency dep = v;
+			ret[k] = dep;
+		}
 		foreach (ref conf; m_info.configurations)
 			if (conf.name == config) {
-				foreach (k, v; conf.buildSettings.dependencies)
-					ret[k] = v;
+				foreach (k, v; conf.buildSettings.dependencies) {
+					Dependency dep = v;
+					ret[k] = dep;
+				}
 				break;
 			}
 		return ret;

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -173,14 +173,7 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 					enforce(pkg !in bs.dependencies, "The dependency '"~pkg~"' is specified more than once." );
 					bs.dependencies[pkg] = Dependency.fromJson(verspec);
 					if (verspec.type == Json.Type.object)
-					{
-						BuildSettingsTemplate dbs;
-						dbs.parseJson(verspec, package_name);
-						// Only create an entry if there's an actual BuildSetting
-						// defined by the user.
-						if (dbs !is BuildSettingsTemplate.init)
-							bs.dependencyBuildSettings[pkg] = dbs;
-					}
+						bs.dependencies[pkg].settings.parseJson(verspec, package_name);
 				}
 				break;
 			case "systemDependencies":

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -207,10 +207,7 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package
 	bs.dependencies[pkg] = dep;
 
 	BuildSettingsTemplate dbs;
-	parseBuildSettings(t, dbs, package_name);
-	// Don't create unneeded entries
-	if (dbs !is BuildSettingsTemplate.init)
-		bs.dependencyBuildSettings[pkg] = dbs;
+	parseBuildSettings(t, bs.dependencies[pkg].settings, package_name);
 }
 
 private void parseConfiguration(Tag t, ref ConfigurationInfo ret, string package_name)
@@ -271,8 +268,8 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 		);
 		if (d.optional) attribs ~= new Attribute(null, "optional", Value(true));
 		auto t = new Tag(null, "dependency", [Value(pack)], attribs);
-		if (pack in bs.dependencyBuildSettings)
-			t.add(bs.dependencyBuildSettings[pack].toSDL());
+		if (d.settings !is typeof(d.settings).init)
+			t.add(d.settings.toSDL());
 		ret ~= t;
 	}
 	if (bs.systemDependencies !is null) add("systemDependencies", bs.systemDependencies);
@@ -553,7 +550,7 @@ lflags "lf3"
 	assert(rec.buildSettings.dependencies.length == 2);
 	assert(rec.buildSettings.dependencies["projectname:subpackage1"].optional == false);
 	assert(rec.buildSettings.dependencies["projectname:subpackage1"].path == NativePath("."));
-	assert(rec.buildSettings.dependencyBuildSettings["projectname:subpackage1"].dflags == ["":["-g", "-debug"]]);
+	assert(rec.buildSettings.dependencies["projectname:subpackage1"].settings.dflags == ["":["-g", "-debug"]]);
 	assert(rec.buildSettings.dependencies["somedep"].version_.toString() == "1.0.0");
 	assert(rec.buildSettings.dependencies["somedep"].optional == true);
 	assert(rec.buildSettings.dependencies["somedep"].path.empty);


### PR DESCRIPTION
Because those are specified in `dependencies`,
they should be stored alongside them.
Unfortunately this will slihtly increase memory usage in the common case,
but unlikely to a point where it would be problematic.

This is technically a breaking change as a field is getting removed,
however this struct has been manipulated a few times in breaking ways,
and it's unlikely `dependencyBuildSettings` is being used outside of dub,
given how recent it is and how narrow its usage is.
However, as `dependencies` is likely to be widely used, a compatibility
type and an `alias this` are provided not to break client code.