### PR TITLE
Use a central build cache for all build artifacts

### DIFF
--- a/changelog/build-cache.dd
+++ b/changelog/build-cache.dd
@@ -1,0 +1,14 @@
+Binary output will now be in a central cache
+
+Up until now, dub would output build artifact in the package directory.
+
+This allowed reuse of build artifact for dependencies, but also created
+issues with large amount of build artifacts in the packages folder,
+preventing the use of read-only location to store packages,
+and making garbage collection of build artifacts unreliable.
+
+Starting from this version, build artifacts will be output by default to
+`$HOME/.dub/cache/build/$BASE_PACKAGE_NAME/$PACKAGE_VERSION/[+$SUB_PACKAGE_NAME]`
+on Linux, and
+`%APPDATA%/cache/build/$BASE_PACKAGE_NAME/$PACKAGE_VERSION/[+$SUB_PACKAGE_NAME]`
+on Windows.

--- a/changelog/metadata-cache.dd
+++ b/changelog/metadata-cache.dd
@@ -1,0 +1,9 @@
+DUB API breaking change: `Package.metadataCache` setter and getter have been removed
+
+Those two functions were used to provide access to the metadata cache file
+to the generator. They were never intended for public consumption,
+and the JSON file format was not stable.
+
+Due to the introduction of the build cache, they needed to be removed,
+as there was no way to provide a sensible transition path, and they should be unused.
+If you have a use case for it, please open an issue in dub repository.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1629,6 +1629,7 @@ class DescribeCommand : PackageBuildCommand {
 		GeneratorSettings settings = this.baseSettings;
 		if (!settings.config.length)
 			settings.config = m_defaultConfig;
+		settings.cache = dub.cachePathDontUse(); // See function's description
 		// Ignore other options
 		settings.buildSettings.options = this.baseSettings.buildSettings.options & BuildOption.lowmem;
 
@@ -1688,27 +1689,10 @@ class CleanCommand : Command {
 		enforce(free_args.length == 0, "Cleaning a specific package isn't possible right now.");
 
 		if (m_allPackages) {
-			bool any_error = false;
-
-			foreach (p; dub.packageManager.getPackageIterator()) {
-				try dub.cleanPackage(p.path);
-				catch (Exception e) {
-					logWarn("Failed to clean package %s at %s: %s", p.name, p.path, e.msg);
-					any_error = true;
-				}
-
-				foreach (sp; p.subPackages.filter!(sp => !sp.path.empty)) {
-					try dub.cleanPackage(p.path ~ sp.path);
-					catch (Exception e) {
-						logWarn("Failed to clean sub package of %s at %s: %s", p.name, p.path ~ sp.path, e.msg);
-						any_error = true;
-					}
-				}
-			}
-
-			if (any_error) return 2;
+			dub.clean();
 		} else {
-			dub.cleanPackage(dub.rootPath);
+			dub.loadPackage();
+			dub.clean(dub.project.rootPackage);
 		}
 
 		return 0;

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -249,7 +249,8 @@ class BuildGenerator : ProjectGenerator {
 			string packageName = pack.basePackage is null ? pack.name : pack.basePackage.name;
 			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
 		}
-		else target_path = pack.path ~ format(".dub/build/%s/", build_id);
+		else
+			target_path = packageCache(settings.cache, pack) ~ "build/" ~ build_id;
 
 		if (!settings.force && isUpToDate(target_path, buildsettings, settings, pack, packages, additional_dep_files)) {
 			logInfo("Up-to-date", Color.green, "%s %s: target for configuration [%s] is up to date.",

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -12,7 +12,9 @@ import dub.generators.cmake;
 import dub.generators.build;
 import dub.generators.sublimetext;
 import dub.generators.visuald;
+import dub.internal.utils;
 import dub.internal.vibecompat.core.file;
+import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
 import dub.internal.logging;
 import dub.package_;
@@ -654,7 +656,10 @@ class ProjectGenerator
 		auto srcs = chain(bs.sourceFiles, bs.importFiles, bs.stringImportFiles)
 			.filter!(f => dexts.canFind(f.extension)).filter!exists;
 		// try to load cached filters first
-		auto cache = ti.pack.metadataCache;
+		const cacheFilePath = packageCache(NativePath(ti.buildSettings.targetPath), ti.pack)
+			~ "metadata_cache.json";
+		enum silent_fail = true;
+		auto cache = jsonFromFile(cacheFilePath, silent_fail);
 		try
 		{
 			auto cachedFilters = cache["versionFilters"];
@@ -713,7 +718,9 @@ class ProjectGenerator
 			"versions": Json(versionFilters.data.map!Json.array),
 			"debugVersions": Json(debugVersionFilters.data.map!Json.array),
 		];
-		ti.pack.metadataCache = cache;
+        enum create_if_missing = true;
+        if (isWritableDir(cacheFilePath.parentPath, create_if_missing))
+            writeJsonFile(cacheFilePath, cache);
 	}
 
 	private static void mergeFromDependent(const scope ref BuildSettings parent, ref BuildSettings child)
@@ -760,8 +767,38 @@ class ProjectGenerator
 	}
 }
 
+/**
+ * Compute and returns the path were artifacts are stored for a given package
+ *
+ * Artifacts are usually stored in:
+ * `$DUB_HOME/cache/$PKG_NAME/$PKG_VERSION[/+$SUB_PKG_NAME]/`
+ * Note that the leading `+` in the subpackage name is to avoid any ambiguity.
+ * Build artifacts are usually stored in a subfolder named "build",
+ * as their names are based on user-supplied values.
+ *
+ * Params:
+ *   cachePath = Base path at which the build cache is located,
+ *               e.g. `$HOME/.dub/cache/`
+ *	 pkg = The package. Cannot be `null`.
+ */
+package(dub) NativePath packageCache(NativePath cachePath, in Package pkg)
+{
+	import std.algorithm.searching : findSplit;
+
+	assert(pkg !is null);
+	assert(!cachePath.empty);
+
+	// For subpackages
+	if (const names = pkg.name.findSplit(":"))
+		return cachePath ~ names[0] ~ pkg.version_.toString()
+			~ ("+" ~ names[2]);
+	// For regular packages
+	return cachePath ~ pkg.name ~ pkg.version_.toString();
+}
+
 
 struct GeneratorSettings {
+	NativePath cache;
 	BuildPlatform platform;
 	Compiler compiler;
 	string config;

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -309,22 +309,6 @@ class Package {
 		writeJsonFile(filename, m_info.toJson());
 	}
 
-	/// Get the metadata cache for this package
-	@property Json metadataCache()
-	{
-		enum silent_fail = true;
-		return jsonFromFile(m_path ~ ".dub/metadata_cache.json", silent_fail);
-	}
-
-	/// Write metadata cache for this package
-	@property void metadataCache(Json json)
-	{
-		enum create_if_missing = true;
-		if (isWritableDir(m_path ~ ".dub", create_if_missing))
-			writeJsonFile(m_path ~ ".dub/metadata_cache.json", json);
-		// TODO: store elsewhere
-	}
-
 	/** Returns the package recipe of a non-path-based sub package.
 
 		For sub packages that are declared within the package recipe of the

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -320,7 +320,9 @@ class Project {
 			mainfile = getTempFile("dub_test_root", ".d");
 		else {
 			import dub.generators.build : computeBuildName;
-			mainfile = rootPackage.path ~ format(".dub/code/%s/dub_test_root.d", computeBuildName(config, settings, import_modules));
+			mainfile = packageCache(settings.cache, this.rootPackage) ~
+				format("code/%s/dub_test_root.d",
+					computeBuildName(config, settings, import_modules));
 		}
 
 		auto escapedMainFile = mainfile.toNativeString().replace("$", "$$");

--- a/test/cache-generated-test-config.sh
+++ b/test/cache-generated-test-config.sh
@@ -2,7 +2,8 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/cache-generated-test-config
-rm -rf .dub
+rm -rf $HOME/.dub/cache/cache-generated-test-config/
+DUB_CODE_CACHE_PATH="$HOME/.dub/cache/cache-generated-test-config/~master/code/"
 
 ## default test
 ${DUB} test --compiler=${DC}
@@ -12,15 +13,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*/dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*/dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls $DUB_CODE_CACHE_PATH/*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 ## test with empty DFLAGS environment variable
 DFLAGS="" ${DUB} test --compiler=${DC}
@@ -30,15 +31,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 DFLAGS="" ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 ## test with DFLAGS environment variable
 DFLAGS="-g" ${DUB} test --compiler=${DC}
@@ -48,15 +49,15 @@ STAT="stat -c '%Y'"
 
 EXECUTABLE_TIME="$(${STAT} cache-generated-test-config-test-library)"
 [ -z "$EXECUTABLE_TIME" ] && die $LINENO 'no EXECUTABLE_TIME was found'
-MAIN_TIME="$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d)")"
+MAIN_TIME="$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d)")"
 [ -z "$MAIN_TIME" ] && die $LINENO 'no MAIN_TIME was found'
 
 DFLAGS="-g" ${DUB} test --compiler=${DC}
-MAIN_FILES_COUNT=$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | wc -l)
+MAIN_FILES_COUNT=$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d | wc -l)
 
 [ $MAIN_FILES_COUNT -ne 1 ] && die $LINENO 'DUB generated more then one main file'
 [ "$EXECUTABLE_TIME" != "$(${STAT} cache-generated-test-config-test-library)" ] && die $LINENO 'The executable has been rebuilt'
-[ "$MAIN_TIME" != "$(${STAT} "$(ls .dub/code/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
+[ "$MAIN_TIME" != "$(${STAT} "$(ls $DUB_CODE_CACHE_PATH/*-\$DFLAGS-*/dub_test_root.d | head -n1)")" ] && die $LINENO 'The test main file has been rebuilt'
 
 
 

--- a/test/issue97-targettype-none.sh
+++ b/test/issue97-targettype-none.sh
@@ -3,7 +3,26 @@ set -e
 
 ${DUB} build --root ${CURR_DIR}/issue97-targettype-none 2>&1 || true
 
+BUILD_CACHE_A="$HOME/.dub/cache/issue97-targettype-none/~master/+a/build/"
+BUILD_CACHE_B="$HOME/.dub/cache/issue97-targettype-none/~master/+b/build/"
+
+if [ ! -d $BUILD_CACHE_A ]; then
+    echo "Generated 'a' subpackage build artifact not found!" 1>&2
+    exit 1
+fi
+if [ ! -d $BUILD_CACHE_B ]; then
+    echo "Generated 'b' subpackage build artifact not found!" 1>&2
+    exit 1
+fi
+
+${DUB} clean --root ${CURR_DIR}/issue97-targettype-none 2>&1
+
 # make sure both sub-packages are cleaned
-OUTPUT=`${DUB} clean --root ${CURR_DIR}/issue97-targettype-none 2>&1`
-echo $OUTPUT | grep -c "Cleaning package at .*/issue97-targettype-none/a/" > /dev/null
-echo $OUTPUT | grep -c "Cleaning package at .*/issue97-targettype-none/b/" > /dev/null
+if [ -d $BUILD_CACHE_A ]; then
+    echo "Generated 'a' subpackage build artifact were not cleaned!" 1>&2
+    exit 1
+fi
+if [ -d $BUILD_CACHE_B ]; then
+    echo "Generated 'b' subpackage build artifact were not cleaned!" 1>&2
+    exit 1
+fi

--- a/test/removed-dub-obj.sh
+++ b/test/removed-dub-obj.sh
@@ -2,14 +2,20 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/removed-dub-obj
-rm -rf .dub
+
+DUB_CACHE_PATH="$HOME/.dub/cache/removed-dub-obj/"
+
+rm -rf $DUB_CACHE_PATH
 
 ${DUB} build --compiler=${DC}
 
-[ -d ".dub/obj" ] && die $LINENO '.dub/obj was found'
+[ -d "$DUB_CACHE_PATH/obj" ] && die $LINENO "$DUB_CACHE_PATH/obj was found"
 
 if [[ ${DC} == *"ldc"* ]]; then
-    [ -f .dub/build/library-*ldc*/obj/test.o* ] || die $LINENO '.dub/build/library-*ldc*/obj/test.o* was not found'
+    if [ ! -f $DUB_CACHE_PATH/~master/build/library-*ldc*/obj/test.o* ]; then
+        ls -lR $DUB_CACHE_PATH
+        die $LINENO '$DUB_CACHE_PATH/~master/build/library-*ldc*/obj/test.o* was not found'
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
```
Currently the central build cache is not configurable, but as most build artifacts end up in `~/.dub/packages/` anyway, this will be a positive change for users.
```

This is essentially https://github.com/dlang/dub/pull/1650 without configurability, because there's a few things needed before we can make it configurable "nicely".

Fix https://github.com/dlang/dub/issues/1473 and would make adding a GC much easier (e.g. https://github.com/dlang/dub/issues/1256 and https://github.com/dlang/dub/issues/631).