### PR TITLE
Remove unused iterateDirectory(string)

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2677,7 +2677,7 @@ class DustmiteCommand : PackageBuildCommand {
 			void copyFolderRec(NativePath folder, NativePath dstfolder)
 			{
 				ensureDirectory(dstfolder);
-				foreach (de; iterateDirectory(folder.toNativeString())) {
+				foreach (de; iterateDirectory(folder)) {
 					if (de.name.startsWith(".")) continue;
 					if (de.isDirectory) {
 						copyFolderRec(folder ~ de.name, dstfolder ~ de.name);

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -1022,7 +1022,7 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 			void copyFolderRec(NativePath folder, NativePath dstfolder)
 			{
 				ensureDirectory(dstfolder);
-				foreach (de; iterateDirectory(folder.toNativeString())) {
+				foreach (de; iterateDirectory(folder)) {
 					if (de.isDirectory) {
 						copyFolderRec(folder ~ de.name, dstfolder ~ de.name);
 					} else {

--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -277,12 +277,6 @@ int delegate(scope int delegate(ref FileInfo)) iterateDirectory(NativePath path)
 	}
 	return &iterator;
 }
-/// ditto
-int delegate(scope int delegate(ref FileInfo)) iterateDirectory(string path)
-{
-	return iterateDirectory(NativePath(path));
-}
-
 
 /**
 	Returns the current working directory.


### PR DESCRIPTION
It was actually unused, because al the call sites were doing a useless round-trip from NativePath to string to NativePath. There is no need for it anymore so we can just remove it to avoid this kind of mistakes in the future.