### PR TITLE
PackageManager: Don't use deprecated interface to PackageOverride

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -234,7 +234,7 @@ class PackageManager {
 						ovr.target.match!(
 							(any) {
 								logWarn("Package override %s %s -> '%s' doesn't reference an existing package.",
-										ovr.package_, ovr.version_, any);
+										ovr.package_, ovr.source, any);
 							},
 						);
 					}


### PR DESCRIPTION
This should trigger a deprecation message with DMD, but doesn't. On the other hand, it triggers a linker error on GDC.

Related to #2577 
@ximion : Could you test this ?