### PR TITLE
Don't depend on the whole of Vibe.d for the test_registry

### DIFF
--- a/test/test_registry.d
+++ b/test/test_registry.d
@@ -1,10 +1,16 @@
 #!/usr/bin/env dub
 /+dub.sdl:
-dependency "vibe-d" version="~>0.9"
+dependency "vibe-d:http" version="~>0.9"
 versions "VibeNoSSL"
 +/
 
-import vibe.d;
+import std.array;
+import vibe.core.args;
+import vibe.core.core;
+import vibe.core.path;
+import vibe.http.fileserver;
+import vibe.http.router;
+import vibe.http.server;
 
 /*
 Provide a special API File Handler as Vibe.d's builtin serveStaticFiles


### PR DESCRIPTION
Makes the code a bit more verbose, but remove the dependency to vibe-d:mongodb, which happens to be the one currently failing on master.