### PR TITLE
CI: Use v2.100.1 temporarily instead of latest (2.101)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,8 @@ jobs:
         # Latest stable version, update at will
         os: [ macOS-11, ubuntu-20.04, windows-2019 ]
         dc:
-          - dmd-latest
+          #- dmd-latest
+          - dmd-2.100.2
           - ldc-latest
           - dmd-master
           - ldc-master


### PR DESCRIPTION
Because 2.101 is broken with preview=in, and dub relies on it.

Upstream fix: https://github.com/dlang/phobos/pull/8627