### PR TITLE
merge stable

### DIFF
--- a/changelog/configy_stricter_parsing.dd
+++ b/changelog/configy_stricter_parsing.dd
@@ -1,7 +1,7 @@
-dub will now warn on unrecognized settings or selections file
+dub will now warn on unrecognized fields in `dub.json`, settings, or selections file
 
 Previously, dub was silently accepting anything it didn't recognize
-in `[dub.]settings.json` and `dub.selections.json`. While the original
+in `dub.json`, `[dub.]settings.json` and `dub.selections.json`. While the original
 intent was to make forward-compatibility easy, it proved detrimental
 as typos would just mean the user setting was ignored.
 

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -1033,7 +1033,7 @@ public struct VersionRange
 
 		string r;
 
-		if (this == Invalid) return "invalid";
+		if (this == Invalid) return "no";
 		if (this.isExactVersion() && m_inclusiveA && m_inclusiveB) {
 			// Special "==" case
 			if (m_versA == Version.masterBranch) return "~master";

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,2 +1,2 @@
 module dub.version_;
-enum dubVersion = "v1.30.0-beta.1";
+enum dubVersion = "v1.30.0-rc.1";


### PR DESCRIPTION
- Changelog: Add mention that dub.json is also checked now
- Fix #1752: Use 'no' as string representation of Dependency.Invalid
- update version to v1.30.0-rc.1
