### PR TITLE
Minor: Align dub.recipe.selection style with dub.recipe.packagerecipe

### DIFF
--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -320,7 +320,7 @@ public struct RecipeDependency
 		return RecipeDependency(d.toDependency(), d.settings);
 	}
 
-	/// In-file of a dependency as specified by the user
+	/// In-file representation of a dependency as specified by the user
 	private struct YAMLFormat
 	{
 		@Name("version") @Optional string version_;

--- a/source/dub/recipe/selection.d
+++ b/source/dub/recipe/selection.d
@@ -16,33 +16,13 @@ public struct Selected
     public uint fileVersion;
 
     /// The selected package and their matching versions
-    public YAMLSelectedDependency[string] versions;
+    public SelectedDependency[string] versions;
 }
 
-
-/// Actual representation of a dependency as permitted in `dub.selections.json`
-private struct SelectedDependency
-{
-    @Optional @Name("version") string version_;
-    @Optional string path;
-    @Optional string repository;
-
-    public void validate () const scope @safe pure
-    {
-        enforce(this.version_.length || this.path.length || this.repository.length,
-                "Need to provide a version string, or an object with one of the following fields: `version`, `path`, or `repository`");
-        enforce(!this.path.length || !this.repository.length,
-                "Cannot provide a `path` dependency if a repository dependency is used");
-        enforce(!this.path.length || !this.version_.length,
-                "Cannot provide a `path` dependency if a `version` dependency is used");
-        enforce(!this.repository.length || this.version_.length,
-                "Cannot provide a `repository` dependency without a `version`");
-    }
-}
 
 /// Wrapper around `SelectedDependency` to do deserialization but still provide
 /// a `Dependency` object to client code.
-private struct YAMLSelectedDependency
+private struct SelectedDependency
 {
     public Dependency actual;
     alias actual this;
@@ -54,31 +34,51 @@ private struct YAMLSelectedDependency
     }
 
     /// Allow external code to assign to this object as if it was a `Dependency`
-    public ref YAMLSelectedDependency opAssign (Dependency dep) return pure nothrow @nogc
+    public ref SelectedDependency opAssign (Dependency dep) return pure nothrow @nogc
     {
         this.actual = dep;
         return this;
     }
 
     /// Read a `Dependency` from the config file - Required to support both short and long form
-    static YAMLSelectedDependency fromYAML (scope ConfigParser!YAMLSelectedDependency p)
+    static SelectedDependency fromYAML (scope ConfigParser!SelectedDependency p)
     {
         import dyaml.node;
 
         if (p.node.nodeID == NodeID.scalar)
-            return YAMLSelectedDependency(Dependency(Version(p.node.as!string)));
+            return SelectedDependency(Dependency(Version(p.node.as!string)));
 
-        auto d = p.parseAs!SelectedDependency;
+        auto d = p.parseAs!YAMLFormat;
         if (d.path.length)
-            return YAMLSelectedDependency(Dependency(NativePath(d.path)));
+            return SelectedDependency(Dependency(NativePath(d.path)));
         else
         {
             assert(d.version_.length);
             if (d.repository.length)
-                return YAMLSelectedDependency(Dependency(Repository(d.repository, d.version_)));
-            return YAMLSelectedDependency(Dependency(Version(d.version_)));
+                return SelectedDependency(Dependency(Repository(d.repository, d.version_)));
+            return SelectedDependency(Dependency(Version(d.version_)));
         }
     }
+
+	/// In-file representation of a dependency as permitted in `dub.selections.json`
+	private struct YAMLFormat
+	{
+		@Optional @Name("version") string version_;
+		@Optional string path;
+		@Optional string repository;
+
+		public void validate () const scope @safe pure
+		{
+			enforce(this.version_.length || this.path.length || this.repository.length,
+				"Need to provide a version string, or an object with one of the following fields: `version`, `path`, or `repository`");
+			enforce(!this.path.length || !this.repository.length,
+				"Cannot provide a `path` dependency if a repository dependency is used");
+			enforce(!this.path.length || !this.version_.length,
+				"Cannot provide a `path` dependency if a `version` dependency is used");
+			enforce(!this.repository.length || this.version_.length,
+				"Cannot provide a `repository` dependency without a `version`");
+		}
+	}
 }
 
 // Ensure we can read all type of dependencies


### PR DESCRIPTION
During review of the PR that switched PackageRecipe parsing to use Configy,
@WebFreak pointed out that having an internal, private structure used for
parsing YAML field was preferable to having it at module level.
This aligns the names and the approach used with the one in PackageRecipe.