### PR TITLE
fix typo in cImportPaths dub describe data

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -987,7 +987,7 @@ class Project {
 			case "stringImportFiles":
 			case "sourceFiles":
 			case "importPaths":
-			case "CImportPaths":
+			case "cImportPaths":
 			case "stringImportPaths":
 				return values.map!(escapeShellFileName).array();
 


### PR DESCRIPTION
since it's not used anywhere else in code in this casing, adjusted to make it the same as everyhing else. Was likely a bug, but no issue was filed for this yet.

Test cases don't seem to exist for cImportPaths with dub describe at all