### PR TITLE
Remove redundant lookup when searching for a tool

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1277,7 +1277,7 @@ class Dub {
 		auto tool = m_project.rootPackage.recipe.ddoxTool;
 		if (tool.empty) tool = "ddox";
 
-		auto tool_pack = m_packageManager.getBestPackage(tool, ">=0.0.0");
+		auto tool_pack = m_packageManager.getBestPackage(tool);
 		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("%s is not present, getting and storing it user wide", tool);

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -715,7 +715,6 @@ class Dub {
 		auto tool = "dscanner";
 
 		auto tool_pack = m_packageManager.getBestPackage(tool);
-		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("Hint", Color.light_blue, "%s is not present, getting and storing it user wide", tool);
 			tool_pack = fetch(tool, VersionRange.Any, defaultPlacementLocation, FetchOptions.none);
@@ -1210,7 +1209,6 @@ class Dub {
 	{
 		string packageName = type;
 		auto template_pack = m_packageManager.getBestPackage(packageName);
-		if (!template_pack) template_pack = m_packageManager.getBestPackage(packageName, "~master");
 		if (!template_pack) {
 			logInfo("%s is not present, getting and storing it user wide", packageName);
 			template_pack = fetch(packageName, VersionRange.Any, defaultPlacementLocation, FetchOptions.none);
@@ -1278,7 +1276,6 @@ class Dub {
 		if (tool.empty) tool = "ddox";
 
 		auto tool_pack = m_packageManager.getBestPackage(tool);
-		if (!tool_pack) tool_pack = m_packageManager.getBestPackage(tool, "~master");
 		if (!tool_pack) {
 			logInfo("%s is not present, getting and storing it user wide", tool);
 			tool_pack = fetch(tool, VersionRange.Any, defaultPlacementLocation, FetchOptions.none);


### PR DESCRIPTION
The first commit just brings one lookup in line with the two others (we could probably factor it out into its own helper, eventually).
The second one removes the second lookup which was proven redundant after inspecting the body of `getBestPackage`.