### PR TITLE
Reduce dependency on the current working directory

### DIFF
--- a/build-files.txt
+++ b/build-files.txt
@@ -58,6 +58,7 @@ source/dub/internal/sdlang/token.d
 source/dub/internal/sdlang/util.d
 source/dub/internal/tinyendian.d
 source/dub/internal/undead/xml.d
+source/dub/internal/temp_files.d
 source/dub/internal/utils.d
 source/dub/internal/vibecompat/core/file.d
 source/dub/internal/vibecompat/data/json.d

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -30,13 +30,12 @@ import std.encoding;
 import std.exception;
 import std.file;
 import std.getopt;
-import std.path : expandTilde, absolutePath, buildNormalizedPath;
-import std.process;
+import std.path : absolutePath, buildNormalizedPath, expandTilde, setExtension;
+import std.process : environment, spawnProcess, wait;
 import std.stdio;
 import std.string;
 import std.typecons : Tuple, tuple;
 import std.variant;
-import std.path: setExtension;
 
 /** Retrieves a list of all available commands.
 
@@ -759,7 +758,7 @@ class Command {
 		Dub dub;
 
 		if (options.bare) {
-			dub = new Dub(NativePath(options.root_path), NativePath(getcwd()));
+			dub = new Dub(NativePath(options.root_path), getWorkingDirectory());
 			dub.defaultPlacementLocation = options.placementLocation;
 
 			return dub;
@@ -2209,7 +2208,7 @@ class AddOverrideCommand : Command {
 		auto source = VersionRange.fromString(free_args[1]);
 		if (existsFile(NativePath(free_args[2]))) {
 			auto target = NativePath(free_args[2]);
-			if (!target.absolute) target = NativePath(getcwd()) ~ target;
+			if (!target.absolute) target = getWorkingDirectory() ~ target;
 			dub.packageManager.addOverride_(scope_, pack, source, target);
 			logInfo("Added override %s %s => %s", pack, source, target);
 		} else {
@@ -2368,7 +2367,7 @@ class DustmiteCommand : PackageBuildCommand {
 	{
 		if (!m_testPackage.length)
 			return super.prepareDub(options);
-		return new Dub(NativePath(options.root_path), NativePath(getcwd()));
+		return new Dub(NativePath(options.root_path), getWorkingDirectory());
 	}
 
 	override int execute(Dub dub, string[] free_args, string[] app_args)
@@ -2402,7 +2401,7 @@ class DustmiteCommand : PackageBuildCommand {
 			auto path = NativePath(free_args[0]);
 			path.normalize();
 			enforceUsage(!path.empty, "Destination path must not be empty.");
-			if (!path.absolute) path = NativePath(getcwd()) ~ path;
+			if (!path.absolute) path = getWorkingDirectory() ~ path;
 			enforceUsage(!path.startsWith(dub.rootPath), "Destination path must not be a sub directory of the tested package!");
 
 			setupPackage(dub, null);

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -17,7 +17,7 @@ import dub.internal.logging;
 import std.algorithm;
 import std.array;
 import std.exception;
-import std.process;
+import std.process : execute;
 import std.typecons;
 
 
@@ -205,7 +205,7 @@ class GDCCompiler : Compiler {
 		settings.addDFlags("-o", tpath);
 	}
 
-	void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback)
+	void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback, NativePath cwd)
 	{
 		auto res_file = getTempFile("dub-build", ".rsp");
 		writeFile(res_file, join(settings.dflags.map!(s => escape(s)), "\n"));
@@ -215,10 +215,10 @@ class GDCCompiler : Compiler {
 		foreach (aa; [settings.environments, settings.buildEnvironments])
 			foreach (k, v; aa)
 				env[k] = v;
-		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, env);
+		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, cwd, env);
 	}
 
-	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback)
+	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback, NativePath cwd)
 	{
 		import std.string;
 		string[] args;
@@ -237,7 +237,7 @@ class GDCCompiler : Compiler {
 		foreach (aa; [settings.environments, settings.buildEnvironments])
 			foreach (k, v; aa)
 				env[k] = v;
-		invokeTool(args, output_callback, env);
+		invokeTool(args, output_callback, cwd, env);
 	}
 
 	string[] lflagsToDFlags(const string[] lflags) const

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -245,7 +245,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		settings.addDFlags("-of"~tpath);
 	}
 
-	void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback)
+	void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback, NativePath cwd)
 	{
 		auto res_file = getTempFile("dub-build", ".rsp");
 		const(string)[] args = settings.dflags;
@@ -257,10 +257,10 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		foreach (aa; [settings.environments, settings.buildEnvironments])
 			foreach (k, v; aa)
 				env[k] = v;
-		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, env);
+		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, cwd, env);
 	}
 
-	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback)
+	void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback, NativePath cwd)
 	{
 		import std.string;
 		auto tpath = NativePath(settings.targetPath) ~ getTargetFileName(settings, platform);
@@ -280,7 +280,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		foreach (aa; [settings.environments, settings.buildEnvironments])
 			foreach (k, v; aa)
 				env[k] = v;
-		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, env);
+		invokeTool([platform.compilerBinary, "@"~res_file.toNativeString()], output_callback, cwd, env);
 	}
 
 	string[] lflagsToDFlags(const string[] lflags) const

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -158,7 +158,7 @@ class Dub {
 			SkipPackageSuppliers skip_registry = SkipPackageSuppliers.none)
 	{
 		m_rootPath = NativePath(root_path);
-		if (!m_rootPath.absolute) m_rootPath = NativePath(getcwd()) ~ m_rootPath;
+		if (!m_rootPath.absolute) m_rootPath = getWorkingDirectory() ~ m_rootPath;
 
 		init();
 
@@ -384,7 +384,7 @@ class Dub {
 	@property void rootPath(NativePath root_path)
 	{
 		m_rootPath = root_path;
-		if (!m_rootPath.absolute) m_rootPath = NativePath(getcwd()) ~ m_rootPath;
+		if (!m_rootPath.absolute) m_rootPath = getWorkingDirectory() ~ m_rootPath;
 	}
 
 	/// Returns the name listed in the dub.json of the current
@@ -686,6 +686,8 @@ class Dub {
 	void generateProject(string ide, GeneratorSettings settings)
 	{
 		settings.cache = this.m_dirs.cache;
+		if (settings.overrideToolWorkingDirectory is NativePath.init)
+			settings.overrideToolWorkingDirectory = m_rootPath;
 		// With a requested `unittest` config, switch to the special test runner
 		// config (which doesn't require an existing `unittest` configuration).
 		if (settings.config == "unittest") {
@@ -705,7 +707,9 @@ class Dub {
 	void testProject(GeneratorSettings settings, string config, NativePath custom_main_file)
 	{
 		settings.cache = this.m_dirs.cache;
-		if (!custom_main_file.empty && !custom_main_file.absolute) custom_main_file = getWorkingDirectory() ~ custom_main_file;
+		if (settings.overrideToolWorkingDirectory is NativePath.init)
+			settings.overrideToolWorkingDirectory = m_rootPath;
+		if (!custom_main_file.empty && !custom_main_file.absolute) custom_main_file = m_rootPath ~ custom_main_file;
 
 		const test_config = m_project.addTestRunnerConfiguration(settings, !m_dryRun, config, custom_main_file);
 		if (!test_config) return; // target type "none"
@@ -760,6 +764,9 @@ class Dub {
 	{
 		import std.stdio;
 		import std.ascii : newline;
+
+		if (settings.overrideToolWorkingDirectory is NativePath.init)
+			settings.overrideToolWorkingDirectory = m_rootPath;
 
 		// Split comma-separated lists
 		string[] requestedDataSplit =
@@ -1313,8 +1320,8 @@ class Dub {
 
 		if (!run) {
 			// TODO: ddox should copy those files itself
-			version(Windows) runCommand(`xcopy /S /D "`~tool_path~`public\*" docs\`);
-			else runCommand("rsync -ru '"~tool_path~"public/' docs/");
+			version(Windows) runCommand(`xcopy /S /D "`~tool_path~`public\*" docs\`, null, m_rootPath.toNativeString());
+			else runCommand("rsync -ru '"~tool_path~"public/' docs/", null, m_rootPath.toNativeString());
 		}
 	}
 
@@ -1369,6 +1376,7 @@ class Dub {
 		if (this.defaultPostRunEnvironments)
 			settings.buildSettings.addPostRunEnvironments(this.defaultPostRunEnvironments);
 		settings.run = true;
+		settings.overrideToolWorkingDirectory = m_rootPath;
 
 		return settings;
 	}
@@ -1887,7 +1895,7 @@ private struct SpecialDirs {
 			result.systemSettings = NativePath("/var/lib/dub/");
 			result.userSettings = NativePath(environment.get("HOME")) ~ ".dub/";
 			if (!result.userSettings.absolute)
-				result.userSettings = NativePath(getcwd()) ~ result.userSettings;
+				result.userSettings = getWorkingDirectory() ~ result.userSettings;
 			result.userPackages = result.userSettings;
 		}
 		result.cache = result.userPackages ~ "cache";

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -203,7 +203,7 @@ class BuildGenerator : ProjectGenerator {
 	{
 		import std.path : absolutePath;
 
-		auto cwd = NativePath(getcwd());
+		auto cwd = settings.toolWorkingDirectory;
 		bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
 		auto build_id = buildsettings.computeBuildID(config, settings);
@@ -233,7 +233,9 @@ class BuildGenerator : ProjectGenerator {
 		if (!cached && buildsettings.postBuildCommands.length) {
 			logInfo("Post-build", Color.light_green, "Running commands");
 			runBuildCommands(CommandType.postBuild, buildsettings.postBuildCommands, pack, m_project, settings, buildsettings,
-							 [["DUB_BUILD_PATH" : target_path is NativePath.init ? "" : target_path.parentPath.toNativeString.absolutePath]]);
+							[["DUB_BUILD_PATH" : target_path is NativePath.init
+								? ""
+								: target_path.parentPath.toNativeString.absolutePath(settings.toolWorkingDirectory.toNativeString)]]);
 		}
 
 		return cached;
@@ -242,7 +244,7 @@ class BuildGenerator : ProjectGenerator {
 	private bool performCachedBuild(GeneratorSettings settings, BuildSettings buildsettings, in Package pack, string config,
 		string build_id, in Package[] packages, in NativePath[] additional_dep_files, out NativePath target_binary_path)
 	{
-		auto cwd = NativePath(getcwd());
+		auto cwd = settings.toolWorkingDirectory;
 
 		NativePath target_path;
 		if (settings.tempBuild) {
@@ -290,7 +292,7 @@ class BuildGenerator : ProjectGenerator {
 
 	private void performRDMDBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out NativePath target_path)
 	{
-		auto cwd = NativePath(getcwd());
+		auto cwd = settings.toolWorkingDirectory;
 		//Added check for existence of [AppNameInPackagejson].d
 		//If exists, use that as the starting file.
 		NativePath mainsrc;
@@ -335,14 +337,14 @@ class BuildGenerator : ProjectGenerator {
 
 		if (buildsettings.preBuildCommands.length){
 			logInfo("Pre-build", Color.light_green, "Running commands");
-			runCommands(buildsettings.preBuildCommands);
+			runCommands(buildsettings.preBuildCommands, null, cwd.toNativeString());
 		}
 
 		logInfo("Building", Color.light_green, "%s %s [%s]", pack.name.color(Mode.bold), pack.version_, config.color(Color.blue));
 
 		logInfo("Running rdmd...");
 		logDiagnostic("rdmd %s", join(flags, " "));
-		auto rdmd_pid = spawnProcess("rdmd" ~ flags);
+		auto rdmd_pid = spawnProcess("rdmd" ~ flags, null, Config.none, cwd.toNativeString());
 		auto result = rdmd_pid.wait();
 		enforce(result == 0, "Build command failed with exit code "~to!string(result));
 
@@ -355,7 +357,7 @@ class BuildGenerator : ProjectGenerator {
 
 	private void performDirectBuild(GeneratorSettings settings, ref BuildSettings buildsettings, in Package pack, string config, out NativePath target_path)
 	{
-		auto cwd = NativePath(getcwd());
+		auto cwd = settings.toolWorkingDirectory;
 		auto generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
 		// make file paths relative to shrink the command line
@@ -483,13 +485,19 @@ class BuildGenerator : ProjectGenerator {
 	/// Output an unique name to represent the source file.
 	/// Calls with path that resolve to the same file on the filesystem will return the same,
 	/// unless they include different symbolic links (which are not resolved).
-
+	deprecated("Use the overload taking in the current working directory")
 	static string pathToObjName(const scope ref BuildPlatform platform, string path)
+	{
+		return pathToObjName(platform, path, getWorkingDirectory);
+	}
+
+	/// ditto
+	static string pathToObjName(const scope ref BuildPlatform platform, string path, NativePath cwd)
 	{
 		import std.digest.crc : crc32Of;
 		import std.path : buildNormalizedPath, dirSeparator, relativePath, stripDrive;
 		if (path.endsWith(".d")) path = path[0 .. $-2];
-		auto ret = buildNormalizedPath(getcwd(), path).replace(dirSeparator, ".");
+		auto ret = buildNormalizedPath(cwd.toNativeString(), path).replace(dirSeparator, ".");
 		auto idx = ret.lastIndexOf('.');
 		const objSuffix = getObjSuffix(platform);
 		return idx < 0 ? ret ~ objSuffix : format("%s_%(%02x%)%s", ret[idx+1 .. $], crc32Of(ret[0 .. idx]), objSuffix);
@@ -505,7 +513,7 @@ class BuildGenerator : ProjectGenerator {
 		bs.targetType = TargetType.object;
 		gs.compiler.prepareBuildSettings(bs, gs.platform, BuildSetting.commandLine);
 		gs.compiler.setTarget(bs, gs.platform, objPath);
-		gs.compiler.invoke(bs, gs.platform, gs.compileCallback);
+		gs.compiler.invoke(bs, gs.platform, gs.compileCallback, gs.toolWorkingDirectory);
 		return objPath;
 	}
 
@@ -529,7 +537,7 @@ class BuildGenerator : ProjectGenerator {
 
 			void compileSource(size_t i, string src) {
 				logInfo("Compiling", Color.light_green, "%s", src);
-				const objPath = pathToObjName(settings.platform, src);
+				const objPath = pathToObjName(settings.platform, src, settings.toolWorkingDirectory);
 				objs[i] = compileUnit(src, objPath, buildsettings, settings);
 			}
 
@@ -543,7 +551,7 @@ class BuildGenerator : ProjectGenerator {
 			lbuildsettings.sourceFiles = is_static_library ? [] : lbuildsettings.sourceFiles.filter!(f => isLinkerFile(settings.platform, f)).array;
 			settings.compiler.setTarget(lbuildsettings, settings.platform);
 			settings.compiler.prepareBuildSettings(lbuildsettings, settings.platform, BuildSetting.commandLineSeparate|BuildSetting.sourceFiles);
-			settings.compiler.invokeLinker(lbuildsettings, settings.platform, objs, settings.linkCallback);
+			settings.compiler.invokeLinker(lbuildsettings, settings.platform, objs, settings.linkCallback, settings.toolWorkingDirectory);
 
 		// NOTE: separate compile/link is not yet enabled for GDC.
 		} else if (generate_binary && (settings.buildMode == BuildMode.allAtOnce || settings.compiler.name == "gdc" || is_static_library)) {
@@ -555,7 +563,7 @@ class BuildGenerator : ProjectGenerator {
 			settings.compiler.prepareBuildSettings(buildsettings, settings.platform, BuildSetting.commandLine);
 
 			// invoke the compiler
-			settings.compiler.invoke(buildsettings, settings.platform, settings.compileCallback);
+			settings.compiler.invoke(buildsettings, settings.platform, settings.compileCallback, settings.toolWorkingDirectory);
 		} else {
 			// determine path for the temporary object file
 			string tempobjname = buildsettings.targetName ~ getObjSuffix(settings.platform);
@@ -575,7 +583,7 @@ class BuildGenerator : ProjectGenerator {
 
 			settings.compiler.prepareBuildSettings(buildsettings, settings.platform, BuildSetting.commandLine);
 
-			settings.compiler.invoke(buildsettings, settings.platform, settings.compileCallback);
+			settings.compiler.invoke(buildsettings, settings.platform, settings.compileCallback, settings.toolWorkingDirectory);
 
 			if (generate_binary) {
 				if (settings.tempBuild) {
@@ -583,7 +591,7 @@ class BuildGenerator : ProjectGenerator {
 				} else {
 					logInfo("Linking", Color.light_green, "%s", buildsettings.targetName.color(Mode.bold));
 				}
-				settings.compiler.invokeLinker(lbuildsettings, settings.platform, [tempobj.toNativeString()], settings.linkCallback);
+				settings.compiler.invokeLinker(lbuildsettings, settings.platform, [tempobj.toNativeString()], settings.linkCallback, settings.toolWorkingDirectory);
 			}
 		}
 	}
@@ -591,7 +599,7 @@ class BuildGenerator : ProjectGenerator {
 	private void runTarget(NativePath exe_file_path, in BuildSettings buildsettings, string[] run_args, GeneratorSettings settings)
 	{
 		if (buildsettings.targetType == TargetType.executable) {
-			auto cwd = NativePath(getcwd());
+			auto cwd = settings.toolWorkingDirectory;
 			auto runcwd = cwd;
 			if (buildsettings.workingDirectory.length) {
 				runcwd = NativePath(buildsettings.workingDirectory);
@@ -737,10 +745,10 @@ unittest { // issue #1235 - pass no library files to compiler command line when 
 	auto prj = new Project(pman, pack);
 
 	final static class TestCompiler : GDCCompiler {
-		override void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback) {
+		override void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback, NativePath cwd) {
 			assert(!settings.dflags[].any!(f => f.canFind("bar")));
 		}
-		override void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback) {
+		override void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback, NativePath cwd) {
 			assert(false);
 		}
 	}

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -806,6 +806,7 @@ struct GeneratorSettings {
 	BuildSettings buildSettings;
 	BuildMode buildMode = BuildMode.separate;
 	int targetExitStatus;
+	NativePath overrideToolWorkingDirectory;
 
 	bool combined; // compile all in one go instead of each dependency separately
 	bool filterVersions;
@@ -820,6 +821,16 @@ struct GeneratorSettings {
 	void delegate(int status, string output) compileCallback;
 	void delegate(int status, string output) linkCallback;
 	void delegate(int status, string output) runCallback;
+
+	/// Returns `overrideToolWorkingDirectory` or if that's not set, just the
+	/// current working directory of the application. This may differ if dub is
+	/// called with the `--root` parameter or when using DUB as a library.
+	NativePath toolWorkingDirectory() const
+	{
+		return overrideToolWorkingDirectory is NativePath.init
+			? getWorkingDirectory()
+			: overrideToolWorkingDirectory;
+	}
 }
 
 
@@ -1167,10 +1178,10 @@ version(Posix) {
 		auto prj = new Project(pman, pack);
 
 		final static class TestCompiler : GDCCompiler {
-			override void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback) {
+			override void invoke(in BuildSettings settings, in BuildPlatform platform, void delegate(int, string) output_callback, NativePath cwd) {
 				assert(false);
 			}
-			override void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback) {
+			override void invokeLinker(in BuildSettings settings, in BuildPlatform platform, string[] objects, void delegate(int, string) output_callback, NativePath cwd) {
 				assert(false);
 			}
 		}

--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -34,7 +34,7 @@ class SublimeTextGenerator : ProjectGenerator {
 
 		auto root = Json([
 			"folders": targets.byValue.map!(f => targetFolderJson(f)).array.Json,
-			"build_systems": buildSystems(settings.platform),
+			"build_systems": buildSystems(settings.platform, settings.toolWorkingDirectory.toNativeString()),
 			"settings": [ "include_paths": buildSettings.importPaths.map!Json.array.Json ].Json,
 		]);
 
@@ -61,7 +61,7 @@ private Json targetFolderJson(in ProjectGenerator.TargetInfo target)
 }
 
 
-private Json buildSystems(BuildPlatform buildPlatform, string workingDiretory = getcwd())
+private Json buildSystems(BuildPlatform buildPlatform, string workingDiretory)
 {
 	static immutable BUILD_TYPES = [
 		//"plain",
@@ -123,5 +123,5 @@ unittest
 	auto buildPlatform = BuildPlatform();
 	buildPlatform.architecture ~= "x86_64";
 
-	auto result = buildPlatform.buildSystems.toString;
+	auto result = buildPlatform.buildSystems(getcwd()).toString;
 }

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -183,7 +183,7 @@ class VisualDGenerator : ProjectGenerator {
 				auto sp = NativePath(s);
 				assert(sp.absolute, format("Source path in %s expected to be absolute: %s", packname, s));
 				//if( !sp.absolute ) sp = pack.path ~ sp;
-				addSourceFile(sp.relativeTo(getWorkingDirectory() ~ basepath), determineStructurePath(sp, targets[packname]), action);
+				addSourceFile(sp.relativeTo(settings.toolWorkingDirectory ~ basepath), determineStructurePath(sp, targets[packname]), action);
 			}
 
 			foreach (p; targets[packname].packages)
@@ -245,6 +245,7 @@ class VisualDGenerator : ProjectGenerator {
 
 		void generateProjectConfiguration(Appender!(char[]) ret, string pack, string type, GeneratorSettings settings, in TargetInfo[string] targets)
 		{
+			auto cwd = settings.toolWorkingDirectory;
 			auto buildsettings = targets[pack].buildSettings.dup;
 			auto basepath = NativePath(".dub/");
 
@@ -255,7 +256,7 @@ class VisualDGenerator : ProjectGenerator {
 				auto ret = new string[settings.length];
 				foreach (i; 0 .. settings.length) {
 					// \" is interpreted as an escaped " by cmd.exe, so we need to avoid that
-					auto p = NativePath(settings[i]).relativeTo(getWorkingDirectory() ~ basepath);
+					auto p = NativePath(settings[i]).relativeTo(cwd ~ basepath);
 					p.endsWithSlash = false;
 					ret[i] = '"' ~ p.toNativeString() ~ '"';
 				}
@@ -328,7 +329,7 @@ class VisualDGenerator : ProjectGenerator {
 				// compute directory for intermediate files (need dummy/ because of how -op determines the resulting path)
 				size_t ndummy = 0;
 				foreach (f; buildsettings.sourceFiles) {
-					auto rpath = NativePath(f).relativeTo(getWorkingDirectory() ~ basepath);
+					auto rpath = NativePath(f).relativeTo(cwd ~ basepath);
 					size_t nd = 0;
 					foreach (s; rpath.bySegment)
 						if (s == "..")
@@ -423,7 +424,7 @@ class VisualDGenerator : ProjectGenerator {
 				auto wdir = NativePath(buildsettings.workingDirectory);
 				if (!wdir.absolute) wdir = m_project.rootPackage.path ~ wdir;
 				ret.formattedWrite("    <debugworkingdir>%s</debugworkingdir>\n",
-					wdir.relativeTo(getWorkingDirectory() ~ basepath).toNativeString());
+					wdir.relativeTo(cwd ~ basepath).toNativeString());
 				ret.put("    <preBuildCommand />\n");
 				ret.put("    <postBuildCommand />\n");
 				ret.put("    <filesToClean>*.obj;*.cmd;*.build;*.dep</filesToClean>\n");

--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -16,7 +16,7 @@ import dub.dependency;
 import std.exception;
 import std.file;
 import std.format;
-import std.process;
+import std.process : environment;
 import std.string;
 
 

--- a/source/dub/internal/temp_files.d
+++ b/source/dub/internal/temp_files.d
@@ -1,0 +1,45 @@
+/**
+	Provides methods to generate temporary file names and folders and
+	automatically clean them up on program exit.
+
+	Copyright: © 2012 Matthias Dondorff, © 2012-2023 Sönke Ludwig
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Matthias Dondorff, Sönke Ludwig, Jan Jurzitza
+*/
+module dub.internal.temp_files;
+
+import std.file;
+
+import dub.internal.vibecompat.core.file;
+
+NativePath getTempDir()
+{
+	return NativePath(std.file.tempDir());
+}
+
+NativePath getTempFile(string prefix, string extension = null)
+{
+	import std.uuid : randomUUID;
+	import std.array: replace;
+
+	string fileName = prefix ~ "-" ~ randomUUID.toString() ~ extension;
+
+	if (extension !is null && extension == ".d")
+		fileName = fileName.replace("-", "_");
+
+	auto path = getTempDir() ~ fileName;
+	temporary_files ~= path;
+	return path;
+}
+
+private NativePath[] temporary_files;
+
+static ~this()
+{
+	foreach (path; temporary_files)
+	{
+		auto spath = path.toNativeString();
+		if (spath.exists)
+			std.file.remove(spath);
+	}
+}

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -30,28 +30,7 @@ version(DubUseCurl)
 	public import std.net.curl : HTTPStatusException;
 }
 
-
-private NativePath[] temporary_files;
-
-NativePath getTempDir()
-{
-	return NativePath(std.file.tempDir());
-}
-
-NativePath getTempFile(string prefix, string extension = null)
-{
-	import std.uuid : randomUUID;
-	import std.array: replace;
-
-	string fileName = prefix ~ "-" ~ randomUUID.toString() ~ extension;
-
-	if (extension !is null && extension == ".d")
-		fileName = fileName.replace("-", "_");
-
-	auto path = getTempDir() ~ fileName;
-	temporary_files ~= path;
-	return path;
-}
+public import dub.internal.temp_files;
 
 /**
  * Obtain a lock for a file at the given path.
@@ -96,16 +75,6 @@ auto lockFile(string path, Duration timeout)
 		if (dur < 1024.msecs) // exponentially increase sleep time
 			dur *= 2;
 		Thread.sleep(dur);
-	}
-}
-
-static ~this()
-{
-	foreach (path; temporary_files)
-	{
-		auto spath = path.toNativeString();
-		if (spath.exists)
-			std.file.remove(spath);
 	}
 }
 

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -145,12 +145,24 @@ void atomicWriteJsonFile(NativePath path, Json json)
 	moveFile(tmppath, path);
 }
 
-void runCommand(string command, string[string] env = null, string workDir = null)
+deprecated("specify a working directory explicitly")
+void runCommand(string command, string[string] env = null)
+{
+	runCommands((&command)[0 .. 1], env, null);
+}
+
+void runCommand(string command, string[string] env, string workDir)
 {
 	runCommands((&command)[0 .. 1], env, workDir);
 }
 
-void runCommands(in string[] commands, string[string] env = null, string workDir = null)
+deprecated("specify a working directory explicitly")
+void runCommands(in string[] commands, string[string] env = null)
+{
+	runCommands(commands, env, null);
+}
+
+void runCommands(in string[] commands, string[string] env, string workDir)
 {
 	import std.stdio : stdin, stdout, stderr, File;
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -418,7 +418,7 @@ class Package {
 	*/
 	void addBuildTypeSettings(ref BuildSettings settings, in BuildPlatform platform, string build_type)
 	const {
-		import std.process;
+		import std.process : environment;
 		string dflags = environment.get("DFLAGS", "");
 		settings.addDFlags(dflags.split());
 

--- a/test/dub-as-a-library-cwd.sh
+++ b/test/dub-as-a-library-cwd.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+$DUB --root="$CURR_DIR/dub-as-a-library-cwd"

--- a/test/dub-as-a-library-cwd/.gitignore
+++ b/test/dub-as-a-library-cwd/.gitignore
@@ -1,0 +1,1 @@
+/dub-as-a-library-cwd

--- a/test/dub-as-a-library-cwd/dub.json
+++ b/test/dub-as-a-library-cwd/dub.json
@@ -1,0 +1,8 @@
+{
+	"name": "dub-as-a-library-cwd",
+	"dependencies": {
+		"dub": {
+			"path": "../.."
+		}
+	}
+}

--- a/test/dub-as-a-library-cwd/source/app.d
+++ b/test/dub-as-a-library-cwd/source/app.d
@@ -1,0 +1,45 @@
+import dub.compilers.buildsettings;
+import dub.compilers.compiler;
+import dub.dub;
+import dub.generators.generator;
+import dub.internal.vibecompat.inet.path;
+import std.algorithm;
+import std.file;
+import std.path;
+import std.stdio;
+
+void main(string[] args)
+{
+	auto project = buildNormalizedPath(getcwd, "subproject");
+	chdir(buildNormalizedPath(getcwd, ".."));
+
+	bool found;
+
+	auto dub = new Dub(project, null, SkipPackageSuppliers.none);
+	dub.packageManager.getOrLoadPackage(NativePath(project));
+	dub.loadPackage();
+	dub.project.validate();
+
+	GeneratorSettings gs;
+	gs.buildType = "debug";
+	gs.config = "application";
+	gs.compiler = getCompiler(dub.defaultCompiler);
+	gs.run = false;
+	gs.force = true;
+	gs.tempBuild = true;
+	gs.platform = gs.compiler.determinePlatform(gs.buildSettings,
+		dub.defaultCompiler, dub.defaultArchitecture);
+
+	gs.compileCallback = (status, output) {
+		found = output.canFind("FIND_THIS_STRING");
+		if (!found)
+			stderr.writeln("Did not find required string!\nExit status:",
+				status, "\n\nOutput:\n", output);
+	};
+
+	stderr.writeln("Checking if building works from a library in a different cwd:");
+	dub.generateProject("build", gs);
+	stderr.writeln("Success: ", found);
+
+	assert(found);
+}

--- a/test/dub-as-a-library-cwd/subproject/dub.sdl
+++ b/test/dub-as-a-library-cwd/subproject/dub.sdl
@@ -1,0 +1,1 @@
+name "subproject"

--- a/test/dub-as-a-library-cwd/subproject/source/app.d
+++ b/test/dub-as-a-library-cwd/subproject/source/app.d
@@ -1,0 +1,11 @@
+module app;
+
+deprecated("FIND_THIS_STRING")
+void foo()
+{
+}
+
+void main(string[] args)
+{
+	foo();
+}


### PR DESCRIPTION
first commit was needed, because introducing the getWorkingDirectory function call in some module here started actually using the symbols from dub.internal.utils it seems. I'm not sure why it didn't trigger before, but it was an issue for me. I just moved the module destructor that cleans up temporary files into a separate module to work around this.

I changed all path concatenation with getcwd and getWorkingDirectory, all spawnProcess/execute calls and some affected dirEntries calls to use a "toolWorkingDirectory" from `GeneratorSettings`.

This affects the compiler and the linker, but also minor things such as the ddox tool or `dub lint`.

This change allows serve-d to always build correctly without needing to chdir the entire application's working directory. (which I can't do, because I have multiple dub instances that may even build in parallel + there were issues that relative paths weren't generated properly)