### PR TITLE
PackageManager: Only iterate on internal fromPath array, not everything

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -286,7 +286,7 @@ class PackageManager {
 		bool allow_sub_packages = false, StrictMode mode = StrictMode.Ignore)
 	{
 		path.endsWithSlash = true;
-		foreach (p; getPackageIterator())
+		foreach (p; this.m_internal.fromPath)
 			if (p.path == path && (!p.parentPackage || (allow_sub_packages && p.parentPackage.path != p.path)))
 				return p;
 		auto pack = Package.load(path, recipe_path, null, null, mode);


### PR DESCRIPTION
getOrLoadPackage is only used for path-based dependencies, which are only stored in m_internal.fromPath.
We can thus reduce the iteration by only using fromPath. If someone had a path-based dependency that pointed to a version-based package, it would lead to this package being loaded twice, but that's not really a concern, as it would not lead to problem either.