### PR TITLE
Fix #2512: Remove hard dependency on libcurl

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -10,7 +10,6 @@ targetPath "bin"
 configuration "application" {
 	targetType "executable"
 	mainSourceFile "source/app.d"
-	libs "curl"
 	versions "DubApplication"
 	// Uncomment to get rich output about the file parsing and json <-> YAML
 	// integrity checks


### PR DESCRIPTION
It's no longer needed as Phobos loads it dynamically.