### PR TITLE
Remove Vibe.d HTTP support / library-nonet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __dummy.html
 
 # Ignore build files.
 /bin/dub
-/bin/__test__library-nonet__
 /bin/__test__library__
 /bin/dub-test-library
 /bin/libdub.a

--- a/dub.sdl
+++ b/dub.sdl
@@ -11,7 +11,7 @@ configuration "application" {
 	targetType "executable"
 	mainSourceFile "source/app.d"
 	libs "curl"
-	versions "DubUseCurl" "DubApplication"
+	versions "DubApplication"
 	// Uncomment to get rich output about the file parsing and json <-> YAML
 	// integrity checks
 	//debugVersions "ConfigFillerDebug"
@@ -21,17 +21,4 @@ configuration "library" {
 	targetType "library"
 	excludedSourceFiles "source/app.d"
 	copyFiles "bin/libcurl.dll" "bin/libeay32.dll" "bin/ssleay32.dll" platform="windows"
-	versions "DubUseCurl"
-}
-
-configuration "library-nonet" {
-	dependency "vibe-d:http" version=">=0.9.0 <0.10.0" optional=true
-	targetType "library"
-	excludedSourceFiles "source/app.d"
-}
-
-configuration "dynamic-library-nonet" {
-	dependency "vibe-d:http" version=">=0.9.0 <0.10.0" optional=true
-	targetType "dynamicLibrary"
-	excludedSourceFiles "source/app.d"
 }

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -4,7 +4,6 @@ set -v -e -o pipefail
 
 vibe_ver=$(jq -r '.versions | .["vibe-d"]' < dub.selections.json)
 dub fetch vibe-d@$vibe_ver # get optional dependency
-dub test --compiler=${DC} -c library-nonet
 
 export DMD="$(command -v $DMD)"
 
@@ -20,7 +19,6 @@ function clean() {
 }
 
 if [ "$COVERAGE" = true ]; then
-    # library-nonet fails to build with coverage (Issue 13742)
     dub test --compiler=${DC} -b unittest-cov
     ./build.d -cov
 

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -23,13 +23,9 @@ import std.file;
 import std.format;
 import std.string : format;
 import std.process;
+import std.net.curl;
+public import std.net.curl : HTTPStatusException;
 import std.traits : isIntegral;
-version(DubUseCurl)
-{
-	import std.net.curl;
-	public import std.net.curl : HTTPStatusException;
-}
-
 
 private NativePath[] temporary_files;
 
@@ -224,9 +220,6 @@ void runCommands(in string[] commands, string[string] env = null, string workDir
 	}
 }
 
-version (Have_vibe_d_http)
-	public import vibe.http.common : HTTPStatusException;
-
 /**
 	Downloads a file from the specified URL.
 
@@ -237,48 +230,36 @@ version (Have_vibe_d_http)
 	`timeout` ms, or if the average transfer rate drops below 10 bytes / s for
 	more than `timeout` seconds.  Pass `0` as `timeout` to disable both timeout
 	mechanisms.
-
-	Note: Timeouts are only implemented when curl is used (DubUseCurl).
 */
 void download(string url, string filename, uint timeout = 8)
 {
-	version(DubUseCurl) {
-		auto conn = HTTP();
-		setupHTTPClient(conn, timeout);
-		logDebug("Storing %s...", url);
-		std.net.curl.download(url, filename, conn);
-		// workaround https://issues.dlang.org/show_bug.cgi?id=18318
-		auto sl = conn.statusLine;
-		logDebug("Download %s %s", url, sl);
-		if (sl.code / 100 != 2)
-			throw new HTTPStatusException(sl.code,
-				"Downloading %s failed with %d (%s).".format(url, sl.code, sl.reason));
-	} else version (Have_vibe_d_http) {
-		import vibe.inet.urltransfer;
-		vibe.inet.urltransfer.download(url, filename);
-	} else assert(false);
+	auto conn = HTTP();
+	setupHTTPClient(conn, timeout);
+	logDebug("Storing %s...", url);
+	std.net.curl.download(url, filename, conn);
+	// workaround https://issues.dlang.org/show_bug.cgi?id=18318
+	auto sl = conn.statusLine;
+	logDebug("Download %s %s", url, sl);
+	if (sl.code / 100 != 2)
+		throw new HTTPStatusException(sl.code,
+			"Downloading %s failed with %d (%s).".format(url, sl.code, sl.reason));
 }
+
 /// ditto
 void download(URL url, NativePath filename, uint timeout = 8)
 {
 	download(url.toString(), filename.toNativeString(), timeout);
 }
+
 /// ditto
 ubyte[] download(string url, uint timeout = 8)
 {
-	version(DubUseCurl) {
-		auto conn = HTTP();
-		setupHTTPClient(conn, timeout);
-		logDebug("Getting %s...", url);
-		return cast(ubyte[])get(url, conn);
-	} else version (Have_vibe_d_http) {
-		import vibe.inet.urltransfer;
-		import vibe.stream.operations;
-		ubyte[] ret;
-		vibe.inet.urltransfer.download(url, (scope input) { ret = input.readAll(); });
-		return ret;
-	} else assert(false);
+	auto conn = HTTP();
+	setupHTTPClient(conn, timeout);
+	logDebug("Getting %s...", url);
+	return cast(ubyte[])get(url, conn);
 }
+
 /// ditto
 ubyte[] download(URL url, uint timeout = 8)
 {
@@ -298,44 +279,25 @@ ubyte[] download(URL url, uint timeout = 8)
 	`timeout` ms, or if the average transfer rate drops below 10 bytes / s for
 	more than `timeout` seconds.  Pass `0` as `timeout` to disable both timeout
 	mechanisms.
-
-	Note: Timeouts are only implemented when curl is used (DubUseCurl).
 **/
 void retryDownload(URL url, NativePath filename, size_t retryCount = 3, uint timeout = 8)
 {
 	foreach(i; 0..retryCount) {
-		version(DubUseCurl) {
-			try {
-				download(url, filename, timeout);
-				return;
-			}
-			catch(HTTPStatusException e) {
-				if (e.status == 404) throw e;
-				else {
-					logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-					if (i == retryCount - 1) throw e;
-					else continue;
-				}
-			}
-			catch(CurlException e) {
+		try {
+			download(url, filename, timeout);
+			return;
+		}
+		catch(HTTPStatusException e) {
+			if (e.status == 404) throw e;
+			else {
 				logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-				continue;
+				if (i == retryCount - 1) throw e;
+				else continue;
 			}
 		}
-		else
-		{
-			try {
-				download(url, filename);
-				return;
-			}
-			catch(HTTPStatusException e) {
-				if (e.status == 404) throw e;
-				else {
-					logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-					if (i == retryCount - 1) throw e;
-					else continue;
-				}
-			}
+		catch(CurlException e) {
+			logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
+			continue;
 		}
 	}
 	throw new Exception("Failed to download %s".format(url));
@@ -345,36 +307,20 @@ void retryDownload(URL url, NativePath filename, size_t retryCount = 3, uint tim
 ubyte[] retryDownload(URL url, size_t retryCount = 3, uint timeout = 8)
 {
 	foreach(i; 0..retryCount) {
-		version(DubUseCurl) {
-			try {
-				return download(url, timeout);
-			}
-			catch(HTTPStatusException e) {
-				if (e.status == 404) throw e;
-				else {
-					logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-					if (i == retryCount - 1) throw e;
-					else continue;
-				}
-			}
-			catch(CurlException e) {
+		try {
+			return download(url, timeout);
+		}
+		catch(HTTPStatusException e) {
+			if (e.status == 404) throw e;
+			else {
 				logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-				continue;
+				if (i == retryCount - 1) throw e;
+				else continue;
 			}
 		}
-		else
-		{
-			try {
-				return download(url);
-			}
-			catch(HTTPStatusException e) {
-				if (e.status == 404) throw e;
-				else {
-					logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
-					if (i == retryCount - 1) throw e;
-					else continue;
-				}
-			}
+		catch(CurlException e) {
+			logDebug("Failed to download %s (Attempt %s of %s)", url, i + 1, retryCount);
+			continue;
 		}
 	}
 	throw new Exception("Failed to download %s".format(url));
@@ -456,32 +402,30 @@ public string getDUBExePath(in string compilerBinary=null)
 }
 
 
-version(DubUseCurl) {
-	void setupHTTPClient(ref HTTP conn, uint timeout)
-	{
-		static if( is(typeof(&conn.verifyPeer)) )
-			conn.verifyPeer = false;
+void setupHTTPClient(ref HTTP conn, uint timeout)
+{
+	static if( is(typeof(&conn.verifyPeer)) )
+		conn.verifyPeer = false;
 
-		auto proxy = environment.get("http_proxy", null);
-		if (proxy.length) conn.proxy = proxy;
+	auto proxy = environment.get("http_proxy", null);
+	if (proxy.length) conn.proxy = proxy;
 
-		auto noProxy = environment.get("no_proxy", null);
-		if (noProxy.length) conn.handle.set(CurlOption.noproxy, noProxy);
+	auto noProxy = environment.get("no_proxy", null);
+	if (noProxy.length) conn.handle.set(CurlOption.noproxy, noProxy);
 
-		conn.handle.set(CurlOption.encoding, "");
-		if (timeout) {
-			// connection (TLS+TCP) times out after 8s
-			conn.handle.set(CurlOption.connecttimeout, timeout);
-			// transfers time out after 8s below 10 byte/s
-			conn.handle.set(CurlOption.low_speed_limit, 10);
-			conn.handle.set(CurlOption.low_speed_time, timeout);
-		}
-
-		conn.addRequestHeader("User-Agent", "dub/"~getDUBVersion()~" (std.net.curl; +https://github.com/rejectedsoftware/dub)");
-
-		enum CURL_NETRC_OPTIONAL = 1;
-		conn.handle.set(CurlOption.netrc, CURL_NETRC_OPTIONAL);
+	conn.handle.set(CurlOption.encoding, "");
+	if (timeout) {
+		// connection (TLS+TCP) times out after 8s
+		conn.handle.set(CurlOption.connecttimeout, timeout);
+		// transfers time out after 8s below 10 byte/s
+		conn.handle.set(CurlOption.low_speed_limit, 10);
+		conn.handle.set(CurlOption.low_speed_time, timeout);
 	}
+
+	conn.addRequestHeader("User-Agent", "dub/"~getDUBVersion()~" (std.net.curl; +https://github.com/rejectedsoftware/dub)");
+
+	enum CURL_NETRC_OPTIONAL = 1;
+	conn.handle.set(CurlOption.netrc, CURL_NETRC_OPTIONAL);
 }
 
 string stripUTF8Bom(string str)


### PR DESCRIPTION
library-nonet has been broken for years, and is not used. Most importantly, it has no support for timeout.
Lastly, the likely reason it was originally introduced was to avoid a hard dependency on cURL, something that has been fixed in Phobos directly.