### PR TITLE
Remove PackageManager deprecations from v1.20.0

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -524,14 +524,6 @@ class Dub {
 		loadSingleFilePackage(NativePath(path));
 	}
 
-	deprecated("Instantiate a Dub instance with the single-argument constructor: `new Dub(path)`")
-	void overrideSearchPath(NativePath path)
-	{
-		if (!path.absolute) path = NativePath(getcwd()) ~ path;
-		m_packageManager.disableDefaultSearchPaths = true;
-		m_packageManager.searchPath = [path];
-	}
-
 	/** Gets the default configuration for a particular build platform.
 
 		This forwards to `Project.getDefaultConfiguration` and requires a

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -78,16 +78,6 @@ class PackageManager {
 		this.refresh(true);
 	}
 
-	deprecated("Use the overload which accepts 3 `NativePath` arguments")
-	this(NativePath user_path, NativePath system_path, bool refresh_packages = true)
-	{
-		m_repositories = [
-			Location(user_path ~ "packages/"),
-			Location(system_path ~ "packages/")];
-
-		if (refresh_packages) refresh(true);
-	}
-
 	this(NativePath package_path, NativePath user_path, NativePath system_path, bool refresh_packages = true)
 	{
 		m_repositories = [
@@ -108,16 +98,6 @@ class PackageManager {
 	}
 	/// ditto
 	@property const(NativePath)[] searchPath() const { return this.m_internal.searchPath; }
-
-	/** Disables searching DUB's predefined search paths.
-	*/
-	deprecated("Instantiate a PackageManager instance with the single-argument constructor: `new PackageManager(path)`")
-	@property void disableDefaultSearchPaths(bool val)
-	{
-		if (val == m_disableDefaultSearchPaths) return;
-		m_disableDefaultSearchPaths = val;
-		refresh(true);
-	}
 
 	/** Returns the effective list of search paths, including default ones.
 	*/


### PR DESCRIPTION
Those deprecations have been introduced in v1.20.0, so if we follow the same 10 releases policy as DMD, we are good to have them removed in the next release. Deprecated in 48a26dbd9bc4c535bcde8e3a5b3fe8e7ae4a93d2