### PR TITLE
Fix #2696: Segfault with bad dub.sdl

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -491,7 +491,9 @@ class Project {
 		m_missingDependencies = [];
 
 		Package resolveSubPackage(Package p, string subname, bool silentFail) {
-			return subname.length ? m_packageManager.getSubPackage(p, subname, silentFail) : p;
+			if (!subname.length || p is null)
+				return p;
+			return m_packageManager.getSubPackage(p, subname, silentFail);
 		}
 
 		void collectDependenciesRec(Package pack, int depth = 0)
@@ -556,6 +558,9 @@ class Project {
 					if (!vspec.repository.empty) {
 						p = m_packageManager.loadSCMPackage(basename, vspec.repository);
 						resolveSubPackage(p, subname, false);
+						enforce(p !is null,
+							"Unable to fetch '%s@%s' using git - does the repository and version exists?".format(
+								dep.name, vspec.repository));
 					} else if (!vspec.path.empty && is_desired) {
 						NativePath path = vspec.path;
 						if (!path.absolute) path = pack.path ~ path;

--- a/source/dub/test/other.d
+++ b/source/dub/test/other.d
@@ -1,0 +1,50 @@
+/*******************************************************************************
+
+    Tests that don't fit in existing categories
+
+*******************************************************************************/
+
+module dub.test.others;
+
+version (unittest):
+
+import std.algorithm;
+import std.format;
+import dub.test.base;
+
+// https://github.com/dlang/dub/issues/2696
+unittest
+{
+    const ValidURL = `git+https://example.com/dlang/dub`;
+    // Taken from a commit in the dub repository
+    const ValidHash = "54339dff7ce9ec24eda550f8055354f712f15800";
+    const Template = `{"name": "%s", "dependencies": {
+"dep1": { "repository": "%s", "version": "%s" }}}`;
+
+    scope dub = new TestDub();
+    dub.packageManager.addTestSCMPackage(
+        Repository(ValidURL, ValidHash),
+        // Note: SCM package are always marked as using `~master`
+        dub.makeTestPackage(`{ "name": "dep1" }`, Version(`~master`)),
+    );
+
+    // Invalid URL, valid hash
+    const a = Template.format("a", "git+https://nope.nope", ValidHash);
+    try
+        dub.loadPackage(dub.addTestPackage(a, Version("1.0.0")));
+    catch (Exception exc)
+        assert(exc.message.canFind("Unable to fetch"));
+
+    // Valid URL, invalid hash
+    const b = Template.format("b", ValidURL, "invalid");
+    try
+        dub.loadPackage(dub.addTestPackage(b, Version("1.0.0")));
+    catch (Exception exc)
+        assert(exc.message.canFind("Unable to fetch"));
+
+    // Valid URL, valid hash
+    const c = Template.format("c", ValidURL, ValidHash);
+    dub.loadPackage(dub.addTestPackage(c, Version("1.0.0")));
+    assert(dub.project.hasAllDependencies());
+    assert(dub.project.getDependency("dep1", true), "Missing 'dep1' dependency");
+}


### PR DESCRIPTION
```
This was a null pointer being passed down.
However, while looking at the code, it was obvious that similar
bugs would trigger for subpackages (as the code was not handling
`null` packages either), so test cases for those have been added.
```

Based on #2761 