### PR TITLE
keep track of specified source paths in target generator

### DIFF
--- a/changelog/describe-source-paths.dd
+++ b/changelog/describe-source-paths.dd
@@ -1,0 +1,10 @@
+Added `specified-source-paths` and `specified-c-source-paths` to `dub describe`
+
+- `specified-source-paths` is the `sourcePaths` value from the package recipe + merged with sourceLibraries
+- `specified-c-source-paths` is the same for `cSourcePaths`
+
+This is added to make it possible to determine the source paths for a project to
+pass for example into an auto-complete server or otherwise use them by the IDE.
+
+These are also new fields in the DUB API: `specifiedSourcePaths` and
+`specifiedCSourcePaths` inside the `BuildSettings` struct.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1817,7 +1817,8 @@ class DescribeCommand : PackageBuildCommand {
 			"target-type, target-path, target-name, working-directory, " ~
 			"copy-files, string-import-files, pre-generate-commands, " ~
 			"post-generate-commands, pre-build-commands, post-build-commands, " ~
-			"pre-run-commands, post-run-commands, requirements",
+			"pre-run-commands, post-run-commands, requirements, " ~
+			"specified-source-paths, specified-c-source-paths",
 		];
 	}
 

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -40,6 +40,8 @@ struct BuildSettings {
 	string[] debugVersions;
 	string[] versionFilters;
 	string[] debugVersionFilters;
+	string[] specifiedSourcePaths; /// sourcePaths, before globbing for *.d and writing into sourceFiles
+	string[] specifiedCSourcePaths; /// cSourcePaths, before globbing for *.{c,i} and writing into sourceFiles
 	string[] importPaths;
 	string[] cImportPaths;
 	string[] stringImportPaths;
@@ -106,6 +108,8 @@ struct BuildSettings {
 		addDebugVersions(bs.debugVersions);
 		addVersionFilters(bs.versionFilters);
 		addDebugVersionFilters(bs.debugVersionFilters);
+		addSpecifiedSourcePaths(bs.specifiedSourcePaths);
+		addSpecifiedCSourcePaths(bs.specifiedCSourcePaths);
 		addImportPaths(bs.importPaths);
 		addCImportPaths(bs.cImportPaths);
 		addStringImportPaths(bs.stringImportPaths);
@@ -147,6 +151,8 @@ struct BuildSettings {
 	void addDebugVersions(in string[] value...) { add(debugVersions, value); }
 	void addVersionFilters(in string[] value...) { add(versionFilters, value); }
 	void addDebugVersionFilters(in string[] value...) { add(debugVersionFilters, value); }
+	void addSpecifiedSourcePaths(in string[] value...) { add(specifiedSourcePaths, value); }
+	void addSpecifiedCSourcePaths(in string[] value...) { add(specifiedCSourcePaths, value); }
 	void addImportPaths(in string[] value...) { add(importPaths, value); }
 	void addCImportPaths(in string[] value...) { add(cImportPaths, value); }
 	void addStringImportPaths(in string[] value...) { add(stringImportPaths, value); }

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -739,6 +739,7 @@ class ProjectGenerator
 		parent.addDebugVersions(child.debugVersions);
 		parent.addVersionFilters(child.versionFilters);
 		parent.addDebugVersionFilters(child.debugVersionFilters);
+		// not merging specifiedSourcePaths and specifiedCSourcePaths, since they are not "specified" in this package
 		parent.addImportPaths(child.importPaths);
 		parent.addCImportPaths(child.cImportPaths);
 		parent.addStringImportPaths(child.stringImportPaths);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -1065,7 +1065,8 @@ class Project {
 			// Is relative path(s) to a directory?
 			enum isRelativeDirectory =
 				attributeName == "importPaths" || attributeName == "cImportPaths" || attributeName == "stringImportPaths" ||
-				attributeName == "targetPath" || attributeName == "workingDirectory";
+				attributeName == "targetPath" || attributeName == "workingDirectory" ||
+				attributeName == "specifiedSourcePaths" || attributeName == "specifiedCSourcePaths";
 
 			// Is relative path(s) to a file?
 			enum isRelativeFile =
@@ -1126,6 +1127,8 @@ class Project {
 			case "target-name":
 			case "working-directory":
 			case "string-import-files":
+			case "specified-source-paths":
+			case "specified-c-source-paths":
 			case "copy-files":
 			case "extra-dependency-files":
 			case "pre-generate-commands":
@@ -1179,6 +1182,8 @@ class Project {
 		case "debug-versions":             return listBuildSetting!"debugVersions"(args);
 		case "import-paths":               return listBuildSetting!"importPaths"(args);
 		case "string-import-paths":        return listBuildSetting!"stringImportPaths"(args);
+		case "specified-source-paths":     return listBuildSetting!"specifiedSourcePaths"(args);
+		case "specified-c-source-paths":   return listBuildSetting!"specifiedCSourcePaths"(args);
 		case "import-files":               return listBuildSetting!"importFiles"(args);
 		case "string-import-files":        return listBuildSetting!"stringImportFiles"(args);
 		case "pre-generate-commands":      return listBuildSetting!"preGenerateCommands"(args);
@@ -1338,6 +1343,8 @@ void processVars(ref BuildSettings dst, in Project project, in Package pack,
 	dst.addDebugVersions(processVars(project, pack, gsettings, settings.debugVersions, false, buildEnvs));
 	dst.addVersionFilters(processVars(project, pack, gsettings, settings.versionFilters, false, buildEnvs));
 	dst.addDebugVersionFilters(processVars(project, pack, gsettings, settings.debugVersionFilters, false, buildEnvs));
+	dst.addSpecifiedSourcePaths(processVars(project, pack, gsettings, settings.specifiedSourcePaths, true, buildEnvs));
+	dst.addSpecifiedCSourcePaths(processVars(project, pack, gsettings, settings.specifiedCSourcePaths, true, buildEnvs));
 	dst.addImportPaths(processVars(project, pack, gsettings, settings.importPaths, true, buildEnvs));
 	dst.addCImportPaths(processVars(project, pack, gsettings, settings.cImportPaths, true, buildEnvs));
 	dst.addStringImportPaths(processVars(project, pack, gsettings, settings.stringImportPaths, true, buildEnvs));

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -556,6 +556,8 @@ struct BuildSettingsTemplate {
 		getPlatformSetting!("debugVersions", "addDebugVersions")(dst, platform);
 		getPlatformSetting!("versionFilters", "addVersionFilters")(dst, platform);
 		getPlatformSetting!("debugVersionFilters", "addDebugVersionFilters")(dst, platform);
+		getPlatformSetting!("sourcePaths", "addSpecifiedSourcePaths")(dst, platform);
+		getPlatformSetting!("cSourcePaths", "addSpecifiedCSourcePaths")(dst, platform);
 		getPlatformSetting!("importPaths", "addImportPaths")(dst, platform);
 		getPlatformSetting!("cImportPaths", "addCImportPaths")(dst, platform);
 		getPlatformSetting!("stringImportPaths", "addStringImportPaths")(dst, platform);

--- a/test/4-describe-data-1-list.sh
+++ b/test/4-describe-data-1-list.sh
@@ -23,6 +23,8 @@ if ! $DUB describe --compiler=$DC --filter-versions \
     '--data=versions, debug-versions' \
     --data=import-paths \
     --data=string-import-paths \
+    --data=specified-source-paths \
+    --data=specified-c-source-paths \
     --data=import-files \
     --data=string-import-files \
     --data=pre-generate-commands \
@@ -99,6 +101,14 @@ echo >> "$expected_file"
 echo "$CURR_DIR/describe-project/views/" >> "$expected_file"
 echo "$CURR_DIR/describe-dependency-2/some-extra-string-import-path/" >> "$expected_file"
 echo "$CURR_DIR/describe-dependency-3/dep3-string-import-path/" >> "$expected_file"
+echo >> "$expected_file"
+# --data=specified-source-paths
+echo "$CURR_DIR/describe-project/src/" >> "$expected_file"
+echo "$CURR_DIR/describe-dependency-1/source/" >> "$expected_file"
+echo >> "$expected_file"
+# --data=specified-c-source-paths
+# no C source paths
+echo >> "$expected_file"
 echo >> "$expected_file"
 # --data=import-files
 echo "$CURR_DIR/describe-dependency-2/some-path/dummy.d" >> "$expected_file"

--- a/test/dub-as-a-library-generator/.gitignore
+++ b/test/dub-as-a-library-generator/.gitignore
@@ -1,0 +1,1 @@
+/dub-as-a-library-generator

--- a/test/dub-as-a-library-generator/dub.json
+++ b/test/dub-as-a-library-generator/dub.json
@@ -1,0 +1,9 @@
+{
+	"name": "dub-as-a-library-generator",
+	"workingDirectory": ".",
+	"dependencies": {
+		"dub": {
+			"path": "../.."
+		}
+	}
+}

--- a/test/dub-as-a-library-generator/source/app.d
+++ b/test/dub-as-a-library-generator/source/app.d
@@ -1,0 +1,51 @@
+import dub.compilers.buildsettings;
+import dub.compilers.compiler;
+import dub.dub;
+import dub.generators.generator;
+import dub.generators.targetdescription;
+import dub.internal.vibecompat.inet.path;
+import std.algorithm;
+import std.conv;
+import std.file;
+import std.path;
+import std.stdio;
+
+void main(string[] args)
+{
+	auto project = buildNormalizedPath(getcwd, "subproject");
+	auto projectPath = NativePath(project);
+
+	auto dub = new Dub(project, null, SkipPackageSuppliers.none);
+	dub.packageManager.getOrLoadPackage(NativePath(project));
+	dub.loadPackage();
+	dub.project.validate();
+
+	GeneratorSettings gs;
+	gs.cache = NativePath(tempDir);
+	gs.buildType = "debug";
+	gs.config = "application";
+	gs.compiler = getCompiler(dub.defaultCompiler);
+
+	auto gen = new TargetDescriptionGenerator(dub.project);
+	gen.generate(gs);
+
+	assert(gen.targetDescriptions.length == 2);
+	assert(gen.targetDescriptionLookup["root"] == 0);
+	assert(gen.targetDescriptionLookup["root:sub"] == 1);
+
+	auto rootBs = gen.targetDescriptions[0].buildSettings;
+	auto subBs = gen.targetDescriptions[1].buildSettings;
+
+	assert(rootBs.specifiedSourcePaths.length == 1);
+	assert(NativePath(rootBs.specifiedSourcePaths[0]).equalsDir(projectPath ~ "source"));
+	assert(subBs.specifiedSourcePaths.length == 2);
+	assert(NativePath(subBs.specifiedSourcePaths[0]).equalsDir(projectPath ~ "sub" ~ "source"));
+	assert(NativePath(subBs.specifiedSourcePaths[1]).equalsDir(projectPath ~ "sub" ~ "impl"));
+}
+
+bool equalsDir(NativePath a, NativePath b)
+{
+	a.endsWithSlash = false;
+	b.endsWithSlash = false;
+	return a == b;
+}

--- a/test/dub-as-a-library-generator/subproject/dub.sdl
+++ b/test/dub-as-a-library-generator/subproject/dub.sdl
@@ -1,0 +1,4 @@
+name "root"
+authors "webfreak"
+subPackage "sub"
+dependency ":sub" version="*"

--- a/test/dub-as-a-library-generator/subproject/source/app.d
+++ b/test/dub-as-a-library-generator/subproject/source/app.d
@@ -1,0 +1,9 @@
+import std.stdio;
+
+import lib : foo;
+// import lib_impl : bar;
+
+void main()
+{
+	writeln("Edit source/app.d to start your project.");
+}

--- a/test/dub-as-a-library-generator/subproject/sub/dub.sdl
+++ b/test/dub-as-a-library-generator/subproject/sub/dub.sdl
@@ -1,0 +1,4 @@
+name "sub"
+sourcePaths "source" "impl"
+importPaths "source"
+

--- a/test/dub-as-a-library-generator/subproject/sub/impl/lib_impl.d
+++ b/test/dub-as-a-library-generator/subproject/sub/impl/lib_impl.d
@@ -1,0 +1,6 @@
+module lib_impl;
+
+void bar()
+{
+
+}

--- a/test/dub-as-a-library-generator/subproject/sub/source/lib.d
+++ b/test/dub-as-a-library-generator/subproject/sub/source/lib.d
@@ -1,0 +1,8 @@
+module lib;
+
+import lib_impl;
+
+void foo()
+{
+
+}


### PR DESCRIPTION
Makes target generator & dub describe able to print which source _paths_ are specified for each package, instead of only listing all the *.d files that have been globbed.

Someone at Funkwerk told me their packages are often using sourcePaths separately from importPaths for packages, so this should cover that use-case and make it possible to implement properly in serve-d.