### PR TITLE
Deprecate `PackageManager.refresh(true)`, only expose `refresh()`

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -480,7 +480,7 @@ shared static this() {
 	{
 		m_dependencies = null;
 		m_missingDependencies = [];
-		m_packageManager.refresh(false);
+		m_packageManager.refresh();
 
 		Package resolveSubPackage(Package p, string subname, bool silentFail) {
 			return subname.length ? m_packageManager.getSubPackage(p, subname, silentFail) : p;


### PR DESCRIPTION
It is not actually used, as all call sites but two use false as an argument. The two calls using true are inside a constructor, meaning there will be no pre-existing packages, so whether true or false is passed will have the same effect / result.