### PR TITLE
Deprecate an unused PackageManager.getPackage ovrld

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -212,6 +212,7 @@ class PackageManager {
 	}
 
 	/// ditto
+	deprecated("Use another `PackageManager` API, open an issue if none suits you")
 	Package getPackage(string name, NativePath path)
 	{
 		foreach( p; getPackageIterator(name) )


### PR DESCRIPTION
This overload is not used anywhere in `dub`, and its use case is not clear. Path where packages are stored should ideally be only known to `PackageManager`, and the API should expose `PlacementLocation` instead of bare `NativePath`. With this in mind, this overload doesn't fit the picture.