### PR TITLE
Move application code for static ctor in main module

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -9,6 +9,20 @@ module app;
 
 import dub.commandline;
 
+// Set output path and options for coverage reports
+version (DigitalMars) version (D_Coverage)
+{
+	shared static this()
+	{
+		import core.runtime, std.file, std.path, std.stdio;
+		dmd_coverSetMerge(true);
+		auto path = buildPath(dirName(thisExePath()), "../cov");
+		if (!path.exists)
+			mkdir(path);
+		dmd_coverDestPath(path);
+	}
+}
+
 /**
  * Workaround https://github.com/dlang/dub/issues/1812
  *

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -33,20 +33,6 @@ import std.process : environment;
 import std.range : assumeSorted, empty;
 import std.string;
 
-// Set output path and options for coverage reports
-version (DigitalMars) version (D_Coverage)
-{
-	shared static this()
-	{
-		import core.runtime, std.file, std.path, std.stdio;
-		dmd_coverSetMerge(true);
-		auto path = buildPath(dirName(thisExePath()), "../cov");
-		if (!path.exists)
-			mkdir(path);
-		dmd_coverDestPath(path);
-	}
-}
-
 static this()
 {
 	import dub.compilers.dmd : DMDCompiler;


### PR DESCRIPTION
This code could easily mess with library users as it has some side effects, so move it somewhere it will only affect the binary.