### PR TITLE
Move PackageManager.getPackagePath to Location

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -852,7 +852,7 @@ class Dub {
 
 		logDebug("Acquiring package zip file");
 
-		NativePath dstpath = PackageManager.getPackagePath(placement, basePackageName, ver.toString());
+		NativePath dstpath = this.m_packageManager.getPackagePath(location, basePackageName, ver.toString());
 		if (!dstpath.existsFile())
 			mkdirRecurse(dstpath.toNativeString());
 		// For libraries leaking their import path


### PR DESCRIPTION
It is more suited as a Location method, as it returns a path based on PackagePath. This also allows us to reduce the leak of information about Location happening in dub.