### PR TITLE
Change platform dependency to use a VersionRange

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -677,11 +677,10 @@ class Package {
 		const dep = m_info.toolchainRequirements.dub;
 
 		static assert(dubVersion.length);
-		immutable dv = dubVersion[(dubVersion[0] == 'v') .. $];
-		static assert(isValidVersion(dv));
+		immutable dv = Version(dubVersion[(dubVersion[0] == 'v') .. $]);
 
 		enforce(dep.matches(dv),
-			"dub-" ~ dv ~ " does not comply with toolchainRequirements.dub "
+			"dub-" ~ dv.toString() ~ " does not comply with toolchainRequirements.dub "
 			~ "specification: " ~ m_info.toolchainRequirements.dub.toString()
 			~ "\nPlease consider upgrading your DUB installation");
 	}

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -332,11 +332,11 @@ private void parseJson(ref ToolchainRequirements tr, Json json)
 private Json toJson(const scope ref ToolchainRequirements tr)
 {
 	auto ret = Json.emptyObject;
-	if (tr.dub != Dependency.any) ret["dub"] = serializeToJson(tr.dub);
-	if (tr.frontend != Dependency.any) ret["frontend"] = serializeToJson(tr.frontend);
-	if (tr.dmd != Dependency.any) ret["dmd"] = serializeToJson(tr.dmd);
-	if (tr.ldc != Dependency.any) ret["ldc"] = serializeToJson(tr.ldc);
-	if (tr.gdc != Dependency.any) ret["gdc"] = serializeToJson(tr.gdc);
+	if (tr.dub != VersionRange.Any) ret["dub"] = serializeToJson(tr.dub);
+	if (tr.frontend != VersionRange.Any) ret["frontend"] = serializeToJson(tr.frontend);
+	if (tr.dmd != VersionRange.Any) ret["dmd"] = serializeToJson(tr.dmd);
+	if (tr.ldc != VersionRange.Any) ret["ldc"] = serializeToJson(tr.ldc);
+	if (tr.gdc != VersionRange.Any) ret["gdc"] = serializeToJson(tr.gdc);
 	return ret;
 }
 

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -213,32 +213,32 @@ struct ToolchainRequirements
 	// currently it fails because `Dependency.opCmp` is not CTFE-able.
 
 	/// DUB version requirement
-	@Optional @converter((scope ConfigParser!Dependency p) => p.node.as!string.parseDependency)
-	Dependency dub = Dependency.any;
+	@Optional @converter((scope ConfigParser!VersionRange p) => p.node.as!string.parseVersionRange)
+	VersionRange dub = VersionRange.Any;
 	/// D front-end version requirement
-	@Optional @converter((scope ConfigParser!Dependency p) => p.node.as!string.parseDMDDependency)
-	Dependency frontend = Dependency.any;
+	@Optional @converter((scope ConfigParser!VersionRange p) => p.node.as!string.parseDMDDependency)
+	VersionRange frontend = VersionRange.Any;
 	/// DMD version requirement
-	@Optional @converter((scope ConfigParser!Dependency p) => p.node.as!string.parseDMDDependency)
-	Dependency dmd = Dependency.any;
+	@Optional @converter((scope ConfigParser!VersionRange p) => p.node.as!string.parseDMDDependency)
+	VersionRange dmd = VersionRange.Any;
 	/// LDC version requirement
-	@Optional @converter((scope ConfigParser!Dependency p) => p.node.as!string.parseDependency)
-	Dependency ldc = Dependency.any;
+	@Optional @converter((scope ConfigParser!VersionRange p) => p.node.as!string.parseVersionRange)
+	VersionRange ldc = VersionRange.Any;
 	/// GDC version requirement
-	@Optional @converter((scope ConfigParser!Dependency p) => p.node.as!string.parseDependency)
-	Dependency gdc = Dependency.any;
+	@Optional @converter((scope ConfigParser!VersionRange p) => p.node.as!string.parseVersionRange)
+	VersionRange gdc = VersionRange.Any;
 
 	/** Get the list of supported compilers.
 
 		Returns:
 			An array of couples of compiler name and compiler requirement
 	*/
-	@property Tuple!(string, Dependency)[] supportedCompilers() const
+	@property Tuple!(string, VersionRange)[] supportedCompilers() const
 	{
-		Tuple!(string, Dependency)[] res;
-		if (dmd != Dependency.invalid) res ~= Tuple!(string, Dependency)("dmd", dmd);
-		if (ldc != Dependency.invalid) res ~= Tuple!(string, Dependency)("ldc", ldc);
-		if (gdc != Dependency.invalid) res ~= Tuple!(string, Dependency)("gdc", gdc);
+		Tuple!(string, VersionRange)[] res;
+		if (dmd != VersionRange.Invalid) res ~= Tuple!(string, VersionRange)("dmd", dmd);
+		if (ldc != VersionRange.Invalid) res ~= Tuple!(string, VersionRange)("ldc", ldc);
+		if (gdc != VersionRange.Invalid) res ~= Tuple!(string, VersionRange)("gdc", gdc);
 		return res;
 	}
 
@@ -246,7 +246,7 @@ struct ToolchainRequirements
 	const {
 		import std.algorithm.searching : all;
 		return only(dub, frontend, dmd, ldc, gdc)
-			.all!(r => r == Dependency.any);
+			.all!(r => r == VersionRange.Any);
 	}
 }
 
@@ -618,39 +618,41 @@ package(dub) void checkPlatform(const scope ref ToolchainRequirements tr, BuildP
 	import std.algorithm.iteration : map;
 	import std.format : format;
 
-	string compilerver;
-	Dependency compilerspec;
+	Version compilerver;
+	VersionRange compilerspec;
 
 	switch (platform.compiler) {
 		default:
-			compilerspec = Dependency.any;
-			compilerver = "0.0.0";
+			compilerspec = VersionRange.Any;
+			compilerver = Version.minRelease;
 			break;
 		case "dmd":
 			compilerspec = tr.dmd;
 			compilerver = platform.compilerVersion.length
-				? dmdLikeVersionToSemverLike(platform.compilerVersion)
-				: "0.0.0";
+				? Version(dmdLikeVersionToSemverLike(platform.compilerVersion))
+				: Version.minRelease;
 			break;
 		case "ldc":
 			compilerspec = tr.ldc;
-			compilerver = platform.compilerVersion;
-			if (!compilerver.length) compilerver = "0.0.0";
+			compilerver = platform.compilerVersion.length
+				? Version(platform.compilerVersion)
+				: Version.minRelease;
 			break;
 		case "gdc":
 			compilerspec = tr.gdc;
-			compilerver = platform.compilerVersion;
-			if (!compilerver.length) compilerver = "0.0.0";
+			compilerver = platform.compilerVersion.length
+				? Version(platform.compilerVersion)
+				: Version.minRelease;
 			break;
 	}
 
-	enforce(compilerspec != Dependency.invalid,
+	enforce(compilerspec != VersionRange.Invalid,
 		format(
 			"Installed %s %s is not supported by %s. Supported compiler(s):\n%s",
 			platform.compiler, platform.compilerVersion, package_name,
 			tr.supportedCompilers.map!((cs) {
 				auto str = "  - " ~ cs[0];
-				if (cs[1] != Dependency.any) str ~= ": " ~ cs[1].toString();
+				if (cs[1] != VersionRange.Any) str ~= ": " ~ cs[1].toString();
 				return str;
 			}).join("\n")
 		)
@@ -665,7 +667,7 @@ package(dub) void checkPlatform(const scope ref ToolchainRequirements tr, BuildP
 		)
 	);
 
-	enforce(tr.frontend.matches(dmdLikeVersionToSemverLike(platform.frontendVersionString)),
+	enforce(tr.frontend.matches(Version(dmdLikeVersionToSemverLike(platform.frontendVersionString))),
 		format(
 			"Installed %s-%s with frontend %s does not comply with %s frontend requirement: %s\n" ~
 			"Please consider upgrading your installation.",
@@ -679,33 +681,31 @@ package bool addRequirement(ref ToolchainRequirements req, string name, string v
 {
 	switch (name) {
 		default: return false;
-		case "dub": req.dub = parseDependency(value); break;
+		case "dub": req.dub = parseVersionRange(value); break;
 		case "frontend": req.frontend = parseDMDDependency(value); break;
-		case "ldc": req.ldc = parseDependency(value); break;
-		case "gdc": req.gdc = parseDependency(value); break;
+		case "ldc": req.ldc = parseVersionRange(value); break;
+		case "gdc": req.gdc = parseVersionRange(value); break;
 		case "dmd": req.dmd = parseDMDDependency(value); break;
 	}
 	return true;
 }
 
-private static Dependency parseDependency(string dep)
+private VersionRange parseVersionRange(string dep)
 {
-	if (dep == "no") return Dependency.invalid;
-	return Dependency(dep);
+	if (dep == "no") return VersionRange.Invalid;
+	return VersionRange.fromString(dep);
 }
 
-private static Dependency parseDMDDependency(string dep)
+private VersionRange parseDMDDependency(string dep)
 {
-	import dub.dependency : Dependency;
 	import std.algorithm : map, splitter;
 	import std.array : join;
 
-	if (dep == "no") return Dependency.invalid;
-	return dep
+	if (dep == "no") return VersionRange.Invalid;
+	return VersionRange.fromString(dep
 		.splitter(' ')
 		.map!(r => dmdLikeVersionToSemverLike(r))
-		.join(' ')
-		.Dependency;
+		.join(' '));
 }
 
 private T clone(T)(ref const(T) val)

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -327,11 +327,11 @@ private void parseToolchainRequirements(ref ToolchainRequirements tr, Tag tag)
 private Tag toSDL(const ref ToolchainRequirements tr)
 {
 	Attribute[] attrs;
-	if (tr.dub != Dependency.any) attrs ~= new Attribute("dub", Value(tr.dub.toString()));
-	if (tr.frontend != Dependency.any) attrs ~= new Attribute("frontend", Value(tr.frontend.toString()));
-	if (tr.dmd != Dependency.any) attrs ~= new Attribute("dmd", Value(tr.dmd.toString()));
-	if (tr.ldc != Dependency.any) attrs ~= new Attribute("ldc", Value(tr.ldc.toString()));
-	if (tr.gdc != Dependency.any) attrs ~= new Attribute("gdc", Value(tr.gdc.toString()));
+	if (tr.dub != VersionRange.Any) attrs ~= new Attribute("dub", Value(tr.dub.toString()));
+	if (tr.frontend != VersionRange.Any) attrs ~= new Attribute("frontend", Value(tr.frontend.toString()));
+	if (tr.dmd != VersionRange.Any) attrs ~= new Attribute("dmd", Value(tr.dmd.toString()));
+	if (tr.ldc != VersionRange.Any) attrs ~= new Attribute("ldc", Value(tr.ldc.toString()));
+	if (tr.gdc != VersionRange.Any) attrs ~= new Attribute("gdc", Value(tr.gdc.toString()));
 	return new Tag(null, "toolchainRequirements", null, attrs);
 }
 
@@ -562,11 +562,11 @@ lflags "lf3"
 	assert(rec.buildTypes.length == 2);
 	assert(rec.buildTypes["debug"].dflags == ["": ["-g", "-debug"]]);
 	assert(rec.buildTypes["release"].dflags == ["": ["-release", "-O"]]);
-	assert(rec.toolchainRequirements.dub == Dependency("~>1.11.0"));
-	assert(rec.toolchainRequirements.frontend == Dependency.any);
-	assert(rec.toolchainRequirements.dmd == Dependency("~>2.82.0"));
-	assert(rec.toolchainRequirements.ldc == Dependency.any);
-	assert(rec.toolchainRequirements.gdc == Dependency.any);
+	assert(rec.toolchainRequirements.dub == VersionRange.fromString("~>1.11.0"));
+	assert(rec.toolchainRequirements.frontend == VersionRange.Any);
+	assert(rec.toolchainRequirements.dmd == VersionRange.fromString("~>2.82.0"));
+	assert(rec.toolchainRequirements.ldc == VersionRange.Any);
+	assert(rec.toolchainRequirements.gdc == VersionRange.Any);
 	assert(rec.ddoxFilterArgs == ["-arg1", "-arg2", "-arg3"], rec.ddoxFilterArgs.to!string);
 	assert(rec.ddoxTool == "ddoxtool");
 	assert(rec.buildSettings.dependencies.length == 2);


### PR DESCRIPTION
Note that this is a breaking change for library users. It changes the platform dependency to only accept version ranges, instead of any dependency. The end-users already could only write VersionRange in there, the type was just too wide.