### PR TITLE
add --deep flag to `dub build`

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1198,6 +1198,7 @@ class GenerateCommand : PackageBuildCommand {
 	protected {
 		string m_generator;
 		bool m_printPlatform, m_printBuilds, m_printConfigs;
+		bool m_deep; // only set in BuildCommand
 	}
 
 	this() @safe pure nothrow
@@ -1274,6 +1275,7 @@ class GenerateCommand : PackageBuildCommand {
 		gensettings.runArgs = app_args;
 		// legacy compatibility, default working directory is always CWD
 		gensettings.overrideToolWorkingDirectory = getWorkingDirectory();
+		gensettings.buildDeep = m_deep;
 
 		logDiagnostic("Generating using %s", m_generator);
 		dub.generateProject(m_generator, gensettings);
@@ -1315,6 +1317,9 @@ class BuildCommand : GenerateCommand {
 		]);
 		args.getopt("n|non-interactive", &m_nonInteractive, [
 			"Don't enter interactive mode."
+		]);
+		args.getopt("d|deep", &m_deep, [
+			"Build all dependencies, even when main target is a static library."
 		]);
 		super.prepare(args);
 		m_generator = "build";

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -89,6 +89,17 @@ class BuildGenerator : ProjectGenerator {
 			settings.buildType.color(Color.magenta), settings.platform.compilerBinary,
 			settings.platform.architecture);
 
+		if (settings.rdmd || (rootTT == TargetType.staticLibrary && !settings.buildDeep)) {
+			// Only build the main target.
+			// RDMD always builds everything at once and static libraries don't need their
+			// dependencies to be built, unless --deep flag is specified
+			NativePath tpath;
+			buildTarget(settings, root_ti.buildSettings.dup, m_project.rootPackage, root_ti.config, root_ti.packages, null, tpath);
+			return;
+		}
+
+		// Recursive build starts here
+
 		bool any_cached = false;
 
 		NativePath[string] target_paths;
@@ -156,15 +167,6 @@ class BuildGenerator : ProjectGenerator {
 					any_cached = true;
 			}
 			target_paths[target] = tpath;
-		}
-
-		// build all targets
-		if (settings.rdmd || (rootTT == TargetType.staticLibrary && !settings.buildDeep)) {
-			// RDMD always builds everything at once and static libraries don't need their
-			// dependencies to be built, unless --deep flag is specified
-			NativePath tpath;
-			buildTarget(settings, root_ti.buildSettings.dup, m_project.rootPackage, root_ti.config, root_ti.packages, null, tpath);
-			return;
 		}
 
 		buildTargetRec(m_project.rootPackage.name);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -159,9 +159,9 @@ class BuildGenerator : ProjectGenerator {
 		}
 
 		// build all targets
-		if (settings.rdmd || rootTT == TargetType.staticLibrary) {
+		if (settings.rdmd || (rootTT == TargetType.staticLibrary && !settings.buildDeep)) {
 			// RDMD always builds everything at once and static libraries don't need their
-			// dependencies to be built
+			// dependencies to be built, unless --deep flag is specified
 			NativePath tpath;
 			buildTarget(settings, root_ti.buildSettings.dup, m_project.rootPackage, root_ti.config, root_ti.packages, null, tpath);
 			return;

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -824,6 +824,9 @@ struct GeneratorSettings {
 	/// single file dub package
 	bool single;
 
+	/// build all dependencies for static libraries
+	bool buildDeep;
+
 	string[] runArgs;
 	void delegate(int status, string output) compileCallback;
 	void delegate(int status, string output) linkCallback;

--- a/test/pr2647-build-deep/.gitignore
+++ b/test/pr2647-build-deep/.gitignore
@@ -1,0 +1,2 @@
+dubhome/
+pr2647-build-deep

--- a/test/pr2647-build-deep/dub.sdl
+++ b/test/pr2647-build-deep/dub.sdl
@@ -1,0 +1,2 @@
+name "pr2647-build-deep";
+targetType "executable";

--- a/test/pr2647-build-deep/pack/dub.sdl
+++ b/test/pr2647-build-deep/pack/dub.sdl
@@ -1,0 +1,3 @@
+name "pack"
+targetType "staticLibrary"
+dependency "urld" version="==2.1.1"

--- a/test/pr2647-build-deep/pack/source/lib.d
+++ b/test/pr2647-build-deep/pack/source/lib.d
@@ -1,0 +1,14 @@
+module lib;
+
+import url;
+
+string getDlangUrl()
+{
+    URL url;
+    with(url)
+    {
+        scheme = "https";
+        host = "dlang.org";
+    }
+    return url.toString();
+}

--- a/test/pr2647-build-deep/source/test_build_deep.d
+++ b/test/pr2647-build-deep/source/test_build_deep.d
@@ -1,0 +1,53 @@
+module test_build_deep;
+
+import std.array;
+import std.file;
+import std.path;
+import std.process;
+import std.stdio;
+
+void main()
+{
+    const dubhome = __FILE_FULL_PATH__.dirName().dirName().buildNormalizedPath("dubhome");
+    const packdir = __FILE_FULL_PATH__.dirName().dirName().buildNormalizedPath("pack");
+    const dub = absolutePath(environment["DUB"]);
+
+    if (exists(dubhome))
+    {
+        rmdirRecurse(dubhome);
+    }
+
+    scope (success)
+    {
+        // leave dubhome in the tree for analysis in case of failure
+        rmdirRecurse(dubhome);
+    }
+
+    const string[string] env = [
+        "DUB_HOME": dubhome,
+    ];
+
+    // testing the regular way first: `dub build` only builds what is needed
+    // (urld is downloaded but not built)
+    const dubBuildProg = [dub, "build"];
+    writefln("running %s ...", dubBuildProg.join(" "));
+    auto dubBuild = spawnProcess(dubBuildProg, stdin, stdout, stderr, env, Config.none, packdir);
+    wait(dubBuild);
+    assert(exists(buildPath(dubhome, "cache", "pack")));
+    assert(isDir(buildPath(dubhome, "cache", "pack")));
+    assert(exists(buildPath(dubhome, "packages", "urld")));
+    assert(isDir(buildPath(dubhome, "packages", "urld")));
+    assert(!exists(buildPath(dubhome, "cache", "urld")));
+
+    // now testing the --deep switch: `dub build --deep` will build urld
+    const dubBuildDeepProg = [dub, "build", "--deep"];
+    writefln("running %s ...", dubBuildDeepProg.join(" "));
+    auto dubBuildDeep = spawnProcess(dubBuildDeepProg, stdin, stdout, stderr, env, Config.none, packdir);
+    wait(dubBuildDeep);
+    assert(exists(buildPath(dubhome, "cache", "pack")));
+    assert(isDir(buildPath(dubhome, "cache", "pack")));
+    assert(exists(buildPath(dubhome, "packages", "urld")));
+    assert(isDir(buildPath(dubhome, "packages", "urld")));
+    assert(exists(buildPath(dubhome, "cache", "urld")));
+    assert(isDir(buildPath(dubhome, "cache", "urld")));
+}


### PR DESCRIPTION
Allows to build all dependencies of a static library.

This provides the same functionality as the [dub-build-deep](https://code.dlang.org/packages/dub-build-deep) package.
The difference is that all dependencies are built in the same DUB invocation, which imply that the build will be fully compatible with `dub describe`.

E.g.
`dub describe vibe-d:http` will describe the build settings of all dependencies of `vibe-d:http` and `dub build --deep vibe-d:http` will build all dependencies with the exact same build settings.
If we build dependencies one by one (as done by `dub-build-deep`), some settings will differ.

See also #2644

Fixes #2224 (and possibly #2209)
