### PR TITLE
Add betterC to probePlatform calls

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -124,7 +124,7 @@ config    /etc/dmd.conf
 
 		BuildPlatform bp = probePlatform(
 			compiler_binary,
-			arch_flags ~ ["-quiet", "-c", "-o-", "-v"],
+			arch_flags ~ ["-betterC", "-quiet", "-c", "-o-", "-v"],
 			arch_override
 		);
 

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -80,7 +80,7 @@ class GDCCompiler : Compiler {
 
 		return probePlatform(
 			compiler_binary,
-			arch_flags ~ ["-fno-druntime", "-fsyntax-only", "-v"],
+			arch_flags ~ ["-fno-druntime", "-nophoboslib", "-fsyntax-only", "-v"],
 			arch_override
 		);
 	}

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -80,7 +80,7 @@ class GDCCompiler : Compiler {
 
 		return probePlatform(
 			compiler_binary,
-			arch_flags ~ ["-fsyntax-only", "-v"],
+			arch_flags ~ ["-fno-druntime", "-fsyntax-only", "-v"],
 			arch_override
 		);
 	}

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -97,7 +97,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 
 		return probePlatform(
 			compiler_binary,
-			arch_flags ~ ["-c", "-o-", "-v"],
+			arch_flags ~ ["-betterC", "-c", "-o-", "-v"],
 			arch_override
 		);
 	}

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -326,13 +326,22 @@ NativePath generatePlatformProbeFile()
 	enum probe = q{
 		module object;
 
-		template _d_arrayappendcTXImpl(Tarr : T[], T)
+		static if (__VERSION__ < 2104)
 		{
-			ref Tarr _d_arrayappendcTX(return ref scope Tarr px, ulong n) @trusted pure nothrow
+			// Work around bug that in older FE versions CTFE would still emit
+			// symbol calls to druntime, which we don't have with betterC
+
+			// Starting with DMD 2.104 this is no problem anymore however, so we
+			// don't need to use this hack there.
+
+			template _d_arrayappendcTXImpl(Tarr : T[], T)
 			{
-				// this should never be called, since we use CTFE only
-				// avoids linker errors when compiler attempts to emit a call to this
-				assert(false);
+				ref Tarr _d_arrayappendcTX(return ref scope Tarr px, ulong n) @trusted pure nothrow
+				{
+					// this should never be called, since we use CTFE only
+					// avoids linker errors when compiler attempts to emit a call to this
+					assert(false);
+				}
 			}
 		}
 

--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -353,8 +353,20 @@ NativePath generatePlatformProbeFile()
 		pragma(msg, `}`);
 		pragma(msg, `%2$s`);
 
-		string[] determinePlatform() { %3$s }
-		string[] determineArchitecture() { %4$s }
+		string[] determinePlatform() {
+			if (__ctfe) {
+				%3$s
+			} else {
+				assert(0);
+			}
+		}
+		string[] determineArchitecture() {
+			if (__ctfe) {
+				%4$s
+			} else {
+				assert(0);
+			}
+		}
 		string determineCompiler() { %5$s }
 
 		}.format(probeBeginMark, probeEndMark, platformCheck, archCheck, compilerCheck);

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -49,7 +49,40 @@ enum string platformCheck = q{
 		version(PlayStation4) ret ~= "playstation4";
 		version(WebAssembly) ret ~= "wasm";
 		return ret;
-	} else assert(0);
+	} else {
+		version(D_BetterC) {
+
+			// Case that we want to avoid for DMD
+			assert(0);
+		} else {
+			string[] ret;
+			version(Windows) ret ~= "windows";
+			version(linux) ret ~= "linux";
+			version(Posix) ret ~= "posix";
+			version(OSX) ret ~= ["osx", "darwin"];
+			version(iOS) ret ~= ["ios", "darwin"];
+			version(TVOS) ret ~= ["tvos", "darwin"];
+			version(WatchOS) ret ~= ["watchos", "darwin"];
+			version(FreeBSD) ret ~= "freebsd";
+			version(OpenBSD) ret ~= "openbsd";
+			version(NetBSD) ret ~= "netbsd";
+			version(DragonFlyBSD) ret ~= "dragonflybsd";
+			version(BSD) ret ~= "bsd";
+			version(Solaris) ret ~= "solaris";
+			version(AIX) ret ~= "aix";
+			version(Haiku) ret ~= "haiku";
+			version(SkyOS) ret ~= "skyos";
+			version(SysV3) ret ~= "sysv3";
+			version(SysV4) ret ~= "sysv4";
+			version(Hurd) ret ~= "hurd";
+			version(Android) ret ~= "android";
+			version(Cygwin) ret ~= "cygwin";
+			version(MinGW) ret ~= "mingw";
+			version(PlayStation4) ret ~= "playstation4";
+			version(WebAssembly) ret ~= "wasm";
+			return ret;
+		}
+	}
 };
 
 /// private
@@ -102,7 +135,61 @@ enum string archCheck = q{
 		version(Alpha_SoftFP) ret ~= "alpha_softfp";
 		version(Alpha_HardFP) ret ~= "alpha_hardfp";
 		return ret;
-	} else assert(0);
+	} else {
+		version(D_BetterC) {
+
+			// Case that we want to avoid for DMD
+			assert(0);
+		} else {
+			string[] ret;
+			version(X86) ret ~= "x86";
+			// Hack: see #1535
+			// Makes "x86_omf" available as a platform specifier in the package recipe
+			version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
+			// Hack: see #1059
+			// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
+			// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
+			// And also makes "x86_mscoff" available as a platform specifier in the package recipe
+			version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
+			version(X86_64) ret ~= "x86_64";
+			version(ARM) ret ~= "arm";
+			version(AArch64) ret ~= "aarch64";
+			version(ARM_Thumb) ret ~= "arm_thumb";
+			version(ARM_SoftFloat) ret ~= "arm_softfloat";
+			version(ARM_HardFloat) ret ~= "arm_hardfloat";
+			version(PPC) ret ~= "ppc";
+			version(PPC_SoftFP) ret ~= "ppc_softfp";
+			version(PPC_HardFP) ret ~= "ppc_hardfp";
+			version(PPC64) ret ~= "ppc64";
+			version(IA64) ret ~= "ia64";
+			version(MIPS) ret ~= "mips";
+			version(MIPS32) ret ~= "mips32";
+			version(MIPS64) ret ~= "mips64";
+			version(MIPS_O32) ret ~= "mips_o32";
+			version(MIPS_N32) ret ~= "mips_n32";
+			version(MIPS_O64) ret ~= "mips_o64";
+			version(MIPS_N64) ret ~= "mips_n64";
+			version(MIPS_EABI) ret ~= "mips_eabi";
+			version(MIPS_NoFloat) ret ~= "mips_nofloat";
+			version(MIPS_SoftFloat) ret ~= "mips_softfloat";
+			version(MIPS_HardFloat) ret ~= "mips_hardfloat";
+			version(SPARC) ret ~= "sparc";
+			version(SPARC_V8Plus) ret ~= "sparc_v8plus";
+			version(SPARC_SoftFP) ret ~= "sparc_softfp";
+			version(SPARC_HardFP) ret ~= "sparc_hardfp";
+			version(SPARC64) ret ~= "sparc64";
+			version(S390) ret ~= "s390";
+			version(S390X) ret ~= "s390x";
+			version(HPPA) ret ~= "hppa";
+			version(HPPA64) ret ~= "hppa64";
+			version(SH) ret ~= "sh";
+			version(SH64) ret ~= "sh64";
+			version(Alpha) ret ~= "alpha";
+			version(Alpha_SoftFP) ret ~= "alpha_softfp";
+			version(Alpha_HardFP) ret ~= "alpha_hardfp";
+			return ret;
+		}
+	}
 };
 
 /// private

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -22,174 +22,83 @@ import std.array;
 // Try to not use phobos in the probes to avoid long import times.
 /// private
 enum string platformCheck = q{
-	if (__ctfe) {
-		string[] ret;
-		version(Windows) ret ~= "windows";
-		version(linux) ret ~= "linux";
-		version(Posix) ret ~= "posix";
-		version(OSX) ret ~= ["osx", "darwin"];
-		version(iOS) ret ~= ["ios", "darwin"];
-		version(TVOS) ret ~= ["tvos", "darwin"];
-		version(WatchOS) ret ~= ["watchos", "darwin"];
-		version(FreeBSD) ret ~= "freebsd";
-		version(OpenBSD) ret ~= "openbsd";
-		version(NetBSD) ret ~= "netbsd";
-		version(DragonFlyBSD) ret ~= "dragonflybsd";
-		version(BSD) ret ~= "bsd";
-		version(Solaris) ret ~= "solaris";
-		version(AIX) ret ~= "aix";
-		version(Haiku) ret ~= "haiku";
-		version(SkyOS) ret ~= "skyos";
-		version(SysV3) ret ~= "sysv3";
-		version(SysV4) ret ~= "sysv4";
-		version(Hurd) ret ~= "hurd";
-		version(Android) ret ~= "android";
-		version(Cygwin) ret ~= "cygwin";
-		version(MinGW) ret ~= "mingw";
-		version(PlayStation4) ret ~= "playstation4";
-		version(WebAssembly) ret ~= "wasm";
-		return ret;
-	} else {
-		version(D_BetterC) {
-
-			// Case that we want to avoid for DMD
-			assert(0);
-		} else {
-			string[] ret;
-			version(Windows) ret ~= "windows";
-			version(linux) ret ~= "linux";
-			version(Posix) ret ~= "posix";
-			version(OSX) ret ~= ["osx", "darwin"];
-			version(iOS) ret ~= ["ios", "darwin"];
-			version(TVOS) ret ~= ["tvos", "darwin"];
-			version(WatchOS) ret ~= ["watchos", "darwin"];
-			version(FreeBSD) ret ~= "freebsd";
-			version(OpenBSD) ret ~= "openbsd";
-			version(NetBSD) ret ~= "netbsd";
-			version(DragonFlyBSD) ret ~= "dragonflybsd";
-			version(BSD) ret ~= "bsd";
-			version(Solaris) ret ~= "solaris";
-			version(AIX) ret ~= "aix";
-			version(Haiku) ret ~= "haiku";
-			version(SkyOS) ret ~= "skyos";
-			version(SysV3) ret ~= "sysv3";
-			version(SysV4) ret ~= "sysv4";
-			version(Hurd) ret ~= "hurd";
-			version(Android) ret ~= "android";
-			version(Cygwin) ret ~= "cygwin";
-			version(MinGW) ret ~= "mingw";
-			version(PlayStation4) ret ~= "playstation4";
-			version(WebAssembly) ret ~= "wasm";
-			return ret;
-		}
-	}
+	string[] ret;
+	version(Windows) ret ~= "windows";
+	version(linux) ret ~= "linux";
+	version(Posix) ret ~= "posix";
+	version(OSX) ret ~= ["osx", "darwin"];
+	version(iOS) ret ~= ["ios", "darwin"];
+	version(TVOS) ret ~= ["tvos", "darwin"];
+	version(WatchOS) ret ~= ["watchos", "darwin"];
+	version(FreeBSD) ret ~= "freebsd";
+	version(OpenBSD) ret ~= "openbsd";
+	version(NetBSD) ret ~= "netbsd";
+	version(DragonFlyBSD) ret ~= "dragonflybsd";
+	version(BSD) ret ~= "bsd";
+	version(Solaris) ret ~= "solaris";
+	version(AIX) ret ~= "aix";
+	version(Haiku) ret ~= "haiku";
+	version(SkyOS) ret ~= "skyos";
+	version(SysV3) ret ~= "sysv3";
+	version(SysV4) ret ~= "sysv4";
+	version(Hurd) ret ~= "hurd";
+	version(Android) ret ~= "android";
+	version(Cygwin) ret ~= "cygwin";
+	version(MinGW) ret ~= "mingw";
+	version(PlayStation4) ret ~= "playstation4";
+	version(WebAssembly) ret ~= "wasm";
+	return ret;
 };
 
 /// private
 enum string archCheck = q{
-	if (__ctfe) {
-		string[] ret;
-		version(X86) ret ~= "x86";
-		// Hack: see #1535
-		// Makes "x86_omf" available as a platform specifier in the package recipe
-		version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
-		// Hack: see #1059
-		// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
-		// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
-		// And also makes "x86_mscoff" available as a platform specifier in the package recipe
-		version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
-		version(X86_64) ret ~= "x86_64";
-		version(ARM) ret ~= "arm";
-		version(AArch64) ret ~= "aarch64";
-		version(ARM_Thumb) ret ~= "arm_thumb";
-		version(ARM_SoftFloat) ret ~= "arm_softfloat";
-		version(ARM_HardFloat) ret ~= "arm_hardfloat";
-		version(PPC) ret ~= "ppc";
-		version(PPC_SoftFP) ret ~= "ppc_softfp";
-		version(PPC_HardFP) ret ~= "ppc_hardfp";
-		version(PPC64) ret ~= "ppc64";
-		version(IA64) ret ~= "ia64";
-		version(MIPS) ret ~= "mips";
-		version(MIPS32) ret ~= "mips32";
-		version(MIPS64) ret ~= "mips64";
-		version(MIPS_O32) ret ~= "mips_o32";
-		version(MIPS_N32) ret ~= "mips_n32";
-		version(MIPS_O64) ret ~= "mips_o64";
-		version(MIPS_N64) ret ~= "mips_n64";
-		version(MIPS_EABI) ret ~= "mips_eabi";
-		version(MIPS_NoFloat) ret ~= "mips_nofloat";
-		version(MIPS_SoftFloat) ret ~= "mips_softfloat";
-		version(MIPS_HardFloat) ret ~= "mips_hardfloat";
-		version(SPARC) ret ~= "sparc";
-		version(SPARC_V8Plus) ret ~= "sparc_v8plus";
-		version(SPARC_SoftFP) ret ~= "sparc_softfp";
-		version(SPARC_HardFP) ret ~= "sparc_hardfp";
-		version(SPARC64) ret ~= "sparc64";
-		version(S390) ret ~= "s390";
-		version(S390X) ret ~= "s390x";
-		version(HPPA) ret ~= "hppa";
-		version(HPPA64) ret ~= "hppa64";
-		version(SH) ret ~= "sh";
-		version(SH64) ret ~= "sh64";
-		version(Alpha) ret ~= "alpha";
-		version(Alpha_SoftFP) ret ~= "alpha_softfp";
-		version(Alpha_HardFP) ret ~= "alpha_hardfp";
-		return ret;
-	} else {
-		version(D_BetterC) {
-
-			// Case that we want to avoid for DMD
-			assert(0);
-		} else {
-			string[] ret;
-			version(X86) ret ~= "x86";
-			// Hack: see #1535
-			// Makes "x86_omf" available as a platform specifier in the package recipe
-			version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
-			// Hack: see #1059
-			// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
-			// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
-			// And also makes "x86_mscoff" available as a platform specifier in the package recipe
-			version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
-			version(X86_64) ret ~= "x86_64";
-			version(ARM) ret ~= "arm";
-			version(AArch64) ret ~= "aarch64";
-			version(ARM_Thumb) ret ~= "arm_thumb";
-			version(ARM_SoftFloat) ret ~= "arm_softfloat";
-			version(ARM_HardFloat) ret ~= "arm_hardfloat";
-			version(PPC) ret ~= "ppc";
-			version(PPC_SoftFP) ret ~= "ppc_softfp";
-			version(PPC_HardFP) ret ~= "ppc_hardfp";
-			version(PPC64) ret ~= "ppc64";
-			version(IA64) ret ~= "ia64";
-			version(MIPS) ret ~= "mips";
-			version(MIPS32) ret ~= "mips32";
-			version(MIPS64) ret ~= "mips64";
-			version(MIPS_O32) ret ~= "mips_o32";
-			version(MIPS_N32) ret ~= "mips_n32";
-			version(MIPS_O64) ret ~= "mips_o64";
-			version(MIPS_N64) ret ~= "mips_n64";
-			version(MIPS_EABI) ret ~= "mips_eabi";
-			version(MIPS_NoFloat) ret ~= "mips_nofloat";
-			version(MIPS_SoftFloat) ret ~= "mips_softfloat";
-			version(MIPS_HardFloat) ret ~= "mips_hardfloat";
-			version(SPARC) ret ~= "sparc";
-			version(SPARC_V8Plus) ret ~= "sparc_v8plus";
-			version(SPARC_SoftFP) ret ~= "sparc_softfp";
-			version(SPARC_HardFP) ret ~= "sparc_hardfp";
-			version(SPARC64) ret ~= "sparc64";
-			version(S390) ret ~= "s390";
-			version(S390X) ret ~= "s390x";
-			version(HPPA) ret ~= "hppa";
-			version(HPPA64) ret ~= "hppa64";
-			version(SH) ret ~= "sh";
-			version(SH64) ret ~= "sh64";
-			version(Alpha) ret ~= "alpha";
-			version(Alpha_SoftFP) ret ~= "alpha_softfp";
-			version(Alpha_HardFP) ret ~= "alpha_hardfp";
-			return ret;
-		}
-	}
+	string[] ret;
+	version(X86) ret ~= "x86";
+	// Hack: see #1535
+	// Makes "x86_omf" available as a platform specifier in the package recipe
+	version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
+	// Hack: see #1059
+	// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
+	// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
+	// And also makes "x86_mscoff" available as a platform specifier in the package recipe
+	version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
+	version(X86_64) ret ~= "x86_64";
+	version(ARM) ret ~= "arm";
+	version(AArch64) ret ~= "aarch64";
+	version(ARM_Thumb) ret ~= "arm_thumb";
+	version(ARM_SoftFloat) ret ~= "arm_softfloat";
+	version(ARM_HardFloat) ret ~= "arm_hardfloat";
+	version(PPC) ret ~= "ppc";
+	version(PPC_SoftFP) ret ~= "ppc_softfp";
+	version(PPC_HardFP) ret ~= "ppc_hardfp";
+	version(PPC64) ret ~= "ppc64";
+	version(IA64) ret ~= "ia64";
+	version(MIPS) ret ~= "mips";
+	version(MIPS32) ret ~= "mips32";
+	version(MIPS64) ret ~= "mips64";
+	version(MIPS_O32) ret ~= "mips_o32";
+	version(MIPS_N32) ret ~= "mips_n32";
+	version(MIPS_O64) ret ~= "mips_o64";
+	version(MIPS_N64) ret ~= "mips_n64";
+	version(MIPS_EABI) ret ~= "mips_eabi";
+	version(MIPS_NoFloat) ret ~= "mips_nofloat";
+	version(MIPS_SoftFloat) ret ~= "mips_softfloat";
+	version(MIPS_HardFloat) ret ~= "mips_hardfloat";
+	version(SPARC) ret ~= "sparc";
+	version(SPARC_V8Plus) ret ~= "sparc_v8plus";
+	version(SPARC_SoftFP) ret ~= "sparc_softfp";
+	version(SPARC_HardFP) ret ~= "sparc_hardfp";
+	version(SPARC64) ret ~= "sparc64";
+	version(S390) ret ~= "s390";
+	version(S390X) ret ~= "s390x";
+	version(HPPA) ret ~= "hppa";
+	version(HPPA64) ret ~= "hppa64";
+	version(SH) ret ~= "sh";
+	version(SH64) ret ~= "sh64";
+	version(Alpha) ret ~= "alpha";
+	version(Alpha_SoftFP) ret ~= "alpha_softfp";
+	version(Alpha_HardFP) ret ~= "alpha_hardfp";
+	return ret;
 };
 
 /// private

--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -22,83 +22,87 @@ import std.array;
 // Try to not use phobos in the probes to avoid long import times.
 /// private
 enum string platformCheck = q{
-	string[] ret;
-	version(Windows) ret ~= "windows";
-	version(linux) ret ~= "linux";
-	version(Posix) ret ~= "posix";
-	version(OSX) ret ~= ["osx", "darwin"];
-	version(iOS) ret ~= ["ios", "darwin"];
-	version(TVOS) ret ~= ["tvos", "darwin"];
-	version(WatchOS) ret ~= ["watchos", "darwin"];
-	version(FreeBSD) ret ~= "freebsd";
-	version(OpenBSD) ret ~= "openbsd";
-	version(NetBSD) ret ~= "netbsd";
-	version(DragonFlyBSD) ret ~= "dragonflybsd";
-	version(BSD) ret ~= "bsd";
-	version(Solaris) ret ~= "solaris";
-	version(AIX) ret ~= "aix";
-	version(Haiku) ret ~= "haiku";
-	version(SkyOS) ret ~= "skyos";
-	version(SysV3) ret ~= "sysv3";
-	version(SysV4) ret ~= "sysv4";
-	version(Hurd) ret ~= "hurd";
-	version(Android) ret ~= "android";
-	version(Cygwin) ret ~= "cygwin";
-	version(MinGW) ret ~= "mingw";
-	version(PlayStation4) ret ~= "playstation4";
-	version(WebAssembly) ret ~= "wasm";
-	return ret;
+	if (__ctfe) {
+		string[] ret;
+		version(Windows) ret ~= "windows";
+		version(linux) ret ~= "linux";
+		version(Posix) ret ~= "posix";
+		version(OSX) ret ~= ["osx", "darwin"];
+		version(iOS) ret ~= ["ios", "darwin"];
+		version(TVOS) ret ~= ["tvos", "darwin"];
+		version(WatchOS) ret ~= ["watchos", "darwin"];
+		version(FreeBSD) ret ~= "freebsd";
+		version(OpenBSD) ret ~= "openbsd";
+		version(NetBSD) ret ~= "netbsd";
+		version(DragonFlyBSD) ret ~= "dragonflybsd";
+		version(BSD) ret ~= "bsd";
+		version(Solaris) ret ~= "solaris";
+		version(AIX) ret ~= "aix";
+		version(Haiku) ret ~= "haiku";
+		version(SkyOS) ret ~= "skyos";
+		version(SysV3) ret ~= "sysv3";
+		version(SysV4) ret ~= "sysv4";
+		version(Hurd) ret ~= "hurd";
+		version(Android) ret ~= "android";
+		version(Cygwin) ret ~= "cygwin";
+		version(MinGW) ret ~= "mingw";
+		version(PlayStation4) ret ~= "playstation4";
+		version(WebAssembly) ret ~= "wasm";
+		return ret;
+	} else assert(0);
 };
 
 /// private
 enum string archCheck = q{
-	string[] ret;
-	version(X86) ret ~= "x86";
-	// Hack: see #1535
-	// Makes "x86_omf" available as a platform specifier in the package recipe
-	version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
-	// Hack: see #1059
-	// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
-	// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
-	// And also makes "x86_mscoff" available as a platform specifier in the package recipe
-	version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
-	version(X86_64) ret ~= "x86_64";
-	version(ARM) ret ~= "arm";
-	version(AArch64) ret ~= "aarch64";
-	version(ARM_Thumb) ret ~= "arm_thumb";
-	version(ARM_SoftFloat) ret ~= "arm_softfloat";
-	version(ARM_HardFloat) ret ~= "arm_hardfloat";
-	version(PPC) ret ~= "ppc";
-	version(PPC_SoftFP) ret ~= "ppc_softfp";
-	version(PPC_HardFP) ret ~= "ppc_hardfp";
-	version(PPC64) ret ~= "ppc64";
-	version(IA64) ret ~= "ia64";
-	version(MIPS) ret ~= "mips";
-	version(MIPS32) ret ~= "mips32";
-	version(MIPS64) ret ~= "mips64";
-	version(MIPS_O32) ret ~= "mips_o32";
-	version(MIPS_N32) ret ~= "mips_n32";
-	version(MIPS_O64) ret ~= "mips_o64";
-	version(MIPS_N64) ret ~= "mips_n64";
-	version(MIPS_EABI) ret ~= "mips_eabi";
-	version(MIPS_NoFloat) ret ~= "mips_nofloat";
-	version(MIPS_SoftFloat) ret ~= "mips_softfloat";
-	version(MIPS_HardFloat) ret ~= "mips_hardfloat";
-	version(SPARC) ret ~= "sparc";
-	version(SPARC_V8Plus) ret ~= "sparc_v8plus";
-	version(SPARC_SoftFP) ret ~= "sparc_softfp";
-	version(SPARC_HardFP) ret ~= "sparc_hardfp";
-	version(SPARC64) ret ~= "sparc64";
-	version(S390) ret ~= "s390";
-	version(S390X) ret ~= "s390x";
-	version(HPPA) ret ~= "hppa";
-	version(HPPA64) ret ~= "hppa64";
-	version(SH) ret ~= "sh";
-	version(SH64) ret ~= "sh64";
-	version(Alpha) ret ~= "alpha";
-	version(Alpha_SoftFP) ret ~= "alpha_softfp";
-	version(Alpha_HardFP) ret ~= "alpha_hardfp";
-	return ret;
+	if (__ctfe) {
+		string[] ret;
+		version(X86) ret ~= "x86";
+		// Hack: see #1535
+		// Makes "x86_omf" available as a platform specifier in the package recipe
+		version(X86) version(CRuntime_DigitalMars) ret ~= "x86_omf";
+		// Hack: see #1059
+		// When compiling with --arch=x86_mscoff build_platform.architecture is equal to ["x86"] and canFind below is false.
+		// This hack prevents unnecessary warning 'Failed to apply the selected architecture x86_mscoff. Got ["x86"]'.
+		// And also makes "x86_mscoff" available as a platform specifier in the package recipe
+		version(X86) version(CRuntime_Microsoft) ret ~= "x86_mscoff";
+		version(X86_64) ret ~= "x86_64";
+		version(ARM) ret ~= "arm";
+		version(AArch64) ret ~= "aarch64";
+		version(ARM_Thumb) ret ~= "arm_thumb";
+		version(ARM_SoftFloat) ret ~= "arm_softfloat";
+		version(ARM_HardFloat) ret ~= "arm_hardfloat";
+		version(PPC) ret ~= "ppc";
+		version(PPC_SoftFP) ret ~= "ppc_softfp";
+		version(PPC_HardFP) ret ~= "ppc_hardfp";
+		version(PPC64) ret ~= "ppc64";
+		version(IA64) ret ~= "ia64";
+		version(MIPS) ret ~= "mips";
+		version(MIPS32) ret ~= "mips32";
+		version(MIPS64) ret ~= "mips64";
+		version(MIPS_O32) ret ~= "mips_o32";
+		version(MIPS_N32) ret ~= "mips_n32";
+		version(MIPS_O64) ret ~= "mips_o64";
+		version(MIPS_N64) ret ~= "mips_n64";
+		version(MIPS_EABI) ret ~= "mips_eabi";
+		version(MIPS_NoFloat) ret ~= "mips_nofloat";
+		version(MIPS_SoftFloat) ret ~= "mips_softfloat";
+		version(MIPS_HardFloat) ret ~= "mips_hardfloat";
+		version(SPARC) ret ~= "sparc";
+		version(SPARC_V8Plus) ret ~= "sparc_v8plus";
+		version(SPARC_SoftFP) ret ~= "sparc_softfp";
+		version(SPARC_HardFP) ret ~= "sparc_hardfp";
+		version(SPARC64) ret ~= "sparc64";
+		version(S390) ret ~= "s390";
+		version(S390X) ret ~= "s390x";
+		version(HPPA) ret ~= "hppa";
+		version(HPPA64) ret ~= "hppa64";
+		version(SH) ret ~= "sh";
+		version(SH64) ret ~= "sh64";
+		version(Alpha) ret ~= "alpha";
+		version(Alpha_SoftFP) ret ~= "alpha_softfp";
+		version(Alpha_HardFP) ret ~= "alpha_hardfp";
+		return ret;
+	} else assert(0);
 };
 
 /// private


### PR DESCRIPTION
When building D projects without a runtime for new platforms, dub will fail when there's no druntime for said platform.

This PR makes all the probePlatform calls use betterC so that runtime-less platforms can be built for with dub.

I need this for building D projects for the SuperH CPU architecture (as used in the SEGA Dreamcast and SEGA Saturn)

NOTE: This PR could be improved by checking the compiler versions before calling probePlatform, to ensure that older compilers without betterC support for the platform probe still works.