### PR TITLE
Change PackageSupplier interface to accept VersionRange

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -848,7 +848,7 @@ class Dub {
 		PackageSupplier supplier;
 		foreach(ps; m_packageSuppliers){
 			try {
-				pinfo = ps.fetchPackageRecipe(basePackageName, Dependency(range), (options & FetchOptions.usePrerelease) != 0);
+				pinfo = ps.fetchPackageRecipe(basePackageName, range, (options & FetchOptions.usePrerelease) != 0);
 				if (pinfo.type == Json.Type.null_)
 					continue;
 				supplier = ps;
@@ -895,7 +895,7 @@ class Dub {
 			import std.zip : ZipException;
 
 			auto path = getTempFile(basePackageName, ".zip");
-			supplier.fetchPackage(path, basePackageName, Dependency(range), (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
+			supplier.fetchPackage(path, basePackageName, range, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
 			scope(exit) removeFile(path);
 			logDiagnostic("Placing to %s...", location.toString());
 
@@ -1790,7 +1790,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		foreach (ps; m_dub.m_packageSuppliers) {
 			if (rootpack == name) {
 				try {
-					auto desc = ps.fetchPackageRecipe(name, dep, prerelease);
+					auto desc = ps.fetchPackageRecipe(name, VersionRange(vers, vers), prerelease);
 					if (desc.type == Json.Type.null_)
 						continue;
 					auto ret = new Package(desc);

--- a/source/dub/packagesuppliers/fallback.d
+++ b/source/dub/packagesuppliers/fallback.d
@@ -29,8 +29,8 @@ package abstract class AbstractFallbackPackageSupplier : PackageSupplier
 
 	// Workaround https://issues.dlang.org/show_bug.cgi?id=2525
 	abstract override Version[] getVersions(string package_id);
-	abstract override void fetchPackage(NativePath path, string package_id, Dependency dep, bool pre_release);
-	abstract override Json fetchPackageRecipe(string package_id, Dependency dep, bool pre_release);
+	abstract override void fetchPackage(NativePath path, string package_id, in VersionRange dep, bool pre_release);
+	abstract override Json fetchPackageRecipe(string package_id, in VersionRange dep, bool pre_release);
 	abstract override SearchResult[] searchPackages(string query);
 }
 

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -39,7 +39,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, string packageId, in VersionRange dep, bool pre_release)
 	{
 		import dub.internal.vibecompat.core.file : copyFile, existsFile;
 		enforce(path.absolute);
@@ -49,7 +49,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		copyFile(filename, path);
 	}
 
-	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(string packageId, in VersionRange dep, bool pre_release)
 	{
 		import std.array : split;
 		import std.path : stripExtension;
@@ -76,7 +76,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		return null;
 	}
 
-	private NativePath bestPackageFile(string packageId, Dependency dep, bool pre_release)
+	private NativePath bestPackageFile(string packageId, in VersionRange dep, bool pre_release)
 	{
 		import std.algorithm.iteration : filter;
 		import std.array : array;

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -47,7 +47,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, string packageId, in VersionRange dep, bool pre_release)
 	{
 		import std.format : format;
 		auto md = getMetadata(packageId);
@@ -71,7 +71,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		throw new Exception("Failed to download package %s from %s".format(packageId, url));
 	}
 
-	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(string packageId, in VersionRange dep, bool pre_release)
 	{
 		auto md = getMetadata(packageId);
 		return getBestPackage(md, packageId, dep, pre_release);
@@ -125,7 +125,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		auto md = getMetadata(query);
 		if (md.type == Json.Type.null_)
 			return null;
-		auto json = getBestPackage(md, query, Dependency.any, true);
+		auto json = getBestPackage(md, query, VersionRange.Any, true);
 		return [SearchResult(json["name"].opt!string, "", json["version"].opt!string)];
 	}
 }

--- a/source/dub/packagesuppliers/registry.d
+++ b/source/dub/packagesuppliers/registry.d
@@ -1,5 +1,6 @@
 module dub.packagesuppliers.registry;
 
+import dub.dependency;
 import dub.packagesuppliers.packagesupplier;
 
 package enum PackagesPath = "packages";
@@ -48,7 +49,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	auto genPackageDownloadUrl(string packageId, Dependency dep, bool pre_release)
+	auto genPackageDownloadUrl(string packageId, in VersionRange dep, bool pre_release)
 	{
 		import std.array : replace;
 		import std.format : format;
@@ -64,7 +65,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		return ret;
 	}
 
-	void fetchPackage(NativePath path, string packageId, Dependency dep, bool pre_release)
+	void fetchPackage(NativePath path, string packageId, in VersionRange dep, bool pre_release)
 	{
 		import std.format : format;
 		auto url = genPackageDownloadUrl(packageId, dep, pre_release);
@@ -84,7 +85,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		throw new Exception("Failed to download package %s from %s".format(packageId, url));
 	}
 
-	Json fetchPackageRecipe(string packageId, Dependency dep, bool pre_release)
+	Json fetchPackageRecipe(string packageId, in VersionRange dep, bool pre_release)
 	{
 		auto md = getMetadata(packageId);
 		return getBestPackage(md, packageId, dep, pre_release);


### PR DESCRIPTION
This is a leftover of the time when everything in dub accepted Dependency. While the mess had been untangled, doing so on this interface proved harder, as there is no good way to deprecate it in a fully backward-compatible manner without introducing a lot of overhead (a new type). Instead, this uses a middle ground approach, where the external implementers (which most likely do not exists) would break (although the fix is trivial), but callers would not.