### PR TITLE
LDC: Don't keep around temporary object files for static libs

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -243,10 +243,9 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 				if (platform.frontendVersion >= 2071) {
 					settings.addDFlags("-cleanup-obj");
 				}
-				if (platform.frontendVersion >= 2095) {
-					// since LDC v1.25, -cleanup-obj additionally defaults to a unique temp -od directory
-				} else {
-					// resort to a unique-ish -od directory
+				if (platform.frontendVersion < 2095) {
+					// Since LDC v1.25, -cleanup-obj defaults to a unique temp -od directory
+					// We need to resort to a unique-ish -od directory before that
 					settings.addDFlags("-od=" ~ settings.targetPath ~ "/obj");
 				}
 				break;

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -104,7 +104,6 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 
 	void prepareBuildSettings(ref BuildSettings settings, const scope ref BuildPlatform platform, BuildSetting fields = BuildSetting.all) const
 	{
-		import std.format : format;
 		enforceBuildRequirements(settings);
 
 		// Keep the current dflags at the end of the array so that they will overwrite other flags.
@@ -117,9 +116,6 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 				if (settings.options & t[0])
 					settings.addDFlags(t[1]);
 		}
-
-		// since LDC always outputs multiple object files, avoid conflicts by default
-		settings.addDFlags("--oq", format("-od=%s/obj", settings.targetPath));
 
 		if (!(fields & BuildSetting.versions)) {
 			settings.addDFlags(settings.versions.map!(s => "-d-version="~s)().array());
@@ -241,7 +237,18 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 			case TargetType.executable: break;
 			case TargetType.library:
 			case TargetType.staticLibrary:
-				settings.addDFlags("-lib");
+				// -oq: name object files uniquely (so the files don't collide)
+				settings.addDFlags("-lib", "-oq");
+				// -cleanup-obj (supported since LDC v1.1): remove object files after archiving to static lib
+				if (platform.frontendVersion >= 2071) {
+					settings.addDFlags("-cleanup-obj");
+				}
+				if (platform.frontendVersion >= 2095) {
+					// since LDC v1.25, -cleanup-obj additionally defaults to a unique temp -od directory
+				} else {
+					// resort to a unique-ish -od directory
+					settings.addDFlags("-od=" ~ settings.targetPath ~ "/obj");
+				}
 				break;
 			case TargetType.dynamicLibrary:
 				settings.addDFlags("-shared");

--- a/test/removed-dub-obj.sh
+++ b/test/removed-dub-obj.sh
@@ -3,19 +3,14 @@
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 cd ${CURR_DIR}/removed-dub-obj
 
-DUB_CACHE_PATH="$HOME/.dub/cache/removed-dub-obj/"
+DUB_CACHE_PATH="$HOME/.dub/cache/removed-dub-obj"
 
-rm -rf $DUB_CACHE_PATH
+rm -rf "$DUB_CACHE_PATH"
 
 ${DUB} build --compiler=${DC}
 
-[ -d "$DUB_CACHE_PATH/obj" ] && die $LINENO "$DUB_CACHE_PATH/obj was found"
+[ -d "$DUB_CACHE_PATH" ] || die $LINENO "$DUB_CACHE_PATH not found"
 
-if [[ ${DC} == *"ldc"* ]]; then
-    if [ ! -f $DUB_CACHE_PATH/~master/build/library-*/obj/test.o* ]; then
-        ls -lR $DUB_CACHE_PATH
-        die $LINENO '$DUB_CACHE_PATH/~master/build/library-*/obj/test.o* was not found'
-    fi
-fi
-
-exit 0
+numObjectFiles=$(find "$DUB_CACHE_PATH" -type f -iname '*.o*' | wc -l)
+# note: fails with LDC < v1.1
+[ "$numObjectFiles" -eq 0 ] || die $LINENO "Found left-over object files in $DUB_CACHE_PATH"


### PR DESCRIPTION
This was a workaround for older LDC versions. Since LDC v1.25, `-cleanup-obj` implies that the temporary object files are placed into a unique temp directory (per compiler invocation), so that object file collisions across parallel dub invocations cannot happen anymore.