### PR TITLE
remove GeneratorSettings.cache

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1878,7 +1878,6 @@ class DescribeCommand : PackageBuildCommand {
 		GeneratorSettings settings = this.baseSettings;
 		if (!settings.config.length)
 			settings.config = m_defaultConfig;
-		settings.cache = dub.cachePathDontUse(); // See function's description
 		// Ignore other options
 		settings.buildSettings.options = this.baseSettings.buildSettings.options & BuildOption.lowmem;
 

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -165,7 +165,7 @@ class Dub {
 
 		m_packageSuppliers = this.computePkgSuppliers(additional_package_suppliers,
 			skip_registry, environment.get("DUB_REGISTRY", null));
-		m_packageManager = new PackageManager(m_rootPath, m_dirs.userPackages, m_dirs.systemSettings, false);
+		m_packageManager = new PackageManager(m_rootPath, m_dirs.userPackages, m_dirs.systemSettings, m_dirs.cache, false);
 
 		auto ccps = m_config.customCachePaths;
 		if (ccps.length)
@@ -199,7 +199,7 @@ class Dub {
 		// to prevent `init` from reading the project's settings.
 		init();
 		this.m_rootPath = root;
-		m_packageManager = new PackageManager(pkg_root);
+		m_packageManager = new PackageManager(pkg_root, m_dirs.cache);
 	}
 
 	deprecated("Use the overload that takes `(NativePath pkg_root, NativePath root)`")
@@ -698,7 +698,6 @@ class Dub {
 	*/
 	void generateProject(string ide, GeneratorSettings settings)
 	{
-		settings.cache = this.m_dirs.cache;
 		if (settings.overrideToolWorkingDirectory is NativePath.init)
 			settings.overrideToolWorkingDirectory = m_rootPath;
 		// With a requested `unittest` config, switch to the special test runner
@@ -719,7 +718,6 @@ class Dub {
 	*/
 	void testProject(GeneratorSettings settings, string config, NativePath custom_main_file)
 	{
-		settings.cache = this.m_dirs.cache;
 		if (settings.overrideToolWorkingDirectory is NativePath.init)
 			settings.overrideToolWorkingDirectory = m_rootPath;
 		if (!custom_main_file.empty && !custom_main_file.absolute) custom_main_file = m_rootPath ~ custom_main_file;
@@ -1343,22 +1341,14 @@ class Dub {
 	}
 
 	/**
-	 * Compute and returns the path were artifacts are stored
+	 * Compute and returns the path were artifacts are stored for the given
+	 * package.
 	 *
-	 * Expose `dub.generator.generator : packageCache` with this instance's
-	 * configured cache.
+	 * See `dub.packagemanager : PackageManager.packageCache`
 	 */
 	protected NativePath packageCache (Package pkg) const
 	{
-		return .packageCache(this.m_dirs.cache, pkg);
-	}
-
-	/// Exposed because `commandLine` replicates `generateProject` for `dub describe`
-	/// instead of treating it like a regular generator... Remove this once the
-	/// flaw is fixed, and don't add more calls to this function!
-	package(dub) NativePath cachePathDontUse () const @safe pure nothrow @nogc
-	{
-		return this.m_dirs.cache;
+		return m_packageManager.packageCache(pkg);
 	}
 
 	/// Make a `GeneratorSettings` suitable to generate tools (DDOC, DScanner, etc...)

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -263,7 +263,7 @@ class BuildGenerator : ProjectGenerator {
 			m_tempTargetExecutablePath = target_path = getTempDir() ~ format(".dub/build/%s-%s/%s/", packageName, pack.version_, build_id);
 		}
 		else
-			target_path = targetCacheDir(settings.cache, pack, build_id);
+			target_path = m_packageMan.targetCacheDir(pack, build_id);
 
 		if (!settings.force && isUpToDate(target_path, buildsettings, settings, pack, packages, additional_dep_files)) {
 			logInfo("Up-to-date", Color.green, "%s %s: target for configuration [%s] is up to date.",
@@ -316,7 +316,7 @@ class BuildGenerator : ProjectGenerator {
 		enum jsonFileName = "db.json";
 		enum lockFileName = "db.lock";
 
-		const pkgCacheDir = packageCache(settings.cache, pack);
+		const pkgCacheDir = m_packageMan.packageCache(pack);
 		auto lock = lockFile((pkgCacheDir ~ lockFileName).toNativeString(), 3.seconds);
 
 		const dbPath = pkgCacheDir ~ jsonFileName;
@@ -777,7 +777,7 @@ unittest { // issue #1235 - pass no library files to compiler command line when 
 
 	auto desc = parseJsonString(`{"name": "test", "targetType": "library", "sourceFiles": ["foo.d", "`~libfile~`"]}`);
 	auto pack = new Package(desc, NativePath("/tmp/fooproject"));
-	auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), false);
+	auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), NativePath("/tmp/cache/"), false);
 	auto prj = new Project(pman, pack);
 
 	final static class TestCompiler : GDCCompiler {

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -121,11 +121,13 @@ class ProjectGenerator
 	protected {
 		Project m_project;
 		NativePath m_tempTargetExecutablePath;
+		PackageManager m_packageMan;
 	}
 
 	this(Project project)
 	{
 		m_project = project;
+		m_packageMan = project.packageManager;
 	}
 
 	/** Performs the full generator process.
@@ -331,7 +333,7 @@ class ProjectGenerator
 
 		if (genSettings.filterVersions)
 			foreach (ref ti; targets.byValue)
-				inferVersionFilters(ti);
+				inferVersionFilters(m_packageMan, ti);
 
 		// mark packages as visited (only used during upwards propagation)
 		void[0][Package] visited;
@@ -629,7 +631,7 @@ class ProjectGenerator
 	}
 
 	// infer applicable version identifiers
-	private static void inferVersionFilters(ref TargetInfo ti)
+	private static void inferVersionFilters(PackageManager packageManager, ref TargetInfo ti)
 	{
 		import std.algorithm.searching : any;
 		import std.file : timeLastModified;
@@ -656,7 +658,7 @@ class ProjectGenerator
 		auto srcs = chain(bs.sourceFiles, bs.importFiles, bs.stringImportFiles)
 			.filter!(f => dexts.canFind(f.extension)).filter!exists;
 		// try to load cached filters first
-		const cacheFilePath = packageCache(NativePath(ti.buildSettings.targetPath), ti.pack)
+		const cacheFilePath = packageManager.packageCache(ti.pack)
 			~ "metadata_cache.json";
 		enum silent_fail = true;
 		auto cache = jsonFromFile(cacheFilePath, silent_fail);
@@ -683,7 +685,7 @@ class ProjectGenerator
 		catch (JSONException e)
 		{
 			logWarn("Exception during loading invalid package cache %s.\n%s",
-				ti.pack.path ~ ".dub/metadata_cache.json", e);
+				cacheFilePath.toNativeString(), e);
 		}
 
 		// use ctRegex for performance reasons, only small compile time increase
@@ -769,55 +771,6 @@ class ProjectGenerator
 }
 
 /**
- * Compute and returns the path were artifacts are stored for a given package
- *
- * Artifacts are stored in:
- * `$DUB_HOME/cache/$PKG_NAME/$PKG_VERSION[/+$SUB_PKG_NAME]/`
- * Note that the leading `+` in the sub-package name is to avoid any ambiguity.
- *
- * Dub writes in the returned path a Json description file of the available
- * artifacts in this cache location. This Json file is read by 3rd party
- * software (e.g. Meson). Returned path should therefore not change across
- * future Dub versions.
- *
- * Build artifacts are usually stored in a sub-folder named "build",
- * as their names are based on user-supplied values.
- *
- * Params:
- *   cachePath = Base path at which the build cache is located,
- *               e.g. `$HOME/.dub/cache/`
- *	 pkg = The package. Cannot be `null`.
- */
-package(dub) NativePath packageCache(NativePath cachePath, in Package pkg)
-{
-	import std.algorithm.searching : findSplit;
-
-	assert(pkg !is null);
-	assert(!cachePath.empty);
-
-	// For subpackages
-	if (const names = pkg.name.findSplit(":"))
-		return cachePath ~ names[0] ~ pkg.version_.toString()
-			~ ("+" ~ names[2]);
-	// For regular packages
-	return cachePath ~ pkg.name ~ pkg.version_.toString();
-}
-
-/**
- * Compute and return the directory where a target should be cached.
- *
- * Params:
- *   cachePath = Base path at which the build cache is located,
- *               e.g. `$HOME/.dub/cache/`
- *	 pkg = The package. Cannot be `null`.
- *   buildId = The build identifier of the target.
- */
-package(dub) NativePath targetCacheDir(NativePath cachePath, in Package pkg, string buildId)
-{
-	return packageCache(cachePath, pkg) ~ "build" ~ buildId;
-}
-
-/**
  * Provides a unique (per build) identifier
  *
  * When building a package, it is important to have a unique but stable
@@ -853,7 +806,6 @@ package(dub) string computeBuildID(in BuildSettings buildsettings, string config
 }
 
 struct GeneratorSettings {
-	NativePath cache;
 	BuildPlatform platform;
 	Compiler compiler;
 	string config;
@@ -1234,7 +1186,7 @@ version(Posix) {
 
 		auto desc = parseJsonString(`{"name": "test", "targetType": "library", "preGenerateCommands": ["touch $PACKAGE_DIR/source/bar.d"]}`);
 		auto pack = new Package(desc, NativePath("dubtest/preGen".absolutePath));
-		auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), false);
+		auto pman = new PackageManager(pack.path, NativePath("/tmp/foo/"), NativePath("/tmp/foo/"), NativePath("/tmp/cache/"), false);
 		auto prj = new Project(pman, pack);
 
 		final static class TestCompiler : GDCCompiler {

--- a/source/dub/generators/targetdescription.d
+++ b/source/dub/generators/targetdescription.d
@@ -12,15 +12,21 @@ import dub.compilers.compiler;
 import dub.description;
 import dub.generators.generator;
 import dub.internal.vibecompat.inet.path;
+import dub.packagemanager;
 import dub.project;
 
 class TargetDescriptionGenerator : ProjectGenerator {
 	TargetDescription[] targetDescriptions;
 	size_t[string] targetDescriptionLookup;
 
+	private {
+		PackageManager m_packageMan;
+	}
+
 	this(Project project)
 	{
 		super(project);
+		m_packageMan = project.packageManager;
 	}
 
 	protected override void generateTargets(GeneratorSettings settings, in TargetInfo[string] targets)
@@ -47,7 +53,7 @@ class TargetDescriptionGenerator : ProjectGenerator {
 			d.buildSettings = ti.buildSettings.dup;
 			const buildId = computeBuildID(d.buildSettings, ti.config, settings);
 			const filename = settings.compiler.getTargetFileName(d.buildSettings, settings.platform);
-			d.cacheArtifactPath = (targetCacheDir(settings.cache, ti.pack, buildId) ~ filename).toNativeString();
+			d.cacheArtifactPath = (m_packageMan.targetCacheDir(ti.pack, buildId) ~ filename).toNativeString();
 			d.dependencies = ti.dependencies.dup;
 			d.linkDependencies = ti.linkDependencies.dup;
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -321,7 +321,7 @@ class Project {
 			mainfile = getTempFile("dub_test_root", ".d");
 		else {
 			import dub.generators.build : computeBuildName;
-			mainfile = packageCache(settings.cache, this.rootPackage) ~
+			mainfile = m_packageManager.packageCache(this.rootPackage) ~
 				format("code/%s/dub_test_root.d",
 					computeBuildName(config, settings, import_modules));
 		}


### PR DESCRIPTION
instead the cache is a property of PackageManager

This way dub lib users don't have to try to figure out where the real cache path is and can just continue using the generator and describe APIs like in previous versions.

Customizing cache path is no longer easily possible and now must be done through creating a custom PackageManager and use that on `new Project()` to pass into the generators. If needed, APIs to modify m_dirs on startup could be added to Dub subclasses in the future.

Also for how the other code was setup, this looks like a more reasonable place to put the code, as well as PackageManager being a good place to handle path modification / generation.

Sadly the GeneratorSettings public API has already been released in a tag and thus this is a breaking change, that for example reggae also uses: https://github.com/atilaneves/reggae/blob/2302be1809edde6e1ac3552ee595970601f960ad/src/reggae/dub/interop/dublib.d#L70

However, at least for reggae, the migration would be trivial, since it already instantiates a custom PackageManager: https://github.com/atilaneves/reggae/blob/2302be1809edde6e1ac3552ee595970601f960ad/src/reggae/dub/interop/dublib.d#L208 and I suppose other apps wanting to control how DUB builds are not using `new Dub` either and instead create custom PackageManager instances.

For the usual dub-as-a-library user this PR allows users to start a DUB build, reusing the default DUB cache directory, without hardcoding or copying the DUB cache paths or SpecialDirs implementation from DUB itself. So I think this is definitely a better API than burdening the users with figuring out where the cache should go for builds if they just want to call `dub build` through the API.

Note: there was `metadata_cache.json` that still used the old non-central cache path? I moved that into the central cache path now, but maybe @Geod24 knows why this was not yet in the central cache? That part might still need a change.