### PR TITLE
Allow to load dub.selections.json before Project instantiation

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -447,7 +447,8 @@ class Dub {
 	/// Loads a specific package as the main project package (can be a sub package)
 	void loadPackage(Package pack)
 	{
-		m_project = new Project(m_packageManager, pack);
+		auto selections = Project.loadSelections(pack);
+		m_project = new Project(m_packageManager, pack, selections);
 	}
 
 	/** Loads a single file package.


### PR DESCRIPTION
The aim of this commit is to have at least one constructor for Project that does not perform IO. By moving the IO to the `Dub` class, we can keep the dependency injection in `Dub` and `PackageManager` only, and don't have to specialize `Project`.