### PR TITLE
Deprecate string-as-version PackageManager.getBestPackage overload

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -440,6 +440,7 @@ class PackageManager {
 	}
 
 	/// Ditto
+	deprecated("Use the overload that accepts a `Version` or a `VersionRange`")
 	Package getBestPackage(string name, string range)
 	{
 		return this.getBestPackage(name, VersionRange.fromString(range));


### PR DESCRIPTION
Because using a typed Version or VersionRange is better than using a string and we want to encourage version validation to be done earlier than later.