### PR TITLE
Deprecate PackageManager.getFirstPackage

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1298,7 +1298,7 @@ class BuildCommand : GenerateCommand {
 		} else if (packageParts.name.startsWith(":")) {
 			// Subpackages are always assumed to be present
 			return 0;
-		} else if (dub.packageManager.getFirstPackage(packageParts.name)) {
+		} else if (dub.packageManager.getBestPackage(packageParts.name)) {
 			// found locally
 			return 0;
 		} else {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -223,6 +223,7 @@ class PackageManager {
 
 	/** Looks up the first package matching the given name.
 	*/
+	deprecated("Use `getBestPackage` instead")
 	Package getFirstPackage(string name)
 	{
 		foreach (ep; getPackageIterator(name))


### PR DESCRIPTION
This function returns the 'first' package, which is very arbitrary. Instead, always return the highest matching package for stable results.