### PR TITLE
Deprecate PackageManager.completeSearchPath

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -110,6 +110,7 @@ class PackageManager {
 
 	/** Returns the effective list of search paths, including default ones.
 	*/
+	deprecated("Use the `PackageManager` facilities instead")
 	@property const(NativePath)[] completeSearchPath()
 	const {
 		auto ret = appender!(const(NativePath)[])();


### PR DESCRIPTION
It is no longer used within the PackageManager and leaks quite a bit of the internals, instead users should have functionalities exposed via the PackageManager's API.