### PR TITLE
Master regression fixes

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -785,7 +785,7 @@ class Dub {
 	{
 		const vrange = dep.visit!(
 			(VersionRange range) => range,
-			(any)                => throw new Exception("Cannot call `dub.fetch` with a " ~ typeof(any).stringof ~ " dependency"),
+			function VersionRange (any) { throw new Exception("Cannot call `dub.fetch` with a " ~ typeof(any).stringof ~ " dependency"); }
 		);
 		return this.fetch(packageId, vrange, location, options, reason);
 	}

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -1138,10 +1138,11 @@ private struct Location {
 			// loaded by the user (e.g. the project and its subpackages),
 			// so don't clean it.
 			this.fromPath = null;
-			this.scanPackageFolder(this.packagePath, mgr, existing);
 		}
 		foreach (path; this.searchPath)
 			this.scanPackageFolder(path, mgr, existing);
+		if (this.packagePath !is NativePath.init)
+			this.scanPackageFolder(this.packagePath, mgr, existing);
 	}
 
     /**


### PR DESCRIPTION
- Fixes the scanning order of packages, so that add-path packages have precedence over cached packages
- Fixes compilation on LDC 1.30.0

Why was it decided to drop all compiler support earlier than "ldc-latest" and "dmd-latest" (which doesn't explain why it didn't even compile on ldc-latest)? Having a buffer range of a few compiler versions greatly reduces friction during version transitions, not only in the build environment for dub itself, but also for dependencies of dub that might move slower. And IMHO using the latest shiny features, such as throw expressions in an infrastructure project like this is just utterly unnecessary. I think this really was a bad decision and should be revised, if possible. BTW, compiling with DMD 1.29.0 on Windows still produces backend errors due to some SumType.