### PR TITLE
Skip path-specified optional dependencies if they don't exist

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -473,6 +473,11 @@ class Project {
 				Dependency vspec = dep.spec;
 				Package p;
 
+				if (vspec.optional && vspec.path() != NativePath.init && !existsDirectory(vspec.path())) {
+					logDiagnostic("%sOptional dependency %s path %s does not exist, not using.", indent, dep.name, vspec.path());
+					continue;
+				}
+
 				auto basename = getBasePackageName(dep.name);
 				auto subname = getSubPackageName(dep.name);
 

--- a/test/pr2663-optional-path/.gitignore
+++ b/test/pr2663-optional-path/.gitignore
@@ -1,0 +1,1 @@
+/pr2663-optional-path

--- a/test/pr2663-optional-path/dub.sdl
+++ b/test/pr2663-optional-path/dub.sdl
@@ -1,0 +1,5 @@
+name "pr2663-optional-path"
+targetType "executable"
+
+dependency "existent" path="existent" optional=true
+dependency "nonexistent" path="nonexistent" optional=true

--- a/test/pr2663-optional-path/dub.selections.json
+++ b/test/pr2663-optional-path/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"existent": {"path":"existent"},
+		"nonexistent": {"path":"nonexistent"}
+	}
+}

--- a/test/pr2663-optional-path/existent/dub.sdl
+++ b/test/pr2663-optional-path/existent/dub.sdl
@@ -1,0 +1,2 @@
+name "existent"
+targetType "sourceLibrary"

--- a/test/pr2663-optional-path/existent/source/existent.d
+++ b/test/pr2663-optional-path/existent/source/existent.d
@@ -1,0 +1,1 @@
+void existent() {}

--- a/test/pr2663-optional-path/source/main.d
+++ b/test/pr2663-optional-path/source/main.d
@@ -1,0 +1,6 @@
+import existent : existent;
+
+void main()
+{
+	existent();
+}


### PR DESCRIPTION
I think this is a useful and harmless alternative way to understand "optional" in this context.

The motivation is being able to do autoconf-like optional dependencies: D packages may install a Dub package file somewhere on the system, which we can pull in if it is present, but silently skip if it's absent.
