### PR TITLE
Don't wastefully execute everything via a shell

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -152,12 +152,12 @@ interface Compiler {
 
 		int status;
 		if (output_callback) {
-			auto result = executeShell(escapeShellCommand(args),
+			auto result = execute(args,
 				env, Config.none, size_t.max, cwd.toNativeString());
 			output_callback(result.status, result.output);
 			status = result.status;
 		} else {
-			auto compiler_pid = spawnShell(escapeShellCommand(args),
+			auto compiler_pid = spawnProcess(args,
 				env, Config.none, cwd.toNativeString());
 			status = compiler_pid.wait();
 		}
@@ -185,7 +185,7 @@ interface Compiler {
 
 		auto fil = generatePlatformProbeFile();
 
-		auto result = executeShell(escapeShellCommand(compiler_binary ~ args ~ fil.toNativeString()));
+		auto result = execute(compiler_binary ~ args ~ fil.toNativeString());
 		enforce!CompilerInvocationException(result.status == 0,
 				format("Failed to invoke the compiler %s to determine the build platform: %s",
 				compiler_binary, result.output));

--- a/source/dub/internal/git.d
+++ b/source/dub/internal/git.d
@@ -72,7 +72,7 @@ private string determineVersionWithGitTool(NativePath path)
 	auto git_dir_param = "--git-dir=" ~ git_dir.toNativeString();
 
 	static string exec(scope string[] params...) {
-		auto ret = executeShell(escapeShellCommand(params));
+		auto ret = execute(params);
 		if (ret.status == 0) return ret.output.strip;
 		logDebug("'%s' failed with exit code %s: %s", params.join(" "), ret.status, ret.output.strip);
 		return null;

--- a/test/issue895-local-configuration.sh
+++ b/test/issue895-local-configuration.sh
@@ -61,7 +61,7 @@ fi
 rm ../etc/dub/settings.json
 echo "Empty file named ldc2." > ../bin/ldc2
 
-if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Failed to invoke the compiler $(dirname $CURR_DIR)/bin/ldc2 to determine the build platform"; then
+if ! { ${DUB} describe --single issue103-single-file-package.d 2>&1 || true; } | grep -cF "Failed to execute '$(dirname $CURR_DIR)/bin/ldc2'"; then
 	rm ../bin/ldc2
 	die $LINENO 'DUB did not find ldc2 adjacent to it.'
 fi


### PR DESCRIPTION
We should only ever use the shell if we want to use the shell's features, such as pipes, non-trivial redirection, or shell language features (branches/loops/etc.).  Otherwise, executing a program via the shell is pointless and wasteful.