### PR TITLE
Bugfix for 'DSO not on commandline'

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -380,6 +380,9 @@ config    /etc/dmd.conf
 		import std.string;
 		auto tpath = NativePath(settings.targetPath) ~ getTargetFileName(settings, platform);
 		auto args = ["-of"~tpath.toNativeString()];
+		// Fix for https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line
+		if (platform.platform.canFind("linux"))
+			args ~= "-L--copy-dt-needed-entries"; // avoids linker errors due to missing DSO on commandline problem
 		args ~= objects;
 		args ~= settings.sourceFiles;
 		if (platform.platform.canFind("linux"))

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -228,7 +228,11 @@ class GDCCompiler : Compiler {
 			assert(tpath !is null, "setTarget should be called before invoke");
 			args = [ "ar", "rcs", tpath ] ~ objects;
 		} else {
-			args = platform.compilerBinary ~ objects ~ settings.sourceFiles ~ settings.lflags ~ settings.dflags.filter!(f => isLinkageFlag(f)).array;
+			args ~= platform.compilerBinary;
+			// Fix for https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line
+			if (platform.platform.canFind("linux"))
+				args ~= "-L--copy-dt-needed-entries"; // avoids linker errors due to missing DSO on commandline problem
+			args ~= objects ~ settings.sourceFiles ~ settings.lflags ~ settings.dflags.filter!(f => isLinkageFlag(f)).array;
 			if (platform.platform.canFind("linux"))
 				args ~= "-L--no-as-needed"; // avoids linker errors due to libraries being specified in the wrong order
 		}

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -265,6 +265,9 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		import std.string;
 		auto tpath = NativePath(settings.targetPath) ~ getTargetFileName(settings, platform);
 		auto args = ["-of"~tpath.toNativeString()];
+		// Fix for https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line
+		if (platform.platform.canFind("linux"))
+			args ~= "-L--copy-dt-needed-entries"; // avoids linker errors due to missing DSO on commandline problem
 		args ~= objects;
 		args ~= settings.sourceFiles;
 		if (platform.platform.canFind("linux"))


### PR DESCRIPTION
On Ubuntu Linux 22.10 the attempt to compile adrdox with ldc2 failed with: BF71E424C08F3A6D4232856F69528B07401A46B683CB4F3FC3760DC6D5493338/adrdox.o: undefined reference to symbol 'inflateEnd' /usr/bin/ld: /lib/x86_64-linux-gnu/libz.so.1: error adding symbol: DSO missing from command line

$ ld --version
GNU ld (GNU Binutils for Ubuntu) 2.39

There is a workaround for this problem. See https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line

This workaround has been added and fixes the linker problem.