### PR TITLE
Dub: Do not re-load already loaded tool Package

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -713,7 +713,7 @@ class Dub {
 		}
 
 		auto dscanner_dub = new Dub(null, m_packageSuppliers);
-		dscanner_dub.loadPackage(tool_pack.path);
+		dscanner_dub.loadPackage(tool_pack);
 		dscanner_dub.upgrade(UpgradeOptions.select);
 
 		GeneratorSettings settings = this.makeAppSettings();
@@ -1276,7 +1276,7 @@ class Dub {
 		}
 
 		auto ddox_dub = new Dub(null, m_packageSuppliers);
-		ddox_dub.loadPackage(tool_pack.path);
+		ddox_dub.loadPackage(tool_pack);
 		ddox_dub.upgrade(UpgradeOptions.select);
 
 		GeneratorSettings settings = this.makeAppSettings();


### PR DESCRIPTION
Instead of giving the path to the Package we just loaded, just give it the Package we just loaded.