### PR TITLE
Add support for C sources and headers to dub

### DIFF
--- a/changelog/collect_c_source_and_headers_for_ImportC.dd
+++ b/changelog/collect_c_source_and_headers_for_ImportC.dd
@@ -1,0 +1,10 @@
+
+Add new keywords 'cSourcePaths' and 'cImportPaths'
+
+The first keyword is added to enable collection of C source files in all 'directories' specified with 'cSourcePaths'.
+All C sources found in the given directories for 'cImportPaths' are passed to the D compiler.
+This ensures backward compatible behaviour for projects that stored C sources aside of D source file, while porting them to D.
+
+The second keyword 'cImportPaths' will add additional search paths for C headers. These directories are passed to the D compilers
+as addition include paths. The feature might need additional tweaking, because the include paths are currently joint with the
+D import paths. This might change in future to support independant search paths for C to be passed to the D compilers.

--- a/changelog/collect_c_source_and_headers_for_ImportC.dd
+++ b/changelog/collect_c_source_and_headers_for_ImportC.dd
@@ -1,7 +1,7 @@
 
 Add new keywords 'cSourcePaths' and 'cImportPaths'
 
-The first keyword is added to enable collection of C source files in all 'directories' specified with 'cSourcePaths'.
+`cSourcePaths` passes the C source files in all specified directories to the compiler.
 All C sources found in the given directories for 'cImportPaths' are passed to the D compiler.
 This ensures backward compatible behaviour for projects that stored C sources aside of D source file, while porting them to D.
 

--- a/changelog/collect_c_source_and_headers_for_ImportC.dd
+++ b/changelog/collect_c_source_and_headers_for_ImportC.dd
@@ -1,5 +1,4 @@
-
-Add new keywords 'cSourcePaths' and 'cImportPaths'
+Add new properties 'cSourcePaths' and 'cImportPaths' to SDL/JSON
 
 `cSourcePaths` passes the C source files in all specified directories to the compiler.
 All C sources found in the given directories for 'cImportPaths' are passed to the D compiler.

--- a/examples/injected-from-dependency/dependency/dub.json
+++ b/examples/injected-from-dependency/dependency/dub.json
@@ -4,6 +4,7 @@
     "targetType": "library",
     "buildOptions": ["betterC"],
     "sourcePaths": ["source"],
+    "cSourcePaths": ["c-source"],
     "importPaths": ["source"],
     "injectSourceFiles": ["ahook.d"]
 }

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -33,6 +33,7 @@ struct BuildSettings {
 	string[] libs;
 	string[] linkerFiles;
 	string[] sourceFiles;
+	string[] cSourceFiles;
 	string[] injectSourceFiles;
 	string[] copyFiles;
 	string[] extraDependencyFiles;

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -139,6 +139,7 @@ struct BuildSettings {
 	void addLibs(in string[] value...) { add(libs, value); }
 	void addLinkerFiles(in string[] value...) { add(linkerFiles, value); }
 	void addSourceFiles(in string[] value...) { add(sourceFiles, value); }
+	void addCSourceFiles(in string[] value...) { add(cSourceFiles, value); }
 	void prependSourceFiles(in string[] value...) { prepend(sourceFiles, value); }
 	void removeSourceFiles(in string[] value...) { removePaths(sourceFiles, value); }
 	void addInjectSourceFiles(in string[] value...) { add(injectSourceFiles, value); }

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -42,6 +42,7 @@ struct BuildSettings {
 	string[] versionFilters;
 	string[] debugVersionFilters;
 	string[] importPaths;
+	string[] cImportPaths;
 	string[] stringImportPaths;
 	string[] importFiles;
 	string[] stringImportFiles;
@@ -82,6 +83,7 @@ struct BuildSettings {
 		assert(ret.targetType == targetType);
 		assert(ret.targetName == targetName);
 		assert(ret.importPaths == importPaths);
+		assert(ret.cImportPaths == cImportPaths);
 		return ret;
 	}
 
@@ -106,6 +108,7 @@ struct BuildSettings {
 		addVersionFilters(bs.versionFilters);
 		addDebugVersionFilters(bs.debugVersionFilters);
 		addImportPaths(bs.importPaths);
+		addCImportPaths(bs.cImportPaths);
 		addStringImportPaths(bs.stringImportPaths);
 		addImportFiles(bs.importFiles);
 		addStringImportFiles(bs.stringImportFiles);
@@ -146,6 +149,7 @@ struct BuildSettings {
 	void addVersionFilters(in string[] value...) { add(versionFilters, value); }
 	void addDebugVersionFilters(in string[] value...) { add(debugVersionFilters, value); }
 	void addImportPaths(in string[] value...) { add(importPaths, value); }
+	void addCImportPaths(in string[] value...) { add(cImportPaths, value); }
 	void addStringImportPaths(in string[] value...) { add(stringImportPaths, value); }
 	void prependStringImportPaths(in string[] value...) { prepend(stringImportPaths, value); }
 	void addImportFiles(in string[] value...) { add(importFiles, value); }
@@ -330,12 +334,13 @@ enum BuildSetting {
 	versions          = 1<<5,
 	debugVersions     = 1<<6,
 	importPaths       = 1<<7,
-	stringImportPaths = 1<<8,
-	options           = 1<<9,
+	cImportPaths       = 1<<8,
+	stringImportPaths = 1<<9,
+	options           = 1<<10,
 	none = 0,
 	commandLine = dflags|copyFiles,
 	commandLineSeparate = commandLine|lflags,
-	all = dflags|lflags|libs|sourceFiles|copyFiles|versions|debugVersions|importPaths|stringImportPaths|options,
+	all = dflags|lflags|libs|sourceFiles|copyFiles|versions|debugVersions|importPaths|cImportPaths|stringImportPaths|options,
 	noOptions = all & ~options
 }
 

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -251,6 +251,11 @@ config    /etc/dmd.conf
 			settings.importPaths = null;
 		}
 
+		if (!(fields & BuildSetting.cImportPaths)) {
+			settings.addDFlags(settings.cImportPaths.map!(s => "-I"~s)().array());
+			settings.cImportPaths = null;
+		}
+
 		if (!(fields & BuildSetting.stringImportPaths)) {
 			settings.addDFlags(settings.stringImportPaths.map!(s => "-J"~s)().array());
 			settings.stringImportPaths = null;

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -110,6 +110,11 @@ class GDCCompiler : Compiler {
 			settings.importPaths = null;
 		}
 
+		if (!(fields & BuildSetting.cImportPaths)) {
+			settings.addDFlags(settings.cImportPaths.map!(s => "-I"~s)().array());
+			settings.cImportPaths = null;
+		}
+
 		if (!(fields & BuildSetting.stringImportPaths)) {
 			settings.addDFlags(settings.stringImportPaths.map!(s => "-J"~s)().array());
 			settings.stringImportPaths = null;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -131,6 +131,11 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 			settings.importPaths = null;
 		}
 
+		if (!(fields & BuildSetting.cImportPaths)) {
+			settings.addDFlags(settings.cImportPaths.map!(s => "-I"~s)().array());
+			settings.cImportPaths = null;
+		}
+
 		if (!(fields & BuildSetting.stringImportPaths)) {
 			settings.addDFlags(settings.stringImportPaths.map!(s => "-J"~s)().array());
 			settings.stringImportPaths = null;

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -35,18 +35,6 @@ void enforceBuildRequirements(ref BuildSettings settings)
 
 
 /**
- * Determine, if the compiler hast ImportC support
- *
- * Note: Discuss and implement, move this to appropriate place!
- *
- * Returns: true or false
- */
-bool haveImportCSupport()
-{
-	assert(false, "Implement " ~ __PRETTY_FUNCTION__);
-}
-
-/**
 	Determines if a specific file name has the extension of a linker file.
 
 	Linker files include static/dynamic libraries, resource files, object files

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -35,6 +35,18 @@ void enforceBuildRequirements(ref BuildSettings settings)
 
 
 /**
+ * Determine, if the compiler hast ImportC support
+ *
+ * Note: Discuss and implement, move this to appropriate place!
+ *
+ * Returns: true or false
+ */
+bool haveImportCSupport()
+{
+	assert(false, "Implement " ~ __PRETTY_FUNCTION__);
+}
+
+/**
 	Determines if a specific file name has the extension of a linker file.
 
 	Linker files include static/dynamic libraries, resource files, object files

--- a/source/dub/description.d
+++ b/source/dub/description.d
@@ -90,6 +90,7 @@ struct PackageDescription {
 	string[] versions; /// D version identifiers to set
 	string[] debugVersions; /// D debug version identifiers to set
 	string[] importPaths;
+	string[] cImportPaths;
 	string[] stringImportPaths;
 	string[] preGenerateCommands; /// Commands executed before creating the description, with variables not substituted.
 	string[] postGenerateCommands; /// Commands executed after creating the description, with variables not substituted.

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -524,10 +524,12 @@ class Dub {
 		enforce(recipe.buildSettings.sourcePaths.length == 0, "Single-file packages are not allowed to specify source paths.");
 		enforce(recipe.buildSettings.cSourcePaths.length == 0, "Single-file packages are not allowed to specify C source paths.");
 		enforce(recipe.buildSettings.importPaths.length == 0, "Single-file packages are not allowed to specify import paths.");
+		enforce(recipe.buildSettings.cImportPaths.length == 0, "Single-file packages are not allowed to specify C import paths.");
 		recipe.buildSettings.sourceFiles[""] = [path.toNativeString()];
 		recipe.buildSettings.sourcePaths[""] = [];
 		recipe.buildSettings.cSourcePaths[""] = [];
 		recipe.buildSettings.importPaths[""] = [];
+		recipe.buildSettings.cImportPaths[""] = [];
 		recipe.buildSettings.mainSourceFile = path.toNativeString();
 		if (recipe.buildSettings.targetType == TargetType.autodetect)
 			recipe.buildSettings.targetType = TargetType.executable;
@@ -740,6 +742,9 @@ class Dub {
 			auto buildSettings = dependencyPackage.getBuildSettings(settings.platform, cfgs[dependencyPackage.name]);
 			foreach (importPath; buildSettings.importPaths) {
 				settings.runArgs ~= ["-I", buildNormalizedPath(dependencyPackage.path.toNativeString(), importPath.idup)];
+			}
+			foreach (cimportPath; buildSettings.cImportPaths) {
+				settings.runArgs ~= ["-I", buildNormalizedPath(dependencyPackage.path.toNativeString(), cimportPath.idup)];
 			}
 		}
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -522,9 +522,11 @@ class Dub {
 		auto recipe = parsePackageRecipe(recipe_content, recipe_filename, null, recipe_default_package_name);
 		enforce(recipe.buildSettings.sourceFiles.length == 0, "Single-file packages are not allowed to specify source files.");
 		enforce(recipe.buildSettings.sourcePaths.length == 0, "Single-file packages are not allowed to specify source paths.");
+		enforce(recipe.buildSettings.cSourcePaths.length == 0, "Single-file packages are not allowed to specify C source paths.");
 		enforce(recipe.buildSettings.importPaths.length == 0, "Single-file packages are not allowed to specify import paths.");
 		recipe.buildSettings.sourceFiles[""] = [path.toNativeString()];
 		recipe.buildSettings.sourcePaths[""] = [];
+		recipe.buildSettings.cSourcePaths[""] = [];
 		recipe.buildSettings.importPaths[""] = [];
 		recipe.buildSettings.mainSourceFile = path.toNativeString();
 		if (recipe.buildSettings.targetType == TargetType.autodetect)

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -211,6 +211,7 @@ class BuildGenerator : ProjectGenerator {
 		// make all paths relative to shrink the command line
 		string makeRelative(string path) { return shrinkPath(NativePath(path), cwd); }
 		foreach (ref f; buildsettings.sourceFiles) f = makeRelative(f);
+		foreach (ref f; buildsettings.cSourceFiles) f = makeRelative(f);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -213,6 +213,7 @@ class BuildGenerator : ProjectGenerator {
 		foreach (ref f; buildsettings.sourceFiles) f = makeRelative(f);
 		foreach (ref f; buildsettings.cSourceFiles) f = makeRelative(f);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
+		foreach (ref p; buildsettings.cImportPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);
 
 		// perform the actual build
@@ -376,6 +377,7 @@ class BuildGenerator : ProjectGenerator {
 		}
 		buildsettings.targetPath = makeRelative(buildsettings.targetPath);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
+		foreach (ref p; buildsettings.cImportPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);
 
 		bool is_temp_target = false;
@@ -675,6 +677,7 @@ private string computeBuildID(in BuildSettings buildsettings, string config, Gen
 		buildsettings.lflags,
 		buildsettings.stringImportPaths,
 		buildsettings.importPaths,
+		buildsettings.cImportPaths,
 		settings.platform.architecture,
 		[
 			(cast(uint)(buildsettings.options & ~BuildOption.color)).to!string, // exclude color option from id

--- a/source/dub/generators/cmake.d
+++ b/source/dub/generators/cmake.d
@@ -84,6 +84,9 @@ class CMakeGenerator: ProjectGenerator
             foreach(directory; info.buildSettings.importPaths)
                 script.put("include_directories(%s)\n".format(directory.sanitizeSlashes));
 
+            foreach(directory; info.buildSettings.cImportPaths)
+                script.put("c_include_directories(%s)\n".format(directory.sanitizeSlashes));
+
             if(addTarget)
             {
                 script.put("add_%s(%s %s\n".format(targetType, name, libType));

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -733,6 +733,7 @@ class ProjectGenerator
 		parent.addVersionFilters(child.versionFilters);
 		parent.addDebugVersionFilters(child.debugVersionFilters);
 		parent.addImportPaths(child.importPaths);
+		parent.addCImportPaths(child.cImportPaths);
 		parent.addStringImportPaths(child.stringImportPaths);
 		parent.addInjectSourceFiles(child.injectSourceFiles);
 		// linker stuff propagates up from static *and* dynamic library deps
@@ -999,6 +1000,7 @@ const(string[string])[] makeCommandEnvironmentVariables(CommandType type,
 	env["LIBS"]                  = join(build_settings.libs, " ");
 	env["SOURCE_FILES"]          = join(build_settings.sourceFiles, " ");
 	env["IMPORT_PATHS"]          = join(build_settings.importPaths, " ");
+	env["C_IMPORT_PATHS"]        = join(build_settings.cImportPaths, " ");
 	env["STRING_IMPORT_PATHS"]   = join(build_settings.stringImportPaths, " ");
 
 	env["DC"]                    = settings.platform.compilerBinary;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -999,6 +999,7 @@ const(string[string])[] makeCommandEnvironmentVariables(CommandType type,
 	env["VERSIONS"]              = join(build_settings.versions, " ");
 	env["LIBS"]                  = join(build_settings.libs, " ");
 	env["SOURCE_FILES"]          = join(build_settings.sourceFiles, " ");
+	env["C_SOURCE_FILES"]        = join(build_settings.cSourceFiles, " ");
 	env["IMPORT_PATHS"]          = join(build_settings.importPaths, " ");
 	env["C_IMPORT_PATHS"]        = join(build_settings.cImportPaths, " ");
 	env["STRING_IMPORT_PATHS"]   = join(build_settings.stringImportPaths, " ");

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -304,7 +304,8 @@ class VisualDGenerator : ProjectGenerator {
 				string imports = join(getPathSettings!"importPaths"(), " ");
 				string cimports = join(getPathSettings!"cImportPaths"(), " ");
 				string stringImports = join(getPathSettings!"stringImportPaths"(), " ");
-				ret.formattedWrite("    <imppath>%s %s</imppath>\n", imports, cimports);
+				string combinedImports = join([imports, cimports], " ");
+				ret.formattedWrite("    <imppath>%s</imppath>\n", combinedImports);
 				ret.formattedWrite("    <fileImppath>%s</fileImppath>\n", stringImports);
 
 				ret.formattedWrite("    <program>%s</program>\n", "$(DMDInstallDir)windows\\bin\\dmd.exe"); // FIXME: use the actually selected compiler!

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -302,8 +302,9 @@ class VisualDGenerator : ProjectGenerator {
 
 				// include paths and string imports
 				string imports = join(getPathSettings!"importPaths"(), " ");
+				string cimports = join(getPathSettings!"cImportPaths"(), " ");
 				string stringImports = join(getPathSettings!"stringImportPaths"(), " ");
-				ret.formattedWrite("    <imppath>%s</imppath>\n", imports);
+				ret.formattedWrite("    <imppath>%s %s</imppath>\n", imports, cimports);
 				ret.formattedWrite("    <fileImppath>%s</fileImppath>\n", stringImports);
 
 				ret.formattedWrite("    <program>%s</program>\n", "$(DMDInstallDir)windows\\bin\\dmd.exe"); // FIXME: use the actually selected compiler!

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -735,3 +735,90 @@ void deepCompareImpl (T) (
 			file, line);
 	}
 }
+
+/**
+ * Determines if a specific file name is suitable source file for the D compiler.
+ *
+ *	Source files include .d, .c and .i files.
+ *
+ * Params:
+ *   f = filename to check
+ * Returns:
+ */
+bool isSourceFile(string f)
+{
+	import std.path;
+	switch (extension(f)) {
+		default:
+			return false;
+		case ".d", ".c", ".i":
+			return true;
+	}
+}
+
+unittest {
+	assert(isSourceFile("test.c"));
+	assert(isSourceFile("test.d"));
+	assert(isSourceFile("test.i"));
+	assert(!isSourceFile("test.o"));
+	assert(!isSourceFile("test.h"));
+}
+
+/**
+ * Determines if a specific file name is suitable header file for the D compiler.
+ *
+ *	Header files include .di and .h
+ *
+ * Params:
+ *   f = filename to check
+ * Returns:
+ */
+bool isHeaderFile(string f)
+{
+	import std.path;
+	switch (extension(f)) {
+		default:
+			return false;
+		case ".di", ".h":
+			return true;
+	}
+}
+
+unittest {
+	assert(!isHeaderFile("test.c"));
+	assert(!isHeaderFile("test.d"));
+	assert(!isHeaderFile("test.i"));
+	assert(!isHeaderFile("test.o"));
+	assert(isHeaderFile("test.di"));
+	assert(isHeaderFile("test.h"));
+}
+
+/**
+ * Determines if a specific file name is a ImportC input file for the D compiler.
+ *
+ *	Header files include .c, .i and .h
+ *
+ * Params:
+ *   f = filename to check
+ * Returns:
+ */
+bool isImportCFile(string f)
+{
+	import std.path;
+	switch (extension(f)) {
+		default:
+			return false;
+		case ".c", ".i", ".h":
+			return true;
+	}
+}
+
+unittest {
+	assert(isImportCFile("test.c"));
+	assert(isImportCFile("test.i"));
+	assert(isImportCFile("test.h"));
+	assert(!isImportCFile("test.d"));
+	assert(!isImportCFile("test.o"));
+	assert(!isImportCFile("test.di"));
+}
+

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -578,13 +578,13 @@ string determineModuleName(BuildSettings settings, NativePath file, NativePath b
 {
 	import std.algorithm : map;
 	import std.array : array;
-	import std.range : walkLength;
+	import std.range : walkLength, chain;
 
 	assert(base_path.absolute);
 	if (!file.absolute) file = base_path ~ file;
 
 	size_t path_skip = 0;
-	foreach (ipath; settings.importPaths.map!(p => NativePath(p))) {
+	foreach (ipath; chain(settings.importPaths, settings.cImportPaths).map!(p => NativePath(p))) {
 		if (!ipath.absolute) ipath = base_path ~ ipath;
 		assert(!ipath.empty);
 		if (file.startsWith(ipath) && ipath.bySegment.walkLength > path_skip)

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -640,6 +640,7 @@ class Package {
 		ret.versions = bs.versions;
 		ret.debugVersions = bs.debugVersions;
 		ret.importPaths = bs.importPaths;
+		ret.cImportPaths = bs.cImportPaths;
 		ret.stringImportPaths = bs.stringImportPaths;
 		ret.preGenerateCommands = bs.preGenerateCommands;
 		ret.postGenerateCommands = bs.postGenerateCommands;
@@ -723,12 +724,14 @@ class Package {
 		immutable hasSP = ("" in bs.sourcePaths) !is null;
 		immutable hasCSP = ("" in bs.cSourcePaths) !is null;
 		immutable hasIP = ("" in bs.importPaths) !is null;
+		immutable hasCIP = ("" in bs.cImportPaths) !is null;
 		if (!hasSP || !hasIP) {
 			foreach (defsf; ["source/", "src/"]) {
 				if (existsFile(m_path ~ defsf)) {
 					if (!hasSP) bs.sourcePaths[""] ~= defsf;
 					if (!hasCSP) bs.cSourcePaths[""] ~= defsf;
 					if (!hasIP) bs.importPaths[""] ~= defsf;
+					if (!hasCIP) bs.cImportPaths[""] ~= defsf;
 				}
 			}
 		}

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -722,16 +722,12 @@ class Package {
 
 		// check for default source folders
 		immutable hasSP = ("" in bs.sourcePaths) !is null;
-		immutable hasCSP = ("" in bs.cSourcePaths) !is null;
 		immutable hasIP = ("" in bs.importPaths) !is null;
-		immutable hasCIP = ("" in bs.cImportPaths) !is null;
 		if (!hasSP || !hasIP) {
 			foreach (defsf; ["source/", "src/"]) {
 				if (existsFile(m_path ~ defsf)) {
 					if (!hasSP) bs.sourcePaths[""] ~= defsf;
-					if (!hasCSP) bs.cSourcePaths[""] ~= defsf;
 					if (!hasIP) bs.importPaths[""] ~= defsf;
-					if (!hasCIP) bs.cImportPaths[""] ~= defsf;
 				}
 			}
 		}

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -721,11 +721,13 @@ class Package {
 
 		// check for default source folders
 		immutable hasSP = ("" in bs.sourcePaths) !is null;
+		immutable hasCSP = ("" in bs.cSourcePaths) !is null;
 		immutable hasIP = ("" in bs.importPaths) !is null;
 		if (!hasSP || !hasIP) {
 			foreach (defsf; ["source/", "src/"]) {
 				if (existsFile(m_path ~ defsf)) {
 					if (!hasSP) bs.sourcePaths[""] ~= defsf;
+					if (!hasCSP) bs.cSourcePaths[""] ~= defsf;
 					if (!hasIP) bs.importPaths[""] ~= defsf;
 				}
 			}

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -927,6 +927,7 @@ class Project {
 		case "versions":
 		case "debugVersions":
 		case "importPaths":
+		case "cImportPaths":
 		case "stringImportPaths":
 		case "options":
 			auto bs = buildSettings.dup;
@@ -936,6 +937,8 @@ class Project {
 			auto ensureTrailingSlash = (string path) => path.endsWith(dirSeparator) ? path : path ~ dirSeparator;
 			static if (attributeName == "importPaths")
 				bs.importPaths = bs.importPaths.map!(ensureTrailingSlash).array();
+			else static if (attributeName == "cImportPaths")
+				bs.cImportPaths = bs.cImportPaths.map!(ensureTrailingSlash).array();
 			else static if (attributeName == "stringImportPaths")
 				bs.stringImportPaths = bs.stringImportPaths.map!(ensureTrailingSlash).array();
 
@@ -978,6 +981,7 @@ class Project {
 			case "sourceFiles":
 			case "cSourceFiles":
 			case "importPaths":
+			case "CImportPaths":
 			case "stringImportPaths":
 				return values.map!(escapeShellFileName).array();
 
@@ -1054,7 +1058,7 @@ class Project {
 		auto getFixedBuildSetting(Package pack) {
 			// Is relative path(s) to a directory?
 			enum isRelativeDirectory =
-				attributeName == "importPaths" || attributeName == "stringImportPaths" ||
+				attributeName == "importPaths" || attributeName == "cImportPaths" || attributeName == "stringImportPaths" ||
 				attributeName == "targetPath" || attributeName == "workingDirectory";
 
 			// Is relative path(s) to a file?
@@ -1321,6 +1325,7 @@ void processVars(ref BuildSettings dst, in Project project, in Package pack,
 	dst.addVersionFilters(processVars(project, pack, gsettings, settings.versionFilters, false, buildEnvs));
 	dst.addDebugVersionFilters(processVars(project, pack, gsettings, settings.debugVersionFilters, false, buildEnvs));
 	dst.addImportPaths(processVars(project, pack, gsettings, settings.importPaths, true, buildEnvs));
+	dst.addCImportPaths(processVars(project, pack, gsettings, settings.cImportPaths, true, buildEnvs));
 	dst.addStringImportPaths(processVars(project, pack, gsettings, settings.stringImportPaths, true, buildEnvs));
 	dst.addRequirements(settings.requirements);
 	dst.addOptions(settings.options);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -294,7 +294,7 @@ class Project {
 			lbuildsettings.importPaths ~= NativePath(mainfil).parentPath.toNativeString;
 		bool firstTimePackage = true;
 		foreach (file; lbuildsettings.sourceFiles) {
-			if (file.isSourceFile) {
+			if (file.endsWith(".d")) {
 				auto fname = NativePath(file).head.name;
 				NativePath msf = NativePath(mainfil);
 				if (msf.absolute)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1315,6 +1315,7 @@ void processVars(ref BuildSettings dst, in Project project, in Package pack,
 	dst.addLFlags(processVars(project, pack, gsettings, settings.lflags, false, buildEnvs));
 	dst.addLibs(processVars(project, pack, gsettings, settings.libs, false, buildEnvs));
 	dst.addSourceFiles(processVars!true(project, pack, gsettings, settings.sourceFiles, true, buildEnvs));
+	dst.addCSourceFiles(processVars!true(project, pack, gsettings, settings.cSourceFiles, true, buildEnvs));
 	dst.addImportFiles(processVars(project, pack, gsettings, settings.importFiles, true, buildEnvs));
 	dst.addStringImportFiles(processVars(project, pack, gsettings, settings.stringImportFiles, true, buildEnvs));
 	dst.addInjectSourceFiles(processVars!true(project, pack, gsettings, settings.injectSourceFiles, true, buildEnvs));

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -922,6 +922,7 @@ class Project {
 
 		case "lflags":
 		case "sourceFiles":
+		case "cSourceFiles":
 		case "injectSourceFiles":
 		case "versions":
 		case "debugVersions":
@@ -975,6 +976,7 @@ class Project {
 			case "importFiles":
 			case "stringImportFiles":
 			case "sourceFiles":
+			case "cSourceFiles":
 			case "importPaths":
 			case "stringImportPaths":
 				return values.map!(escapeShellFileName).array();

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -294,7 +294,7 @@ class Project {
 			lbuildsettings.importPaths ~= NativePath(mainfil).parentPath.toNativeString;
 		bool firstTimePackage = true;
 		foreach (file; lbuildsettings.sourceFiles) {
-			if (file.endsWith(".d")) {
+			if (file.isSourceFile) {
 				auto fname = NativePath(file).head.name;
 				NativePath msf = NativePath(mainfil);
 				if (msf.absolute)

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -290,6 +290,7 @@ private Json toJson(const scope ref BuildSettingsTemplate bs)
 	foreach (suffix, arr; bs.debugVersions) ret[withSuffix("debugVersions", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.versionFilters) ret[withSuffix("-versionFilters", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.debugVersionFilters) ret[withSuffix("-debugVersionFilters", suffix)] = serializeToJson(arr);
+	foreach (suffix, arr; bs.importPaths) ret[withSuffix("importPaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.cImportPaths) ret[withSuffix("cImportPaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.stringImportPaths) ret[withSuffix("stringImportPaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.preGenerateCommands) ret[withSuffix("preGenerateCommands", suffix)] = serializeToJson(arr);

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -220,6 +220,7 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 			case "-versionFilters": bs.versionFilters[suffix] = deserializeJson!(string[])(value); break;
 			case "-debugVersionFilters": bs.debugVersionFilters[suffix] = deserializeJson!(string[])(value); break;
 			case "importPaths": bs.importPaths[suffix] = deserializeJson!(string[])(value); break;
+			case "cImportPaths": bs.cImportPaths[suffix] = deserializeJson!(string[])(value); break;
 			case "stringImportPaths": bs.stringImportPaths[suffix] = deserializeJson!(string[])(value); break;
 			case "preGenerateCommands": bs.preGenerateCommands[suffix] = deserializeJson!(string[])(value); break;
 			case "postGenerateCommands": bs.postGenerateCommands[suffix] = deserializeJson!(string[])(value); break;
@@ -289,7 +290,7 @@ private Json toJson(const scope ref BuildSettingsTemplate bs)
 	foreach (suffix, arr; bs.debugVersions) ret[withSuffix("debugVersions", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.versionFilters) ret[withSuffix("-versionFilters", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.debugVersionFilters) ret[withSuffix("-debugVersionFilters", suffix)] = serializeToJson(arr);
-	foreach (suffix, arr; bs.importPaths) ret[withSuffix("importPaths", suffix)] = serializeToJson(arr);
+	foreach (suffix, arr; bs.cImportPaths) ret[withSuffix("cImportPaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.stringImportPaths) ret[withSuffix("stringImportPaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.preGenerateCommands) ret[withSuffix("preGenerateCommands", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.postGenerateCommands) ret[withSuffix("postGenerateCommands", suffix)] = serializeToJson(arr);

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -209,6 +209,7 @@ private void parseJson(ref BuildSettingsTemplate bs, Json json, string package_n
 			case "files":
 			case "sourceFiles": bs.sourceFiles[suffix] = deserializeJson!(string[])(value); break;
 			case "sourcePaths": bs.sourcePaths[suffix] = deserializeJson!(string[])(value); break;
+			case "cSourcePaths": bs.cSourcePaths[suffix] = deserializeJson!(string[])(value); break;
 			case "sourcePath": bs.sourcePaths[suffix] ~= [value.get!string]; break; // deprecated
 			case "excludedSourceFiles": bs.excludedSourceFiles[suffix] = deserializeJson!(string[])(value); break;
 			case "injectSourceFiles": bs.injectSourceFiles[suffix] = deserializeJson!(string[])(value); break;
@@ -279,6 +280,7 @@ private Json toJson(const scope ref BuildSettingsTemplate bs)
 	foreach (suffix, arr; bs.libs) ret[withSuffix("libs", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.sourceFiles) ret[withSuffix("sourceFiles", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.sourcePaths) ret[withSuffix("sourcePaths", suffix)] = serializeToJson(arr);
+	foreach (suffix, arr; bs.cSourcePaths) ret[withSuffix("cSourcePaths", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.excludedSourceFiles) ret[withSuffix("excludedSourceFiles", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.injectSourceFiles) ret[withSuffix("injectSourceFiles", suffix)] = serializeToJson(arr);
 	foreach (suffix, arr; bs.copyFiles) ret[withSuffix("copyFiles", suffix)] = serializeToJson(arr);

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -530,7 +530,7 @@ struct BuildSettingsTemplate {
  		// collect import files and remove sources
 		import std.algorithm : copy, setDifference;
 
-		auto importFiles = collectFiles(importPaths, "*.{d,di}").sort();
+		auto importFiles = collectFiles(importPaths, "*.{d,di,h}").sort();
 		immutable nremoved = importFiles.setDifference(sourceFiles).copy(importFiles.release).length;
 		importFiles = importFiles[0 .. $ - nremoved];
 		dst.addImportFiles(importFiles.release);

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -524,6 +524,7 @@ struct BuildSettingsTemplate {
 
  		// collect source files
 		dst.addSourceFiles(collectFiles(sourcePaths, "*.d"));
+		dst.addSourceFiles(collectFiles(sourcePaths, "*.c"));
 		auto sourceFiles = dst.sourceFiles.sort();
 
  		// collect import files and remove sources

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -424,6 +424,7 @@ struct BuildSettingsTemplate {
 	@StartsWith("libs") string[][string] libs;
 	@StartsWith("sourceFiles") string[][string] sourceFiles;
 	@StartsWith("sourcePaths") string[][string] sourcePaths;
+	@StartsWith("cSourcePaths") string[][string] cSourcePaths;
 	@StartsWith("excludedSourceFiles") string[][string] excludedSourceFiles;
 	@StartsWith("injectSourceFiles") string[][string] injectSourceFiles;
 	@StartsWith("copyFiles") string[][string] copyFiles;
@@ -524,7 +525,7 @@ struct BuildSettingsTemplate {
 
  		// collect source files
 		dst.addSourceFiles(collectFiles(sourcePaths, "*.d"));
-		dst.addSourceFiles(collectFiles(sourcePaths, "*.c"));
+		dst.addSourceFiles(collectFiles(cSourcePaths, "*.c"));
 		auto sourceFiles = dst.sourceFiles.sort();
 
  		// collect import files and remove sources

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -525,7 +525,7 @@ struct BuildSettingsTemplate {
 
  		// collect source files
 		dst.addSourceFiles(collectFiles(sourcePaths, "*.d"));
-		dst.addSourceFiles(collectFiles(cSourcePaths, "*.c"));
+		dst.addSourceFiles(collectFiles(cSourcePaths, "*.{c,i}"));
 		auto sourceFiles = dst.sourceFiles.sort();
 
  		// collect import files and remove sources

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -434,6 +434,7 @@ struct BuildSettingsTemplate {
 	@StartsWith("versionFilters") string[][string] versionFilters;
 	@StartsWith("debugVersionFilters") string[][string] debugVersionFilters;
 	@StartsWith("importPaths") string[][string] importPaths;
+	@StartsWith("cImportPaths") string[][string] cImportPaths;
 	@StartsWith("stringImportPaths") string[][string] stringImportPaths;
 	@StartsWith("preGenerateCommands") string[][string] preGenerateCommands;
 	@StartsWith("postGenerateCommands") string[][string] postGenerateCommands;
@@ -531,10 +532,12 @@ struct BuildSettingsTemplate {
  		// collect import files and remove sources
 		import std.algorithm : copy, setDifference;
 
-		auto importFiles = collectFiles(importPaths, "*.{d,di,h}").sort();
+		auto importFiles =
+            chain(collectFiles(importPaths, "*.{d,di}"), collectFiles(cImportPaths, "*.h"))
+            .sort();
 		immutable nremoved = importFiles.setDifference(sourceFiles).copy(importFiles.release).length;
 		importFiles = importFiles[0 .. $ - nremoved];
-		dst.addImportFiles(importFiles.release);
+		dst.addImportFiles(importFiles.release.array);
 
 		dst.addStringImportFiles(collectFiles(stringImportPaths, "*"));
 
@@ -551,6 +554,7 @@ struct BuildSettingsTemplate {
 		getPlatformSetting!("versionFilters", "addVersionFilters")(dst, platform);
 		getPlatformSetting!("debugVersionFilters", "addDebugVersionFilters")(dst, platform);
 		getPlatformSetting!("importPaths", "addImportPaths")(dst, platform);
+		getPlatformSetting!("cImportPaths", "addCImportPaths")(dst, platform);
 		getPlatformSetting!("stringImportPaths", "addStringImportPaths")(dst, platform);
 		getPlatformSetting!("preGenerateCommands", "addPreGenerateCommands")(dst, platform);
 		getPlatformSetting!("postGenerateCommands", "addPostGenerateCommands")(dst, platform);

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -533,11 +533,12 @@ struct BuildSettingsTemplate {
 		import std.algorithm : copy, setDifference;
 
 		auto importFiles =
-            chain(collectFiles(importPaths, "*.{d,di}"), collectFiles(cImportPaths, "*.h"))
-            .sort();
+			chain(collectFiles(importPaths, "*.{d,di}"), collectFiles(cImportPaths, "*.h"))
+			.array()
+			.sort();
 		immutable nremoved = importFiles.setDifference(sourceFiles).copy(importFiles.release).length;
 		importFiles = importFiles[0 .. $ - nremoved];
-		dst.addImportFiles(importFiles.release.array);
+		dst.addImportFiles(importFiles.release);
 
 		dst.addStringImportFiles(collectFiles(stringImportPaths, "*"));
 

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -156,6 +156,7 @@ private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, string
 		case "x:versionFilters": setting.parsePlatformStringArray(bs.versionFilters); break;
 		case "x:debugVersionFilters": setting.parsePlatformStringArray(bs.debugVersionFilters); break;
 		case "importPaths": setting.parsePlatformStringArray(bs.importPaths); break;
+		case "cImportPaths": setting.parsePlatformStringArray(bs.cImportPaths); break;
 		case "stringImportPaths": setting.parsePlatformStringArray(bs.stringImportPaths); break;
 		case "preGenerateCommands": setting.parsePlatformStringArray(bs.preGenerateCommands); break;
 		case "postGenerateCommands": setting.parsePlatformStringArray(bs.postGenerateCommands); break;
@@ -295,6 +296,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 	foreach (suffix, arr; bs.versionFilters) adda("versionFilters", suffix, arr, "x");
 	foreach (suffix, arr; bs.debugVersionFilters) adda("debugVersionFilters", suffix, arr, "x");
 	foreach (suffix, arr; bs.importPaths) adda("importPaths", suffix, arr);
+	foreach (suffix, arr; bs.cImportPaths) adda("cImportPaths", suffix, arr);
 	foreach (suffix, arr; bs.stringImportPaths) adda("stringImportPaths", suffix, arr);
 	foreach (suffix, arr; bs.preGenerateCommands) adda("preGenerateCommands", suffix, arr);
 	foreach (suffix, arr; bs.postGenerateCommands) adda("postGenerateCommands", suffix, arr);
@@ -486,6 +488,8 @@ x:debugVersionFilters "debug3"
 x:debugVersionFilters
 importPaths "import1" "import2"
 importPaths "import3"
+cImportPaths "cimport1" "cimport2"
+cImportPaths "cimport3"
 stringImportPaths "string1" "string2"
 stringImportPaths "string3"
 preGenerateCommands "preg1" "preg2"
@@ -580,6 +584,7 @@ lflags "lf3"
 	assert(rec.buildSettings.versionFilters == ["": ["version1", "version2", "version3"]]);
 	assert(rec.buildSettings.debugVersionFilters == ["": ["debug1", "debug2", "debug3"]]);
 	assert(rec.buildSettings.importPaths == ["": ["import1", "import2", "import3"]]);
+	assert(rec.buildSettings.cImportPaths == ["": ["cimport1", "cimport2", "cimport3"]]);
 	assert(rec.buildSettings.stringImportPaths == ["": ["string1", "string2", "string3"]]);
 	assert(rec.buildSettings.preGenerateCommands == ["": ["preg1", "preg2", "preg3"]]);
 	assert(rec.buildSettings.postGenerateCommands == ["": ["postg1", "postg2", "postg3"]]);

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -145,6 +145,7 @@ private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, string
 		case "libs": setting.parsePlatformStringArray(bs.libs); break;
 		case "sourceFiles": setting.parsePlatformStringArray(bs.sourceFiles); break;
 		case "sourcePaths": setting.parsePlatformStringArray(bs.sourcePaths); break;
+		case "cSourcePaths": setting.parsePlatformStringArray(bs.cSourcePaths); break;
 		case "excludedSourceFiles": setting.parsePlatformStringArray(bs.excludedSourceFiles); break;
 		case "mainSourceFile": bs.mainSourceFile = setting.stringTagValue; break;
 		case "injectSourceFiles": setting.parsePlatformStringArray(bs.injectSourceFiles); break;
@@ -284,6 +285,7 @@ private Tag[] toSDL(const scope ref BuildSettingsTemplate bs)
 	foreach (suffix, arr; bs.libs) adda("libs", suffix, arr);
 	foreach (suffix, arr; bs.sourceFiles) adda("sourceFiles", suffix, arr);
 	foreach (suffix, arr; bs.sourcePaths) adda("sourcePaths", suffix, arr);
+	foreach (suffix, arr; bs.cSourcePaths) adda("cSourcePaths", suffix, arr);
 	foreach (suffix, arr; bs.excludedSourceFiles) adda("excludedSourceFiles", suffix, arr);
 	foreach (suffix, arr; bs.injectSourceFiles) adda("injectSourceFiles", suffix, arr);
 	foreach (suffix, arr; bs.copyFiles) adda("copyFiles", suffix, arr);
@@ -462,6 +464,8 @@ sourceFiles "source1" "source2"
 sourceFiles "source3"
 sourcePaths "sourcepath1" "sourcepath2"
 sourcePaths "sourcepath3"
+cSourcePaths "csourcepath1" "csourcepath2"
+cSourcePaths "csourcepath3"
 excludedSourceFiles "excluded1" "excluded2"
 excludedSourceFiles "excluded3"
 mainSourceFile "main source"
@@ -565,6 +569,7 @@ lflags "lf3"
 	assert(rec.buildSettings.libs == ["": ["lib1", "lib2", "lib3"]]);
 	assert(rec.buildSettings.sourceFiles == ["": ["source1", "source2", "source3"]]);
 	assert(rec.buildSettings.sourcePaths == ["": ["sourcepath1", "sourcepath2", "sourcepath3"]]);
+	assert(rec.buildSettings.cSourcePaths == ["": ["csourcepath1", "csourcepath2", "csourcepath3"]]);
 	assert(rec.buildSettings.excludedSourceFiles == ["": ["excluded1", "excluded2", "excluded3"]]);
 	assert(rec.buildSettings.mainSourceFile == "main source");
 	assert(rec.buildSettings.sourceFiles == ["": ["source1", "source2", "source3"]]);
@@ -656,6 +661,13 @@ unittest {
 	PackageRecipe rec;
 	parseSDL(rec, sdl, null, "testfile");
 	assert("" in rec.buildSettings.sourcePaths);
+}
+
+unittest {
+	auto sdl = "name \"test\"\ncSourcePaths";
+	PackageRecipe rec;
+	parseSDL(rec, sdl, null, "testfile");
+	assert("" in rec.buildSettings.cSourcePaths);
 }
 
 unittest {

--- a/test/use-c-sources/dub.json
+++ b/test/use-c-sources/dub.json
@@ -1,0 +1,11 @@
+{
+    "toolchainRequirements": {
+        "dub": ">=1.29.0",
+        "frontend": ">=2.101.0"
+    },
+    "cSourcePaths": [
+        "source"
+    ],
+    "description": "A minimal D application using ImportC and C sources in a dub project.",
+    "name": "use-c-sources"
+}

--- a/test/use-c-sources/source/app.d
+++ b/test/use-c-sources/source/app.d
@@ -1,0 +1,37 @@
+/** Some test code for ImportC */
+module app.d;
+
+import std.algorithm.iteration;
+import std.array;
+import std.conv;
+import std.exception;
+import std.range;
+import std.stdio;
+import std.string;
+
+import some_c_code;
+
+void main()
+{
+	doCCalls();
+}
+
+/// Call C functions in zstd_binding module
+void doCCalls()
+{
+	relatedCode(42);
+
+	ulong a = 3;
+	uint b = 4;
+	auto rs0 = multiplyU64byU32(&a, &b);
+	writeln("Result of multiplyU64byU32(3,4) = ", rs0);
+
+	uint[8] arr = [1, 2, 3, 4, 5, 6, 7, 8];
+	auto rs1 = multiplyAndAdd(arr.ptr, arr.length, 3);
+	writeln("Result of sum(%s*3) = ".format(arr), rs1);
+
+	foreach (n; 1 .. 20)
+	{
+		writeln("fac(", n, ") = ", fac(n));
+	}
+}

--- a/test/use-c-sources/source/some_c_code.c
+++ b/test/use-c-sources/source/some_c_code.c
@@ -1,0 +1,34 @@
+
+#include <stdio.h>
+
+#include "some_c_code.h"
+
+// Some test functions follow to proof that C code can be called from D main()
+
+void relatedCode(size_t aNumber)
+{
+	printf("Hallo! This is some output from C code! (%d)\n", aNumber);
+}
+
+uint64_t multiplyU64byU32(uint64_t*a, uint32_t*b)
+{
+    return *a * *b;
+}
+
+uint64_t multiplyAndAdd(uint32_t*arr, size_t arrlen, uint32_t mult)
+{
+    uint64_t acc = 0;
+    for (int i = 0; i < arrlen; i++)
+    {
+        acc += arr[i]*mult;
+    }
+    return acc;
+}
+
+uint64_t fac(uint64_t n)
+{
+	if (n > 1)
+		return n * fac(n-1);
+	else
+		return 1;
+}

--- a/test/use-c-sources/source/some_c_code.h
+++ b/test/use-c-sources/source/some_c_code.h
@@ -1,0 +1,12 @@
+#ifndef SOME_C_CODE_H
+#define SOME_C_CODE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+extern void relatedCode(size_t aNumber);
+extern uint64_t multiplyU64byU32(uint64_t*a, uint32_t*b);
+extern uint64_t multiplyAndAdd(uint32_t*arr, size_t arrlen, uint32_t mult);
+extern uint64_t fac(uint64_t n);
+
+#endif


### PR DESCRIPTION
Add changes to support C source and header files with Dub

- This is a work-in-project PR as basis for discussions on scope changes and impacts involved with adding C source and header file support to dub.
- The goal is to be able to use C files (.c, .h and .i) in Dub projects the same way as usual D files (.d and .di). Dub shall be able to pick up these files automatically and pass them to the D compiler.
- We need some switch to enable the support in JSON/SDL files (backward compatibility, test staging). For this 'cSourcePaths' and 'cImportPaths' were added. If specified, dub will pick up C source and pass extra paths to the compiler.
- We need some way to detect existing ImportC support in D compilers (separate issue, WIP)
- We must generalize some code by using isSourceFile(), isHeaderFile() and isImportCFile() instead of just checking for ".d" extension. (separate issue, WIP)