### PR TITLE
Trivial: Remove dead import from dub.dependency

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -7,11 +7,8 @@
 */
 module dub.dependency;
 
-import dub.internal.utils;
-import dub.internal.vibecompat.core.file;
 import dub.internal.vibecompat.data.json;
 import dub.internal.vibecompat.inet.path;
-import dub.package_;
 import dub.semver;
 import dub.internal.logging;
 


### PR DESCRIPTION
This module is not performing any IO besides logging,
and doesn't use package_ or utils.