### PR TITLE
Improve dub build times

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -686,9 +686,9 @@ class ProjectGenerator
 				ti.pack.path ~ ".dub/metadata_cache.json", e);
 		}
 
-		// use ctRegex for performance reasons, only small compile time increase
-		enum verRE = ctRegex!`(?:^|\s)version\s*\(\s*([^\s]*?)\s*\)`;
-		enum debVerRE = ctRegex!`(?:^|\s)debug\s*\(\s*([^\s]*?)\s*\)`;
+		// force RT, due to CT costs being very noticable of std.regex
+		auto verRE = regex(`(?:^|\s)version\s*\(\s*([^\s]*?)\s*\)`);
+		auto debVerRE = regex(`(?:^|\s)debug\s*\(\s*([^\s]*?)\s*\)`);
 
 		auto versionFilters = appender!(string[]);
 		auto debugVersionFilters = appender!(string[]);


### PR DESCRIPTION
This is the only thing inside of dub itself that could improve build times that I have found so far.

I'll wait on ldc's --ftime-trace improvements that include CTFE before looking into this again.

https://github.com/ldc-developers/ldc/pull/4339

Other improvements needed to improve build times: https://github.com/dlang-community/D-YAML/pull/314