### PR TITLE
Fix #2574: Suggest alternative spelling when a command is mistyped

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -465,6 +465,8 @@ int runDubCommandLine(string[] args)
 	}
 
 	if (cmd is null) {
+		logInfoNoTag("USAGE: dub [--version] [<command>] [<options...>] [-- [<application arguments...>]]");
+		writeln();
 		logError("Unknown command: %s", command_name_argument.value);
 		import std.algorithm.iteration : filter;
 		import std.uni : toUpper;

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -466,7 +466,7 @@ int runDubCommandLine(string[] args)
 
 	if (cmd is null) {
 		logInfoNoTag("USAGE: dub [--version] [<command>] [<options...>] [-- [<application arguments...>]]");
-		logInfoNoTag();
+		logInfoNoTag("");
 		logError("Unknown command: %s", command_name_argument.value);
 		import std.algorithm.iteration : filter;
 		import std.uni : toUpper;
@@ -480,7 +480,7 @@ int runDubCommandLine(string[] args)
 			}
 		}
 
-		logInfoNoTag();
+		logInfoNoTag("");
 		return 1;
 	}
 

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -473,13 +473,12 @@ int runDubCommandLine(string[] args)
 			foreach (Command command; key.commands)
 			{
 				if (levenshteinDistance(command_name_argument.value, command.name) < 4) {
-					logInfo("Did you mean '%s'?", command.name);
+					logInfo("Did you mean '%s?", command.name);
 				}
 			}
 		}
 
 		writeln();
-		showHelp(handler.commandGroups, common_args);
 		return 1;
 	}
 

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -466,7 +466,7 @@ int runDubCommandLine(string[] args)
 
 	if (cmd is null) {
 		logInfoNoTag("USAGE: dub [--version] [<command>] [<options...>] [-- [<application arguments...>]]");
-		writeln();
+		logInfoNoTag();
 		logError("Unknown command: %s", command_name_argument.value);
 		import std.algorithm.iteration : filter;
 		import std.uni : toUpper;
@@ -480,7 +480,7 @@ int runDubCommandLine(string[] args)
 			}
 		}
 
-		writeln();
+		logInfoNoTag();
 		return 1;
 	}
 

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -473,7 +473,7 @@ int runDubCommandLine(string[] args)
 			foreach (Command command; key.commands)
 			{
 				if (levenshteinDistance(command_name_argument.value, command.name) < 4) {
-					logInfo("Did you mean '%s?", command.name);
+					logInfo("Did you mean '%s'?", command.name);
 				}
 			}
 		}

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -466,6 +466,18 @@ int runDubCommandLine(string[] args)
 
 	if (cmd is null) {
 		logError("Unknown command: %s", command_name_argument.value);
+		import std.algorithm.iteration : filter;
+		import std.uni : toUpper;
+		foreach (CommandGroup key; handler.commandGroups)
+		{
+			foreach (Command command; key.commands)
+			{
+				if (levenshteinDistance(command_name_argument.value, command.name) < 4) {
+					logInfo("Did you mean '%s'?", command.name);
+				}
+			}
+		}
+
 		writeln();
 		showHelp(handler.commandGroups, common_args);
 		return 1;

--- a/test/issue2574-mistyping-commands.sh
+++ b/test/issue2574-mistyping-commands.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+$DUB upfrade 2>&1 >/dev/null && die $LINENO '"dub upfrade" should not succeed'
+
+if [ "$($DUB upfrade 2>&1 | grep -Fc "Unknown command: upfrade")" != "1" ]; then
+	die $LINENO 'Missing Unknown command line'
+fi
+
+if [ "$($DUB upfrade 2>&1 | grep -Fc "Did you mean 'upgrade'?")" != "1" ]; then
+	die $LINENO 'Missing upgrade suggestion'
+fi
+
+if [ "$($DUB upfrade 2>&1 | grep -Fc "build")" != "0" ]; then
+	die $LINENO 'Did not expect to see build as a suggestion and did not want a full list of commands'
+fi


### PR DESCRIPTION
Suggesting similar command names