### PR TITLE
Unify reading and writing files under a single API

### DIFF
--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -357,8 +357,7 @@ NativePath generatePlatformProbeFile()
 		}.format(probeBeginMark, probeEndMark, platformCheck, archCheck, compilerCheck);
 
 	auto path = getTempFile("dub_platform_probe", ".d");
-	auto fil = openFile(path, FileMode.createTrunc);
-	fil.write(probe);
+	writeFile(path, probe);
 
 	return path;
 }

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -119,11 +119,7 @@ class VisualDGenerator : ProjectGenerator {
 
 			// Writing solution file
 			logDebug("About to write to .sln file with %s bytes", to!string(ret.data.length));
-			auto sln = openFile(solutionFileName(), FileMode.createTrunc);
-			scope(exit) sln.close();
-			sln.put(ret.data);
-			sln.flush();
-
+			NativePath(solutionFileName()).writeFile(ret.data);
 			logInfo("Generated", Color.green, "%s (solution)", solutionFileName());
 		}
 
@@ -244,10 +240,7 @@ class VisualDGenerator : ProjectGenerator {
 			ret.put("\n  </Folder>\n</DProject>");
 
 			logDebug("About to write to '%s.visualdproj' file %s bytes", getPackageFileName(packname), ret.data.length);
-			auto proj = openFile(projFileName(packname), FileMode.createTrunc);
-			scope(exit) proj.close();
-			proj.put(ret.data);
-			proj.flush();
+			projFileName(packname).writeFile(ret.data);
 		}
 
 		void generateProjectConfiguration(Appender!(char[]) ret, string pack, string type, GeneratorSettings settings, in TargetInfo[string] targets)

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -22,57 +22,17 @@ import std.string;
 import std.utf;
 
 
-/* Add output range support to File
-*/
-struct RangeFile {
-@safe:
-	std.stdio.File file;
-
-	void put(scope const ubyte[] bytes) @trusted { file.rawWrite(bytes); }
-	void put(scope const char[] str) { put(cast(const(ubyte)[])str); }
-	void put(char ch) @trusted { put((&ch)[0 .. 1]); }
-	void put(dchar ch) { char[4] chars; put(chars[0 .. encode(chars, ch)]); }
-
-	ubyte[] readAll()
-	{
-		auto sz = this.size;
-		enforce(sz <= size_t.max, "File is too big to read to memory.");
-		() @trusted { file.seek(0, SEEK_SET); } ();
-		auto ret = new ubyte[cast(size_t)sz];
-		rawRead(ret);
-		return ret;
-	}
-
-	void rawRead(ubyte[] dst) @trusted { enforce(file.rawRead(dst).length == dst.length, "Failed to readall bytes from file."); }
-	void write(string str) { put(str); }
-	void close() @trusted { file.close(); }
-	void flush() @trusted { file.flush(); }
-	@property ulong size() @trusted { return file.size; }
-}
-
-
-/**
-	Opens a file stream with the specified mode.
-*/
-RangeFile openFile(NativePath path, FileMode mode = FileMode.read)
+/// Writes `buffer` to a file
+public void writeFile(NativePath path, const void[] buffer)
 {
-	string fmode;
-	final switch(mode){
-		case FileMode.read: fmode = "rb"; break;
-		case FileMode.readWrite: fmode = "r+b"; break;
-		case FileMode.createTrunc: fmode = "wb"; break;
-		case FileMode.append: fmode = "ab"; break;
-	}
-	auto ret = std.stdio.File(path.toNativeString(), fmode);
-	assert(ret.isOpen);
-	return RangeFile(ret);
-}
-/// ditto
-RangeFile openFile(string path, FileMode mode = FileMode.read)
-{
-	return openFile(NativePath(path), mode);
+	std.file.write(path.toNativeString(), buffer);
 }
 
+/// Returns the content of a file
+public ubyte[] readFile(NativePath path)
+{
+	return cast(ubyte[]) std.file.read(path.toNativeString());
+}
 
 /**
 	Moves or renames a file.

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -306,9 +306,7 @@ class Package {
 	void storeInfo(NativePath path)
 	const {
 		auto filename = path ~ defaultPackageFilename;
-		auto dstFile = openFile(filename.toNativeString(), FileMode.createTrunc);
-		scope(exit) dstFile.close();
-		dstFile.writePrettyJsonString(m_info.toJson());
+		writeJsonFile(filename, m_info.toJson());
 	}
 
 	/// Get the metadata cache for this package

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -710,9 +710,7 @@ class PackageManager {
 		ZipArchive archive;
 		{
 			logDebug("Opening file %s", src);
-			auto f = openFile(src, FileMode.read);
-			scope(exit) f.close();
-			archive = new ZipArchive(f.readAll());
+			archive = new ZipArchive(readFile(src));
 		}
 
 		logDebug("Extracting from zip.");
@@ -779,11 +777,7 @@ class PackageManager {
 					}
 				}
 
-				{
-					auto dstFile = openFile(dst_path, FileMode.createTrunc);
-					scope(exit) dstFile.close();
-					dstFile.put(archive.expand(a));
-				}
+				writeFile(dst_path, archive.expand(a));
 				setAttributes(dst_path.toNativeString(), a);
 symlink_exit:
 				++countFiles;
@@ -974,7 +968,7 @@ symlink_exit:
 				logDebug("Hashed directory name %s", NativePath(file.name).head);
 			}
 			else {
-				hash.put(openFile(NativePath(file.name)).readAll());
+				hash.put(cast(ubyte[]) readFile(NativePath(file.name)));
 				logDebug("Hashed file contents from %s", NativePath(file.name).head);
 			}
 		}

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -9,6 +9,7 @@ module dub.recipe.io;
 
 import dub.recipe.packagerecipe;
 import dub.internal.logging;
+import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.inet.path;
 import configy.Read;
 
@@ -35,16 +36,8 @@ PackageRecipe readPackageRecipe(
 	NativePath filename, string parent_name = null, StrictMode mode = StrictMode.Ignore)
 {
 	import dub.internal.utils : stripUTF8Bom;
-	import dub.internal.vibecompat.core.file : openFile, FileMode;
 
-	string text;
-
-	{
-		auto f = openFile(filename.toNativeString(), FileMode.read);
-		scope(exit) f.close();
-		text = stripUTF8Bom(cast(string)f.readAll());
-	}
-
+	string text = stripUTF8Bom(cast(string)readFile(filename));
 	return parsePackageRecipe(text, filename.toNativeString(), parent_name, null, mode);
 }
 
@@ -209,16 +202,16 @@ unittest { // make sure targetType of sub packages are sanitized too
 */
 void writePackageRecipe(string filename, const scope ref PackageRecipe recipe)
 {
-	import dub.internal.vibecompat.core.file : openFile, FileMode;
-	auto f = openFile(filename, FileMode.createTrunc);
-	scope(exit) f.close();
-	serializePackageRecipe(f, recipe, filename);
+	writePackageRecipe(NativePath(filename), recipe);
 }
 
 /// ditto
 void writePackageRecipe(NativePath filename, const scope ref PackageRecipe recipe)
 {
-	writePackageRecipe(filename.toNativeString, recipe);
+	import std.array;
+	auto app = appender!string();
+	serializePackageRecipe(app, recipe, filename.toNativeString());
+	writeFile(filename, app.data);
 }
 
 /** Converts a package recipe to its textual representation.


### PR DESCRIPTION
This removes the range API and instead uses Appender, while using a limited and centralized set of functions to read/write from files.
The end goal is to permit dependency injection,
which is a pre-requisite to extending the test-suite.