### PR TITLE
Make getDUBExePath returns a NativePath

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -1053,7 +1053,7 @@ const(string[string])[] makeCommandEnvironmentVariables(CommandType type,
 	env["DC_BASE"]               = settings.platform.compiler;
 	env["D_FRONTEND_VER"]        = to!string(settings.platform.frontendVersion);
 
-	env["DUB_EXE"]               = getDUBExePath(settings.platform.compilerBinary);
+	env["DUB_EXE"]               = getDUBExePath(settings.platform.compilerBinary).toNativeString();
 	env["DUB_PLATFORM"]          = join(settings.platform.platform, " ");
 	env["DUB_ARCH"]              = join(settings.platform.architecture, " ");
 

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -381,11 +381,11 @@ string getDUBVersion()
 	Throws:
 		an Exception if no valid DUB executable is found
 */
-public string getDUBExePath(in string compilerBinary=null)
+public NativePath getDUBExePath(in string compilerBinary=null)
 {
 	version(DubApplication) {
 		import std.file : thisExePath;
-		return thisExePath();
+		return NativePath(thisExePath());
 	}
 	else {
 		// this must be dub as a library
@@ -418,7 +418,7 @@ public string getDUBExePath(in string compilerBinary=null)
 		.filter!exists;
 
 		enforce(!dubLocs.empty, "Could not find DUB executable");
-		return dubLocs.front.array;
+		return NativePath(dubLocs.front.array);
 	}
 }
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1569,7 +1569,7 @@ private string getVariable(Project, Package)(string name, in Project project, in
 	}
 
 	if (name == "DUB") {
-		return getDUBExePath(gsettings.platform.compilerBinary);
+		return getDUBExePath(gsettings.platform.compilerBinary).toNativeString();
 	}
 
 	if (name == "ARCH") {


### PR DESCRIPTION
Fairly simple diff. Trying to reduce dependency on string being used for paths.
Note that no deprecation is necessary here, as this is an internal function (`dub.internal.utils : getDUBExePath`).