### PR TITLE
Remove commandline arguments that do not work for lint (dscanner)

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1499,8 +1499,8 @@ class LintCommand : PackageBuildCommand {
 			"Import paths"
 		]);
 
-		args.getopt("config", &m_config, [
-			"Use the given configuration file."
+		args.getopt("dscanner-config", &m_config, [
+			"Use the given d-scanner configuration file."
 		]);
 
 		super.prepare(args);


### PR DESCRIPTION
`dub lint` (which in turn just calls dscanner) does not build and does not look into dub.{sdl|json}. So it does not need the parameters that a regular build requires.

The helptext now hints, that the config is a dscanner config (in contrast to a dub config).

Fixes #1940