### PR TITLE
Revert "Temporarily disable ldc-master as the dustmite test is broken"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           - dmd-latest
           - ldc-latest
           - dmd-master
-#          - ldc-master
+          - ldc-master
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This partially reverts commit b1f3b0333d762027a4533d5389487797abec88c1.
So that it doesn't get forgotten.