### PR TITLE
platform: add support for LoongArch

### DIFF
--- a/source/dub/platform.d
+++ b/source/dub/platform.d
@@ -98,6 +98,10 @@ enum string archCheck = q{
 	version(Alpha) ret ~= "alpha";
 	version(Alpha_SoftFP) ret ~= "alpha_softfp";
 	version(Alpha_HardFP) ret ~= "alpha_hardfp";
+	version(LoongArch32) ret ~= "loongarch32";
+	version(LoongArch64) ret ~= "loongarch64";
+	version(LoongArch_SoftFloat) ret ~= "loongarch_softfloat";
+	version(LoongArch_HardFloat) ret ~= "loongarch_hardfloat";
 	return ret;
 };
 


### PR DESCRIPTION
This pull request adds the platform probing support for LoongArch.

This is part of the pull request series that adds the D language support for LoongArch.
You can find the pull request for `druntime` support at https://github.com/dlang/dmd/pull/15628.