### PR TITLE
PackageManager: Load packages lazily on dub build

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -163,7 +163,7 @@ class Dub {
 
 		m_packageSuppliers = this.computePkgSuppliers(additional_package_suppliers,
 			skip_registry, environment.get("DUB_REGISTRY", null));
-		m_packageManager = new PackageManager(m_rootPath, m_dirs.localRepository, m_dirs.systemSettings);
+		m_packageManager = new PackageManager(m_rootPath, m_dirs.localRepository, m_dirs.systemSettings, false);
 
 		auto ccps = m_config.customCachePaths;
 		if (ccps.length)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -480,7 +480,6 @@ shared static this() {
 	{
 		m_dependencies = null;
 		m_missingDependencies = [];
-		m_packageManager.refresh();
 
 		Package resolveSubPackage(Package p, string subname, bool silentFail) {
 			return subname.length ? m_packageManager.getSubPackage(p, subname, silentFail) : p;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -527,7 +527,9 @@ shared static this() {
 							return resolveSubPackage(tmp, subname, true);
 						},
 						(VersionRange range) {
-							return m_packageManager.getBestPackage(dep.name, range);
+							// See `dub.recipe.selection : SelectedDependency.fromYAML`
+							assert(range.isExactVersion());
+							return m_packageManager.getPackage(dep.name, vspec.version_);
 						},
 					);
 				} else if (m_dependencies.canFind!(d => getBasePackageName(d.name) == basename)) {


### PR DESCRIPTION
Implements the solution outlined [here](https://github.com/dlang/dub/issues/2338#issuecomment-1219409732).

```
A problem of the current design of dub is that all locations are scanned,
regardless of what action is being performed, often multiple times.
With this change, a regular `dub build` on a project with all dependencies
resolved will no longer loads all available package, which can substantially
speed up development.
```

Fixes #2338