### PR TITLE
Deprecate Project.packageManager

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2712,7 +2712,7 @@ class DustmiteCommand : PackageBuildCommand {
 				foreach (ref subp; recipe.subPackages)
 					if (subp.path.length) {
 						auto sub_path = base_path ~ NativePath(subp.path);
-						auto pack = prj.packageManager.getOrLoadPackage(sub_path);
+						auto pack = dub.packageManager.getOrLoadPackage(sub_path);
 						fixPathDependencies(pack.recipe, sub_path);
 						pack.storeInfo(sub_path);
 					} else fixPathDependencies(subp.recipe, base_path);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -61,14 +61,12 @@ string computeBuildName(string config, in GeneratorSettings settings, const stri
 
 class BuildGenerator : ProjectGenerator {
 	private {
-		PackageManager m_packageMan;
 		NativePath[] m_temporaryFiles;
 	}
 
 	this(Project project)
 	{
 		super(project);
-		m_packageMan = project.packageManager;
 	}
 
 	override void generateTargets(GeneratorSettings settings, in TargetInfo[string] targets)

--- a/source/dub/generators/visuald.d
+++ b/source/dub/generators/visuald.d
@@ -33,14 +33,12 @@ import std.uuid;
 
 class VisualDGenerator : ProjectGenerator {
 	private {
-		PackageManager m_pkgMgr;
 		string[string] m_projectUuids;
 	}
 
 	this(Project project)
 	{
 		super(project);
-		m_pkgMgr = project.packageManager;
 	}
 
 	override void generateTargets(GeneratorSettings settings, in TargetInfo[string] targets)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -135,6 +135,7 @@ class Project {
 	@property inout(SelectedVersions) selections() inout { return m_selections; }
 
 	/// Package manager instance used by the project.
+	deprecated("Use `Dub.packageManager` instead")
 	@property inout(PackageManager) packageManager() inout { return m_packageManager; }
 
 	/** Determines if all dependencies necessary to build have been collected.


### PR DESCRIPTION
There is no reason to expose the PackageManager through the Project. In fact, the only two places it was used were in generators, where the PackageManager was stored but never used. The generators arguably should not have access to the PackageManager, as all the Packages should have been loaded and handled to them before the generation starts.