### PR TITLE
Remove fallback to ~master on dub fetch, fix #2679

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2176,8 +2176,7 @@ class FetchCommand : FetchRemoveCommand {
 			}
 			catch(Exception e){
 				logInfo("Getting a release version failed: %s", e.msg);
-				logInfo("Retry with ~master...");
-				dub.fetch(name, VersionRange.fromString("~master"), location, fetchOpts);
+				return 1;
 			}
 		}
 		return 0;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -913,7 +913,8 @@ class Dub {
 				logDebug("Full error: %s", e.toString().sanitize());
 			}
 		}
-		enforce(pinfo.type != Json.Type.undefined, "No package "~packageId~" was found matching the dependency " ~ range.toString());
+		enforce(!pinfo.type.among(Json.Type.undefined, Json.Type.null_),
+				"No package " ~ packageId ~ " was found matching the dependency " ~ range.toString());
 		Version ver = Version(pinfo["version"].get!string);
 
 		// always upgrade branch based versions - TODO: actually check if there is a new commit available


### PR DESCRIPTION
The retry does not make sense, as one cannot add a package to the registry without a release version.
It is also not in line with Dub strategy, as we are trying to reduce the usage of branch dependencies.

This also fixes issue https://github.com/dlang/dub/issues/2679 which pointed out the error message
was sub-par. The API of the registry seems to have changed and
we now get `null` instead of `undefined`, leading to an error
inside the JSON module instead of the enforce being triggered.