### PR TITLE
Move computeBuildID outside of BuildGenerator

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -206,7 +206,7 @@ class BuildGenerator : ProjectGenerator {
 		auto cwd = NativePath(getcwd());
 		bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
-		auto build_id = computeBuildID(config, buildsettings, settings);
+		auto build_id = buildsettings.computeBuildID(config, settings);
 
 		// make all paths relative to shrink the command line
 		string makeRelative(string path) { return shrinkPath(NativePath(path), cwd); }
@@ -402,27 +402,6 @@ class BuildGenerator : ProjectGenerator {
 			foreach (f; buildsettings.copyFiles)
 				m_temporaryFiles ~= NativePath(buildsettings.targetPath).parentPath ~ NativePath(f).head;
 		}
-	}
-
-	private string computeBuildID(string config, in BuildSettings buildsettings, GeneratorSettings settings)
-	{
-		const(string[])[] hashing = [
-			buildsettings.versions,
-			buildsettings.debugVersions,
-			buildsettings.dflags,
-			buildsettings.lflags,
-			buildsettings.stringImportPaths,
-			buildsettings.importPaths,
-			settings.platform.architecture,
-			[
-				(cast(uint)(buildsettings.options & ~BuildOption.color)).to!string, // exclude color option from id
-				settings.platform.compilerBinary,
-				settings.platform.compiler,
-				settings.platform.compilerVersion,
-			],
-		];
-
-		return computeBuildName(config, settings, hashing);
 	}
 
 	private void copyTargetFile(in NativePath build_path, in BuildSettings buildsettings, in GeneratorSettings settings)
@@ -673,6 +652,38 @@ class BuildGenerator : ProjectGenerator {
 		}
 		m_temporaryFiles = null;
 	}
+}
+
+/**
+ * Provides a unique (per build) identifier
+ *
+ * When building a package, it is important to have a unique but stable
+ * identifier to differentiate builds and allow their caching.
+ * This function provides such an identifier.
+ * Example:
+ * ```
+ * application-debug-linux.posix-x86_64-dmd_v2.100.2-D80285212AEC1FF9855F18AD52C68B9EEB5C7690609C224575F920096FB1965B
+ * ```
+ */
+private string computeBuildID(in BuildSettings buildsettings, string config, GeneratorSettings settings)
+{
+	const(string[])[] hashing = [
+		buildsettings.versions,
+		buildsettings.debugVersions,
+		buildsettings.dflags,
+		buildsettings.lflags,
+		buildsettings.stringImportPaths,
+		buildsettings.importPaths,
+		settings.platform.architecture,
+		[
+			(cast(uint)(buildsettings.options & ~BuildOption.color)).to!string, // exclude color option from id
+			settings.platform.compilerBinary,
+			settings.platform.compiler,
+			settings.platform.compilerVersion,
+		],
+	];
+
+	return computeBuildName(config, settings, hashing);
 }
 
 private NativePath getMainSourceFile(in Package prj)


### PR DESCRIPTION
It does not use anything from 'this', only its input parameters. Additionally, change the order so it is usable with UFCS.