### PR TITLE
add `dub describe --data=configs,builds`

### DIFF
--- a/changelog/describe-configs.dd
+++ b/changelog/describe-configs.dd
@@ -1,0 +1,6 @@
+Added `default-config`, `configs`, `default-build`, `builds` data to dub describe
+
+- `default-config` will be a single string that is the `--config` configuration that DUB would pick when not provided any configuration such as in a simple `dub build` call
+- `configs` is a list of all available configurations (default generated application and/or library, or the manually specified ones in the recipe)
+- `default-build` will be a single string that is the `--build` build type that DUB would pick when not provided any (currently always "debug")
+- `builds` is a list of all available build types (built-in + custom defined)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1143,6 +1143,10 @@ class Project {
 			case "post-build-environments":
 			case "pre-run-environments":
 			case "post-run-environments":
+			case "default-config":
+			case "configs":
+			case "default-build":
+			case "builds":
 				enforce(false, "--data="~requestedData~" can only be used with `--data-list` or `--data-list --data-0`.");
 				break;
 
@@ -1194,6 +1198,10 @@ class Project {
 		case "post-run-environments":      return listBuildSetting!"postRunEnvironments"(args);
 		case "requirements":               return listBuildSetting!"requirements"(args);
 		case "options":                    return listBuildSetting!"options"(args);
+		case "default-config":             return [getDefaultConfiguration(settings.platform)];
+		case "configs":                    return configurations;
+		case "default-build":              return [builds[0]];
+		case "builds":                     return builds;
 
 		default:
 			enforce(false, "--data="~requestedData~

--- a/test/4-describe-data-1-list.sh
+++ b/test/4-describe-data-1-list.sh
@@ -30,6 +30,10 @@ if ! $DUB describe --compiler=$DC --filter-versions \
     --data=pre-build-commands \
     --data=post-build-commands \
     '--data=requirements, options' \
+    --data=default-config \
+    --data=configs \
+    --data=default-build \
+    --data=builds \
     > "$temp_file"; then
     die $LINENO 'Printing project data failed!'
 fi
@@ -130,6 +134,33 @@ echo "debugMode" >> "$expected_file"
 echo "debugInfo" >> "$expected_file"
 echo "stackStomping" >> "$expected_file"
 echo "warnings" >> "$expected_file"
+echo >> "$expected_file"
+# --data=default-config
+echo "my-project-config" >> "$expected_file"
+echo >> "$expected_file"
+# --data=configs
+echo "my-project-config" >> "$expected_file"
+echo >> "$expected_file"
+# --data=default-build
+echo "debug" >> "$expected_file"
+echo >> "$expected_file"
+# --data=builds
+echo "debug" >> "$expected_file"
+echo "plain" >> "$expected_file"
+echo "release" >> "$expected_file"
+echo "release-debug" >> "$expected_file"
+echo "release-nobounds" >> "$expected_file"
+echo "unittest" >> "$expected_file"
+echo "profile" >> "$expected_file"
+echo "profile-gc" >> "$expected_file"
+echo "docs" >> "$expected_file"
+echo "ddox" >> "$expected_file"
+echo "cov" >> "$expected_file"
+echo "cov-ctfe" >> "$expected_file"
+echo "unittest-cov" >> "$expected_file"
+echo "unittest-cov-ctfe" >> "$expected_file"
+echo "syntax" >> "$expected_file"
+# echo >> "$expected_file"
 
 if ! diff "$expected_file" "$temp_file"; then
     echo "Result:"


### PR DESCRIPTION
supersedes the trivial part of #2204

since --print-configs/--print-builds had a bunch of nasty side effects, like fetching dependencies and running/building the project which especially in scripts testing for configs is undesired.