### PR TITLE
packagesuppliers/filesystem.d: Only glob versions of a package_id

### DIFF
--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -26,12 +26,16 @@ class FileSystemPackageSupplier : PackageSupplier {
 		import std.algorithm.sorting : sort;
 		import std.file : dirEntries, DirEntry, SpanMode;
 		import std.conv : to;
+		import dub.semver : isValidVersion;
 		Version[] ret;
-		foreach (DirEntry d; dirEntries(m_path.toNativeString(), package_id~"*", SpanMode.shallow)) {
+		foreach (DirEntry d; dirEntries(m_path.toNativeString(), package_id~"*.zip", SpanMode.shallow)) {
 			NativePath p = NativePath(d.name);
-			logDebug("Entry: %s", p);
-			enforce(to!string(p.head)[$-4..$] == ".zip");
 			auto vers = p.head.name[package_id.length+1..$-4];
+			if (!isValidVersion(vers)) {
+				logDebug("Ignoring entry '%s' because it isn't a version of package '%s'", p, package_id);
+				continue;
+			}
+			logDebug("Entry: %s", p);
 			logDebug("Version: %s", vers);
 			ret ~= Version(vers);
 		}


### PR DESCRIPTION
When looking for versions of a package don't include other packages that start with the same name as the queried package. This is done by requiring that the first character after the - is a digit.

If a directory contains the files botan-1.zip and botan-math-2.zip the current implementation would report both 1 and math-2 as candidates followed by an error that math-2 is not a valid version:
```
$ ls /tmp/mytest
botan-1.13.4.zip  botan-1.13.5.zip  botan-1.13.6.zip  botan-math-1.0.3.zip  botan-math-1.0.4.zip  repo

$ dub --vverbose --cache=local --registry=file:///tmp/mytest/ --skip-registry=all fetch botan@1.13.6
Note: Failed to determine version of package repo at .. Assuming ~master.
Entry: /tmp/mytest/botan-math-1.0.3.zip
Version: math-1.0.3
     Warning Package botan not found for file repository at /tmp/mytest/: Invalid SemVer format: math-1.0.3
Full error: object.Exception@source/dub/dependency.d(783): Invalid SemVer format: math-1.0.3
----------------
??:? pure @safe noreturn std.exception.bailOut!(Exception).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x55c1f07c9a9b]
??:? pure @safe bool std.exception.enforce!().enforce!(bool).enforce(bool, lazy const(char)[], immutable(char)[], ulong) [0x55c1f07c9a1c]
??:? pure ref @safe dub.dependency.Version dub.dependency.Version.__ctor(immutable(char)[]) [0x55c1f0963092]
??:? dub.dependency.Version[] dub.packagesuppliers.filesystem.FileSystemPackageSupplier.getVersions(immutable(char)[]) [0x55c1f0b7ba72]
??:? dub.internal.vibecompat.inet.path.NativePath dub.packagesuppliers.filesystem.FileSystemPackageSupplier.bestPackageFile(immutable(char)[], dub.dependency.Dependency, bool) [0x55c1f0b7c0a6]
??:? dub.internal.vibecompat.data.json.Json dub.packagesuppliers.filesystem.FileSystemPackageSupplier.fetchPackageRecipe(immutable(char)[], dub.dependency.Dependency, bool) [0x55c1f0b7bdab]
??:? dub.package_.Package dub.dub.Dub.fetch(immutable(char)[], in dub.dependency.VersionRange, dub.packagemanager.PlacementLocation, dub.dub.FetchOptions, immutable(char)[]) [0x55c1f0973a1e]
??:? int dub.commandline.FetchCommand.execute(dub.dub.Dub, immutable(char)[][], immutable(char)[][]) [0x55c1f07bbef6]
??:? int dub.commandline.runDubCommandLine(immutable(char)[][]) [0x55c1f07b4a15]
??:? _Dmain [0x55c1f0797fe7]
Error No package botan was found matching the dependency 1.13.6
Full exception: object.Exception@source/dub/dub.d(866): No package botan was found matching the dependency 1.13.6
----------------
??:? pure @safe noreturn std.exception.bailOut!(Exception).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x55c1f07c9a9b]
??:? pure @safe bool std.exception.enforce!().enforce!(bool).enforce(bool, lazy const(char)[], immutable(char)[], ulong) [0x55c1f07c9a1c]
??:? dub.package_.Package dub.dub.Dub.fetch(immutable(char)[], in dub.dependency.VersionRange, dub.packagemanager.PlacementLocation, dub.dub.FetchOptions, immutable(char)[]) [0x55c1f0973b73]
??:? int dub.commandline.FetchCommand.execute(dub.dub.Dub, immutable(char)[][], immutable(char)[][]) [0x55c1f07bbef6]
??:? int dub.commandline.runDubCommandLine(immutable(char)[][]) [0x55c1f07b4a15]
??:? _Dmain [0x55c1f0797fe7]

```