### PR TITLE
Cache json db

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1883,6 +1883,11 @@ private struct SpecialDirs {
 	 * project directory, but this led to issues with packages stored on
 	 * read-only file system / location, and lingering artifacts scattered
 	 * through the file system.
+	 *
+	 * Dub writes in the cache directory some Json description files
+	 * of the available artifacts. These files are intended to be read by
+	 * 3rd party software (e.g. Meson). The default cache location specified
+	 * in this function should therefore not change across future Dub versions.
 	 */
 	NativePath cache;
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -321,7 +321,7 @@ class BuildGenerator : ProjectGenerator {
 			db = Json.emptyArray;
 		}
 
-		foreach (entry; db) {
+		foreach_reverse (entry; db) {
 			if (entry["buildId"].get!string == build_id) {
 				// duplicate
 				return;

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -330,16 +330,17 @@ class BuildGenerator : ProjectGenerator {
 
 		Json entry = Json.emptyObject;
 
-		entry["package"] = pack.name;
-		entry["configuration"] = config;
+		entry["architecture"] = serializeToJson(settings.platform.architecture);
+		entry["buildId"] = build_id;
 		entry["buildType"] = settings.buildType;
 		entry["compiler"] = settings.platform.compiler;
-		entry["compilerVersion"] = settings.platform.compilerVersion;
 		entry["compilerBinary"] = settings.platform.compilerBinary;
-		entry["architecture"] = serializeToJson(settings.platform.architecture);
+		entry["compilerVersion"] = settings.platform.compilerVersion;
+		entry["configuration"] = config;
+		entry["package"] = pack.name;
 		entry["platform"] = serializeToJson(settings.platform.platform);
-		entry["buildId"] = build_id;
 		entry["targetBinaryPath"] = target_binary_path;
+		entry["version"] = pack.version_.toString();
 
 		db ~= entry;
 

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -320,6 +320,14 @@ class BuildGenerator : ProjectGenerator {
 		else {
 			db = Json.emptyArray;
 		}
+
+		foreach (entry; db) {
+			if (entry["buildId"].get!string == build_id) {
+				// duplicate
+				return;
+			}
+		}
+
 		Json entry = Json.emptyObject;
 
 		entry["package"] = pack.name;

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -299,12 +299,12 @@ class BuildGenerator : ProjectGenerator {
 		import dub.internal.vibecompat.data.json;
 		import core.time : seconds;
 
-		// Generate a `build-db.json` in the package version cache directory.
+		// Generate a `db.json` in the package version cache directory.
 		// This is read by 3rd party software (e.g. Meson) in order to find
 		// relevant build artifacts in Dub's cache.
 
-		enum jsonFileName = "build-db.json";
-		enum lockFileName = "build-db.lock";
+		enum jsonFileName = "db.json";
+		enum lockFileName = "db.lock";
 
 		const pkgCacheDir = packageCache(settings.cache, pack);
 		auto lock = lockFile((pkgCacheDir ~ lockFileName).toNativeString(), 3.seconds);

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -771,9 +771,15 @@ class ProjectGenerator
 /**
  * Compute and returns the path were artifacts are stored for a given package
  *
- * Artifacts are usually stored in:
+ * Artifacts are stored in:
  * `$DUB_HOME/cache/$PKG_NAME/$PKG_VERSION[/+$SUB_PKG_NAME]/`
  * Note that the leading `+` in the sub-package name is to avoid any ambiguity.
+ *
+ * Dub writes in the returned path a Json description file of the available
+ * artifacts in this cache location. This Json file is read by 3rd party
+ * software (e.g. Meson). Returned path should therefore not change across
+ * future Dub versions.
+ *
  * Build artifacts are usually stored in a sub-folder named "build",
  * as their names are based on user-supplied values.
  *

--- a/test/pr2642-cache-db/.gitignore
+++ b/test/pr2642-cache-db/.gitignore
@@ -1,0 +1,2 @@
+dubhome/
+pr2642-cache-db

--- a/test/pr2642-cache-db/dub.sdl
+++ b/test/pr2642-cache-db/dub.sdl
@@ -1,0 +1,2 @@
+name "pr2642-cache-db";
+targetType "executable";

--- a/test/pr2642-cache-db/source/test_cache_db.d
+++ b/test/pr2642-cache-db/source/test_cache_db.d
@@ -1,0 +1,78 @@
+module test_cache_db;
+
+import std.path;
+import std.file;
+import std.process;
+import std.stdio;
+import std.json;
+
+void main()
+{
+    const dubhome = __FILE_FULL_PATH__.dirName().dirName().buildNormalizedPath("dubhome");
+    if (exists(dubhome))
+    {
+        rmdirRecurse(dubhome);
+    }
+
+    const string[string] env = [
+        "DUB_HOME": dubhome,
+    ];
+    const fetchProgram = [
+        environment["DUB"],
+        "fetch",
+        "vibe-d@0.9.6",
+    ];
+    auto dubFetch = spawnProcess(fetchProgram, stdin, stdout, stderr, env);
+    wait(dubFetch);
+    const buildProgram = [
+        environment["DUB"],
+        "build",
+        "--build=debug",
+        "vibe-d:http@0.9.6",
+    ];
+    auto dubBuild = spawnProcess(buildProgram, stdin, stdout, stderr, env);
+    wait(dubBuild);
+
+    scope (success)
+    {
+        // leave dubhome in the tree for analysis in case of failure
+        rmdirRecurse(dubhome);
+    }
+
+    const buildDbPath = buildNormalizedPath(dubhome, "cache", "vibe-d", "0.9.6", "+http", "db.json");
+    assert(exists(buildDbPath), buildDbPath ~ " should exist");
+    const buildDbStr = readText(buildDbPath);
+    auto json = parseJSON(buildDbStr);
+    assert(json.type == JSONType.array, "build db should be an array");
+    assert(json.array.length == 1);
+    auto db = json.array[0].object;
+
+    void assertArray(string field)
+    {
+        assert(field in db, "db.json should have an array field " ~ field);
+        assert(db[field].type == JSONType.array, "expected field " ~ field ~ " to be an array");
+    }
+
+    void assertString(string field, string value = null)
+    {
+        assert(field in db, "db.json should have an string field " ~ field);
+        assert(db[field].type == JSONType.string, "expected field " ~ field ~ " to be a string");
+        if (value)
+            assert(db[field].str == value, "expected field " ~ field ~ " to equal " ~ value);
+    }
+
+    assertArray("architecture");
+    assertString("buildId");
+    assertString("buildType", "debug");
+    assertString("compiler");
+    assertString("compilerBinary");
+    assertString("compilerVersion");
+    assertString("configuration", "library");
+    assertString("package", "vibe-d:http");
+    assertArray("platform");
+    assertString("targetBinaryPath");
+    assertString("version", "0.9.6");
+
+    const binName = db["targetBinaryPath"].str;
+    assert(isFile(binName), "expected " ~ binName ~ " to be a file.");
+}


### PR DESCRIPTION
As discussed in #2640, proposal to write Json files in the cache for 3rd party software like Meson to assess compatibility of artifacts in the Dub cache.
I've made the choice to write small Json files per package version rather than a gigantic one for the whole cache.
This comes at the price of stabilizing the directory structure within the cache (up to where the json file is written).

The PR add the following files in the cache
```
~/.dub/cache/vibe-d/0.9.6/+http/build-db.json
~/.dub/cache/vibe-d/0.9.6/+http/build-db.lock
```
To ensure interoperability, the following stabilization apply:
```
~/.dub/cache/vibe-d/0.9.6/+http/build-db.json
~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      1             2
```
1. `$DUB_HOME/cache` _default_ location is stable (env-vars and settings customization still apply)
2. Json file path relative to `$DUB_HOME/cache` is stable

The final artifact location remains up to Dub developers.

fixes #2640