### PR TITLE
Leave dependencies results in tmp dir if they can't get writen to their target directory

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -294,8 +294,13 @@ class BuildGenerator : ProjectGenerator {
 		target_binary_path = getTargetPath(cbuildsettings, settings);
 
 		if (!settings.tempBuild) {
-			copyTargetFile(target_path, buildsettings, settings);
-			updateCacheDatabase(settings, cbuildsettings, pack, config, build_id, target_binary_path.toNativeString());
+            try {
+                copyTargetFile(target_path, buildsettings, settings);
+                updateCacheDatabase(settings, cbuildsettings, pack, config, build_id, target_binary_path.toNativeString());
+            } catch (std.file.FileException e) {
+                logWarn("Can't copy result to target, leaving it in the cache.");
+                logDiagnostic("Full error: %s", e.toString().sanitize);
+            }
 		}
 
 		return false;


### PR DESCRIPTION
When you try to build an app with dub and one of their dependencies is located in a read-only directory, the whole process fails with the following message (when running with --vverbose):

```
Error <target file>: Read-only file system
Full exception: std.file.FileException@std/file.d(4332): <target file>: Read-only file system
----------------
??:? @trusted void std.file.copyImpl(scope const(char)[], scope const(char)[], scope const(char)*, scope const(char)*, std.typecons.Flag!("preserveAttributes").Flag) [0x7efe6d875c59]
source/dub/compilers/buildsettings.d:4251 [0x516daf]
source/dub/internal/vibecompat/core/file.d:78 [0x4d4b12]
source/dub/internal/vibecompat/core/file.d:193 [0x51722e]
source/dub/generators/build.d:509 [0x67f30c]
source/dub/generators/build.d:299 [0x67e01d]
source/dub/generators/build.d:234 [0x679e50]
source/dub/generators/build.d:174 [0x67aadc]
source/dub/generators/build.d:128 [0x67a3cf]
source/dub/generators/build.d:180 [0x678fa6]
source/dub/generators/generator.d:185 [0x4b798d]
source/dub/commandline.d:1463 [0x7b4891]
source/dub/commandline.d [0x7b4d5d]
source/dub/commandline.d:509 [0x6f9b64]
??:? void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).runAll() [0x7efe6d520b8c]
??:? _d_run_main2 [0x7efe6d5209a2]
??:? _d_run_main [0x7efe6d5207ec]
??:? [0x7efe6d17b149]
??:? __libc_start_main [0x7efe6d17b20a]
??:? [0x47d914]
```

This patch adds code to catch that exception and stop the dependency from being copied to the target directory, letting the build process to continue using the dependency results directly from the tmp-dir.

This might help to solve #1473