### PR TITLE
try to fix pr_info permissions problem

### DIFF
--- a/.github/workflows/pr_info.yml
+++ b/.github/workflows/pr_info.yml
@@ -4,10 +4,16 @@ name: PR Info
 # - comments build deprecations/warnings (highlighting new ones since last tested PR)
 
 on:
-  pull_request:
+  # NOTE: high sensitivity, as GITHUB_TOKEN is in the context of the dub repository here and may do harm
+  # use just `pull_request` if you copy paste this elsewhere
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - master
       - stable
+  push:
+    branches:
+      - test-pr_info
 
 jobs:
   pr_info:
@@ -44,7 +50,7 @@ jobs:
     - name: Checkout old stuff, with new comment script
       run: |
         git checkout ${{ github.base_ref }}
-        git checkout ${{ github.sha }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
+        git checkout ${{ github.base_ref }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
 
     # first dump old info
 
@@ -53,9 +59,10 @@ jobs:
 
     - name: Checkout PR target
       run: |
-        git checkout ${{ github.sha }}
+        git checkout ${{ github.head_ref }}
         git clean -fd
         git reset --hard
+        git checkout ${{ github.base_ref }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
 
     - name: Evaluate PR
       run: ./scripts/ci/summary_comment.sh | tee ../NEW_OUTPUT.txt

--- a/.github/workflows/pr_info_intro.yml
+++ b/.github/workflows/pr_info_intro.yml
@@ -1,0 +1,25 @@
+name: PR Info (pre-comment)
+
+on:
+  # NOTE: high probability for security vulnerabilities if doing ANYTHING in
+  # this file other than commenting something!
+  pull_request_target:
+    branches:
+      - master
+      - stable
+
+jobs:
+  intro_comment:
+    name: Make intro comment
+    runs-on: ubuntu-20.04
+    steps:
+    - name: 'Prepare sticky comment'
+      # commit of v2.5.0
+      # same one used again at the bottom of the file to update the comment.
+      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+      with:
+        message: |
+          Thanks for your Pull Request and making D better!
+
+          This comment will automatically be updated to summarize some statistics in a few minutes.
+        only_create: true

--- a/.github/workflows/pr_info_post.yml
+++ b/.github/workflows/pr_info_post.yml
@@ -1,0 +1,49 @@
+name: PR Info (comment)
+
+on:
+  workflow_run:
+    workflows: ["PR Info"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: PR Info
+    runs-on: ubuntu-20.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+    # from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    - name: 'Download artifact'
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: matchArtifact.id,
+            archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+    - run: unzip pr.zip
+
+    - name: Set variable
+      run: |
+        PR_ID=$(cat ./pr/NR)
+        echo "PR_ID=$PR_ID" >> $GITHUB_ENV
+
+    - name: Update GitHub comment
+      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+      with:
+        path: pr/comment.txt
+        number: ${{ env.PR_ID }}

--- a/.github/workflows/pr_info_untrusted.yml
+++ b/.github/workflows/pr_info_untrusted.yml
@@ -4,32 +4,18 @@ name: PR Info
 # - comments build deprecations/warnings (highlighting new ones since last tested PR)
 
 on:
-  # NOTE: high sensitivity, as GITHUB_TOKEN is in the context of the dub repository here and may do harm
-  # use just `pull_request` if you copy paste this elsewhere
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
     branches:
       - master
       - stable
-  push:
-    branches:
-      - test-pr_info
 
 jobs:
   pr_info:
     name: PR Info
     runs-on: ubuntu-20.04
     steps:
-    - name: 'Prepare sticky comment'
-      # commit of v2.5.0
-      # same one used again at the bottom of the file to update the comment.
-      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
-      with:
-        message: |
-          Thanks for your Pull Request and making D better!
-
-          This comment will automatically be updated to summarize some statistics in a few minutes.
-        only_create: true
+    # we first create a comment thanking the user in pr_info_intro.yml
+    # (separate step due to needing GITHUB_TOKEN access)
 
     - name: '[Linux] Install dependencies'
       if: runner.os == 'Linux'
@@ -50,7 +36,7 @@ jobs:
     - name: Checkout old stuff, with new comment script
       run: |
         git checkout ${{ github.base_ref }}
-        git checkout ${{ github.base_ref }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
+        git checkout ${{ github.sha }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
 
     # first dump old info
 
@@ -59,10 +45,9 @@ jobs:
 
     - name: Checkout PR target
       run: |
-        git checkout ${{ github.head_ref }}
+        git checkout ${{ github.sha }}
         git clean -fd
         git reset --hard
-        git checkout ${{ github.base_ref }} -- ./scripts/ci/summary_comment.sh ./scripts/ci/summary_comment_diff.sh
 
     - name: Evaluate PR
       run: ./scripts/ci/summary_comment.sh | tee ../NEW_OUTPUT.txt
@@ -70,7 +55,14 @@ jobs:
     - name: Generate comment
       run: ./scripts/ci/summary_comment_diff.sh ../OLD_OUTPUT.txt ../NEW_OUTPUT.txt | tee comment.txt
 
-    - name: Update GitHub comment
-      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+    - name: Prepare comment for upload
+      run: |
+        mkdir -p ./pr
+        mv comment.txt pr
+        echo ${{ github.event.number }} > ./pr/NR
+
+    - name: upload comment to high-trust action making the comment
+      uses: actions/upload-artifact@v2
       with:
-        path: comment.txt
+        name: pr
+        path: pr/


### PR DESCRIPTION
cc @rikkimax 

turns out when people make PRs from other forks, the action also runs in their fork context there!

Using pull_request_target means we need to specially check that everything is correct to avoid that the token gets pwnd.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

I have also found a vulnerability that was in there before for testing, where it would load an updated script from the fork. This is now fixed and explicitly guarded against.