### PR TITLE
Trivial: Simplify some deprecated code

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -795,9 +795,7 @@ class Dub {
 	deprecated("Use `clean(Package)` instead")
 	void cleanPackage(NativePath path)
 	{
-		auto ppack = Package.findPackageFile(path);
-		enforce(!ppack.empty, "No package found.", path.toNativeString());
-		this.clean(Package.load(path, ppack));
+		this.clean(Package.load(path));
 	}
 
 	/// Ditto


### PR DESCRIPTION
While this code is deprecated, it is confusing as it is using findPackageFile only to provide a worse error message than one would have got by simply calling Package.load.