### PR TITLE
 Fixes #2452 - Accept non-existing file in `sourceFiles`

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -690,6 +690,10 @@ unittest {
  * Search for module keyword in file
  */
 string getModuleNameFromFile(string filePath) {
+	if (!filePath.exists)
+	{
+		return null;
+	}
 	string fileContent = filePath.readText;
 
 	logDiagnostic("Get module name from path: %s", filePath);

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -37,6 +37,7 @@ describe-project/dummy-dep1.dat
 */*test-application
 */exec-simple
 issue1474/ext/fortytwo.d
+issue2452/ext/fortytwo.d
 
 cov-ctfe/test
 issue1003-check-empty-ld-flags/issue1003-empty-ld-flags

--- a/test/issue2452/dub.json
+++ b/test/issue2452/dub.json
@@ -1,0 +1,9 @@
+{
+	"name": "generated-sources-and-source-files-without-glob",
+	"description": "Example of using pre generate commands and sourceFiles without glob.",
+	"sourceFiles": ["ext/fortytwo.d"],
+	"preGenerateCommands": [
+		"mkdir -p ext",
+		"echo 'extern(C) int fun42 () { return 42; }' > ext/fortytwo.d"
+	]
+}

--- a/test/issue2452/source/app.d
+++ b/test/issue2452/source/app.d
@@ -1,0 +1,8 @@
+import std.stdio;
+
+import fortytwo;
+
+void main()
+{
+	writefln("ShouldBe42: %s", fun42());
+}


### PR DESCRIPTION
It fixes #2452 by accepting non-existing source files in `sourceFiles` that will be generated in `preGenerateCommands`.