### PR TITLE
Trivial: Move TestDub behind a version (unittest)

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1832,7 +1832,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
  * nor should it do any file IO, to make it usable and reliable in unittests.
  * Currently it reads environment variables but does not read the configuration.
  */
-package final class TestDub : Dub
+version(unittest) package final class TestDub : Dub
 {
     /// Forward to base constructor
     public this (string root = ".", PackageSupplier[] extras = null,


### PR DESCRIPTION
As it should not be compiled in the final binary for releases, it's just a class to help with unittests.