### PR TITLE
Path: Add missing else clause on version statement

### DIFF
--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -132,8 +132,8 @@ struct NativePath {
 
 		foreach( i, f; m_nodes ){
 			version(Windows) { if( i > 0 ) ret.put('\\'); }
-			version(Posix) { if( i > 0 ) ret.put('/'); }
-			else { enforce("Unsupported OS"); }
+			else version(Posix) { if( i > 0 ) ret.put('/'); }
+			else { static assert(0, "Unsupported OS"); }
 			ret.put(f.toString());
 		}
 


### PR DESCRIPTION
This was wrong on many level:
- The missing `else` clause meant that the `enforce` clause was always there on Windows;
- The `enforce("Reason")` should have been `enforce(false, "Reason")`, as in its current form it would never fail and not serve its intended purpose;
- It was pushing at runtime something that was easily detected at CT;