### PR TITLE
Project: Do not call reinit from constructor

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -86,8 +86,6 @@ class Project {
 			m_selections = !selected.isNull() ?
 				new SelectedVersions(selected.get()) : new SelectedVersions();
 		} else m_selections = new SelectedVersions;
-
-		reinit();
 	}
 
 	/** List of all resolved dependencies.


### PR DESCRIPTION
```
By the time we reach project instantiation, the PackageManager has already been initialized, and calling reinit is just pointless work for no benefit.
```

Let's see if the CI agrees. Fixes #2338 .