### PR TITLE
make build names much smaller

### DIFF
--- a/test/issue2051_running_unittests_from_dub_single_file_packages_fails.d
+++ b/test/issue2051_running_unittests_from_dub_single_file_packages_fails.d
@@ -1,5 +1,5 @@
 /+ dub.sdl:
-   name "issue2051_running_unittests_from_dub_single_file_packages_fails"
+   name "issue2051"
  +/
 
 import std.algorithm : any;

--- a/test/removed-dub-obj.sh
+++ b/test/removed-dub-obj.sh
@@ -12,9 +12,9 @@ ${DUB} build --compiler=${DC}
 [ -d "$DUB_CACHE_PATH/obj" ] && die $LINENO "$DUB_CACHE_PATH/obj was found"
 
 if [[ ${DC} == *"ldc"* ]]; then
-    if [ ! -f $DUB_CACHE_PATH/~master/build/library-*ldc*/obj/test.o* ]; then
+    if [ ! -f $DUB_CACHE_PATH/~master/build/library-*/obj/test.o* ]; then
         ls -lR $DUB_CACHE_PATH
-        die $LINENO '$DUB_CACHE_PATH/~master/build/library-*ldc*/obj/test.o* was not found'
+        die $LINENO '$DUB_CACHE_PATH/~master/build/library-*/obj/test.o* was not found'
     fi
 fi
 


### PR DESCRIPTION
Should fix windows path name limitations in most cases (unless your package name is very long)

Should improve verbose log output / the linker line in regular output + debugging paths in broken builds and compiler invocations.

In the unittest we just pick a smaller name to fix the windows test runner.

Moved platforms (linux.posix) + architecture (x86_64) + compiler (dmd_v2.102.0) out of the filename into the hash. While they may be interesting, I think, especially architecture and such, are rather internal. So I decided to un-expose those in the filenames.

From the sha256 we only take half the hash now (should be plenty of bytes still) + instead of hex strings, which are 200% of byte size, we use base64 (url, with padding removed), which is only 133% of byte size.

Sample in naming changes:

```
/home/webfreak/.dub/cache/PACKAGE_NAME/~master/build/application-debug-linux.posix-x86_64-dmd_v2.102.0-D95E91464418B72BDBF518DAA90BF13D4018E81A07B52C64F0C5EB6A60977D58/TARGET_NAME
->
/home/webfreak/.dub/cache/PACKAGE_NAME/~master/build/application-debug-aCpueoVTBosJsJSHQ-aldQ/TARGET_NAME
```

@Geod24 do you think this is a breaking change? I think at least the checksum could be halfed in length without incompatibilities.