### PR TITLE
Fix #1752: Use 'no' as string representation of Dependency.Invalid

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -1031,7 +1031,7 @@ public struct VersionRange
 
 		string r;
 
-		if (this == Invalid) return "invalid";
+		if (this == Invalid) return "no";
 		if (this.isExactVersion() && m_inclusiveA && m_inclusiveB) {
 			// Special "==" case
 			if (m_versA == Version.masterBranch) return "~master";


### PR DESCRIPTION
Pretty simple and straightforward fix. No test because whatever idea I have to test it will probably break soon, as I'm working on not having the files rewritten in JSON. But tested locally, works.