### PR TITLE
Document PackageManager.getBestPackage, deprecate Dependency overload

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1709,8 +1709,6 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 					logDiagnostic("Sub package %s doesn't exist in %s %s.", name, basename, dep.version_);
 					return null;
 				}
-			} else if (auto ret = m_dub.m_packageManager.getBestPackage(name, dep)) {
-				return ret;
 			} else {
 				logDiagnostic("External sub package %s %s not found.", name, dep.version_);
 				return null;
@@ -1735,7 +1733,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		}
 		const vers = dep.version_;
 
-		if (auto ret = m_dub.m_packageManager.getBestPackage(name, dep))
+		if (auto ret = m_dub.m_packageManager.getBestPackage(name, vers))
 			return ret;
 
 		auto key = name ~ ":" ~ vers.toString();
@@ -1765,7 +1763,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 					FetchOptions fetchOpts;
 					fetchOpts |= prerelease ? FetchOptions.usePrerelease : FetchOptions.none;
 					m_dub.fetch(rootpack, vers, m_dub.defaultPlacementLocation, fetchOpts, "need sub package description");
-					auto ret = m_dub.m_packageManager.getBestPackage(name, dep);
+					auto ret = m_dub.m_packageManager.getBestPackage(name, vers);
 					if (!ret) {
 						logWarn("Package %s %s doesn't have a sub package %s", rootpack, dep.version_, name);
 						return null;

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -371,21 +371,47 @@ class PackageManager {
 		return this.m_repositories[base].getPackagePath(name, vers);
 	}
 
-	/** Searches for the latest version of a package matching the given dependency.
-	*/
-	Package getBestPackage(string name, VersionRange range = VersionRange.Any)
-	{
-		return this.getBestPackage(name, Dependency(range));
-	}
-
-	/// Ditto
+	/**
+	 * Searches for the latest version of a package matching the version range.
+	 *
+	 * This will search the local filesystem only (it doesn't connect
+	 * to the registry) for the "best" (highest version) that matches `range`.
+	 * An overload with a single version exists to search for an exact version.
+	 *
+	 * Params:
+	 *   name = Package name to search for
+	 *   vers = Exact version to search for
+	 *   range = Range of versions to search for, defaults to any
+	 *
+	 * Returns:
+	 *	 The best package matching the parameters, or `null` if none was found.
+	 */
 	Package getBestPackage(string name, Version vers)
 	{
 		return this.getBestPackage(name, VersionRange(vers, vers));
 	}
 
 	/// Ditto
+	Package getBestPackage(string name, VersionRange range = VersionRange.Any)
+	{
+		return this.getBestPackage_(name, Dependency(range));
+	}
+
+	/// Ditto
+	Package getBestPackage(string name, string range)
+	{
+		return this.getBestPackage(name, VersionRange.fromString(range));
+	}
+
+	/// Ditto
+	deprecated("`getBestPackage` should only be used with a `Version` or `VersionRange` argument")
 	Package getBestPackage(string name, Dependency version_spec, bool enable_overrides = true)
+	{
+		return this.getBestPackage_(name, version_spec, enable_overrides);
+	}
+
+	// TODO: Merge this into `getBestPackage(string, VersionRange)`
+	private Package getBestPackage_(string name, Dependency version_spec, bool enable_overrides = true)
 	{
 		Package ret;
 		foreach (p; getPackageIterator(name)) {
@@ -399,12 +425,6 @@ class PackageManager {
 				return ovr;
 		}
 		return ret;
-	}
-
-	/// ditto
-	Package getBestPackage(string name, string version_spec)
-	{
-		return getBestPackage(name, Dependency(version_spec));
 	}
 
 	/** Gets the a specific sub package.


### PR DESCRIPTION
The Dependency overload is not needed, as calling getBestPackage with an SCM / path dependency does not make sense.