### PR TITLE
Replace all instances of mkdirRecurse with ensureDir

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2423,7 +2423,7 @@ class DustmiteCommand : PackageBuildCommand {
 
 			void copyFolderRec(NativePath folder, NativePath dstfolder)
 			{
-				mkdirRecurse(dstfolder.toNativeString());
+				ensureDirectory(dstfolder);
 				foreach (de; iterateDirectory(folder.toNativeString())) {
 					if (de.name.startsWith(".")) continue;
 					if (de.isDirectory) {

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -485,7 +485,7 @@ class Dub {
 	void loadSingleFilePackage(NativePath path)
 	{
 		import dub.recipe.io : parsePackageRecipe;
-		import std.file : mkdirRecurse, readText;
+		import std.file : readText;
 		import std.path : baseName, stripExtension;
 
 		path = makeAbsolute(path);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -168,14 +168,13 @@ class BuildGenerator : ProjectGenerator {
 		buildTargetRec(m_project.rootPackage.name);
 
 		if (dynamicLibDepsFilesToCopy.length) {
-			const rootTargetPath = root_ti.buildSettings.targetPath;
+			const rootTargetPath = NativePath(root_ti.buildSettings.targetPath);
 
-			if (!existsFile(rootTargetPath))
-				mkdirRecurse(rootTargetPath);
-
+			ensureDirectory(rootTargetPath);
 			foreach (src; dynamicLibDepsFilesToCopy) {
-				logDiagnostic("Copying target from %s to %s", src.toNativeString(), rootTargetPath);
-				hardLinkFile(src, NativePath(rootTargetPath) ~ src.head, true);
+				logDiagnostic("Copying target from %s to %s",
+					src.toNativeString(), rootTargetPath.toNativeString());
+				hardLinkFile(src, rootTargetPath ~ src.head, true);
 			}
 		}
 
@@ -428,8 +427,7 @@ class BuildGenerator : ProjectGenerator {
 
 	private void copyTargetFile(in NativePath build_path, in BuildSettings buildsettings, in GeneratorSettings settings)
 	{
-		if (!existsFile(NativePath(buildsettings.targetPath)))
-			mkdirRecurse(buildsettings.targetPath);
+		ensureDirectory(NativePath(buildsettings.targetPath));
 
 		string[] filenames = [
 			settings.compiler.getTargetFileName(buildsettings, settings.platform)

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -908,13 +908,12 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 	}
 
 	if (generate_binary) {
-		if (!exists(buildsettings.targetPath))
-			mkdirRecurse(buildsettings.targetPath);
+		ensureDirectory(NativePath(buildsettings.targetPath));
 
 		if (buildsettings.copyFiles.length) {
 			void copyFolderRec(NativePath folder, NativePath dstfolder)
 			{
-				mkdirRecurse(dstfolder.toNativeString());
+				ensureDirectory(dstfolder);
 				foreach (de; iterateDirectory(folder.toNativeString())) {
 					if (de.isDirectory) {
 						copyFolderRec(folder ~ de.name, dstfolder ~ de.name);
@@ -1119,7 +1118,7 @@ version(Posix) {
 		import dub.compilers.gdc : GDCCompiler;
 		import std.algorithm : canFind;
 		import std.path : absolutePath;
-		import std.file : mkdirRecurse, rmdirRecurse, write;
+		import std.file : rmdirRecurse, write;
 
 		mkdirRecurse("dubtest/preGen/source");
 		write("dubtest/preGen/source/foo.d", "");

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -62,8 +62,7 @@ void initPackage(NativePath root_path, VersionRange[string] deps, string type,
 
 	//Check to see if a target directory needs to be created
 	if (!root_path.empty) {
-		if (!existsFile(root_path))
-			createDirectory(root_path);
+		ensureDirectory(root_path);
 	}
 
 	//Make sure we do not overwrite anything accidentally
@@ -98,7 +97,7 @@ private void initMinimalPackage(NativePath root_path, ref PackageRecipe p, scope
 	p.description = "A minimal D application.";
 	pre_write_callback();
 
-	createDirectory(root_path ~ "source");
+	ensureDirectory(root_path ~ "source");
 	write((root_path ~ "source/app.d").toNativeString(),
 q{import std.stdio;
 
@@ -116,9 +115,9 @@ private void initVibeDPackage(NativePath root_path, ref PackageRecipe p, scope v
 	p.description = "A simple vibe.d server application.";
 	pre_write_callback();
 
-	createDirectory(root_path ~ "source");
-	createDirectory(root_path ~ "views");
-	createDirectory(root_path ~ "public");
+	ensureDirectory(root_path ~ "source");
+	ensureDirectory(root_path ~ "views");
+	ensureDirectory(root_path ~ "public");
 	write((root_path ~ "source/app.d").toNativeString(),
 q{import vibe.vibe;
 
@@ -153,8 +152,8 @@ private void initDeimosPackage(NativePath root_path, ref PackageRecipe p, scope 
 	p.buildSettings.targetType = TargetType.sourceLibrary;
 	pre_write_callback();
 
-	createDirectory(root_path ~ "C");
-	createDirectory(root_path ~ "deimos");
+	ensureDirectory(root_path ~ "C");
+	ensureDirectory(root_path ~ "deimos");
 }
 
 /**

--- a/source/dub/internal/git.d
+++ b/source/dub/internal/git.d
@@ -46,7 +46,7 @@ version (Windows)
 		if (head_commit.length) {
 			import dub.internal.utils : atomicWriteJsonFile;
 
-			if (!existsFile(path ~".dub")) createDirectory(path ~ ".dub");
+			ensureDirectory(path ~ ".dub");
 			atomicWriteJsonFile(vcachepath, Json(["commit": Json(head_commit), "version": Json(ret)]));
 		}
 

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -109,7 +109,8 @@ bool isWritableDir(NativePath p, bool create_if_missing = false)
 {
 	import std.random;
 	auto fname = p ~ format("__dub_write_test_%08X", uniform(0, uint.max));
-	if (create_if_missing && !exists(p.toNativeString())) mkdirRecurse(p.toNativeString());
+	if (create_if_missing)
+		ensureDirectory(p);
 	try writeFile(fname, "Canary");
 	catch (Exception) return false;
 	remove(fname.toNativeString());

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -244,14 +244,10 @@ FileInfo getFileInfo(string path)
 /**
 	Creates a new directory.
 */
-void createDirectory(NativePath path)
+void ensureDirectory(NativePath path)
 {
-	mkdir(path.toNativeString());
-}
-/// ditto
-void createDirectory(string path)
-{
-	createDirectory(NativePath(path));
+	if (!existsDirectory(path))
+		mkdirRecurse(path.toNativeString());
 }
 
 /**

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -681,8 +681,7 @@ class PackageManager {
 	Package store(NativePath src, PlacementLocation dest, string name, Version vers)
 	{
 		NativePath dstpath = this.getPackagePath(dest, name, vers.toString());
-		if (!dstpath.existsFile())
-			mkdirRecurse(dstpath.toNativeString());
+		ensureDirectory(dstpath);
 		// For libraries leaking their import path
 		dstpath = dstpath ~ name;
 
@@ -750,7 +749,7 @@ class PackageManager {
 		}
 
 		// extract & place
-		mkdirRecurse(destination.toNativeString());
+		ensureDirectory(destination);
 		logDebug("Copying all files...");
 		int countFiles = 0;
 		foreach(ArchiveMember a; archive.directory) {
@@ -760,11 +759,9 @@ class PackageManager {
 
 			logDebug("Creating %s", cleanedPath);
 			if( dst_path.endsWithSlash ){
-				if( !existsDirectory(dst_path) )
-					mkdirRecurse(dst_path.toNativeString());
+				ensureDirectory(dst_path);
 			} else {
-				if( !existsDirectory(dst_path.parentPath) )
-					mkdirRecurse(dst_path.parentPath.toNativeString());
+				ensureDirectory(dst_path.parentPath);
 				// for symlinks on posix systems, use the symlink function to
 				// create them. Windows default unzip doesn't handle symlinks,
 				// so we don't need to worry about it for Windows.
@@ -1186,7 +1183,7 @@ private struct Location {
 			newlist ~= jovr;
 		}
 		auto path = this.packagePath;
-		if (!existsDirectory(path)) mkdirRecurse(path.toNativeString());
+		ensureDirectory(path);
 		writeJsonFile(path ~ LocalOverridesFilename, Json(newlist));
 	}
 
@@ -1210,7 +1207,7 @@ private struct Location {
 		}
 
 		NativePath path = this.packagePath;
-		if( !existsDirectory(path) ) mkdirRecurse(path.toNativeString());
+		ensureDirectory(path);
 		writeJsonFile(path ~ LocalPackagesFilename, Json(newlist));
 	}
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -332,8 +332,7 @@ class Project {
 		}
 
 		if (generate_main && (settings.force || !existsFile(mainfile))) {
-			import std.file : mkdirRecurse;
-			mkdirRecurse(mainfile.parentPath.toNativeString());
+		    ensureDirectory(mainfile.parentPath);
 
 			const runnerCode = custommodname.length ?
 				format("import %s;", custommodname) : DefaultTestRunnerCode;


### PR DESCRIPTION
All usages actually want to ensure the directory is present, and don't care about having a separation between existence check and creation.