### PR TITLE
Fix add-path based development workflow

### DIFF
--- a/build.d
+++ b/build.d
@@ -35,7 +35,11 @@ immutable VersionFilePath = RootPath.buildPath("source", "dub", "version_.d");
 /// Path to the file containing the files to be built
 immutable SourceListPath = RootPath.buildPath("build-files.txt");
 /// Path at which the newly built `dub` binary will be
-immutable DubBinPath = RootPath.buildPath("bin", "dub");
+version (Windows) {
+	immutable DubBinPath = RootPath.buildPath("bin", "dub.exe");
+} else {
+	immutable DubBinPath = RootPath.buildPath("bin", "dub");
+}
 
 // Flags for DMD
 immutable OutputFlag = "-of" ~ DubBinPath;

--- a/test/prefer-add-path-packages.sh
+++ b/test/prefer-add-path-packages.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+. $(dirname ${BASH_SOURCE[0]})/common.sh
+
+TMPDIR=$CURR_DIR/tmp-add-path
+
+PACK_PATH="$CURR_DIR"/issue2262-exact-cached-version-match
+
+# make sure that there are no left-over selections files or temp directory
+rm -f $PACK_PATH/dub.selections.json
+rm -rf $TMPDIR
+
+# make sure that there are no cached versions of the dependency
+$DUB remove gitcompatibledubpackage@* -n || true
+
+# build normally, should select 1.0.4
+if ! ${DUB} build --root $PACK_PATH | grep "gitcompatibledubpackage 1\.0\.4:"; then
+    die $LINENO 'The initial build failed.'
+fi
+
+# clone gitcompatibledubpackage and check out 1.0.4+commit.2.ccb31bf
+mkdir $TMPDIR
+$DUB add-path $TMPDIR
+cd $TMPDIR
+git clone https://github.com/dlang-community/gitcompatibledubpackage.git
+cd gitcompatibledubpackage
+git checkout -q ccb31bf6a655437176ec02e04c2305a8c7c90d67
+cd ../..
+
+if ! $DUB list | grep "gitcompatibledubpackage 1\.0\.4+commit.2.gccb31bf"; then
+    $DUB remove-path $TMPDIR
+    die $LINENO 'Cloned package was not found in search path'
+fi
+
+# should pick up the cloned package instead of the cached one now
+if ! ${DUB} build --root $PACK_PATH | grep "gitcompatibledubpackage 1\.0\.4+commit.2.gccb31bf:"; then
+    $DUB remove-path $TMPDIR
+    die $LINENO 'Did not pick up the add-path package.'
+fi
+
+# clean up
+$DUB remove-path $TMPDIR
+rm -f $PACK_PATH/dub.selections.json
+rm -rf $TMPDIR


### PR DESCRIPTION
The logic that locally checked out packages added using `add-path` take precedence and don't follow the `strict` matching rules got broken again due to a recent change. It should be noted that this fix requires a call to `PackageManager.refresh()`, which will, in order to get the anticipated performance improvement, probably need to be the target for a more fine-grained approach, where only the cache directory is skipped during package scanning instead of everything.