### PR TITLE
Add C source files to the list of sourceFiles as well

### DIFF
--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -524,6 +524,7 @@ struct BuildSettingsTemplate {
 
  		// collect source files
 		dst.addSourceFiles(collectFiles(sourcePaths, "*.d"));
+		dst.addSourceFiles(collectFiles(sourcePaths, "*.c"));
 		auto sourceFiles = dst.sourceFiles.sort();
 
  		// collect import files and remove sources


### PR DESCRIPTION
Starting with the next DMD version 2.101 the compiler also processes C files. Added some code to pickup the C files in the source directories as well.

Tested the code with some example project for ImportC features: https://gitlab.vahanus.net:dlang/examples/importc-tests.git

The PR might need additional checks for available DMD/LDC/GDC versions, so that C files are only added, if the compiler
can process it. Or at least output some warnings/hints. Please advise.