### PR TITLE
Deprecate `Package.load`, use `PackageManager.load` instead

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -80,9 +80,10 @@ static immutable string[] builtinBuildTypes = [
 /**	Represents a package, including its sub packages.
 */
 class Package {
+	// `package` visibility as it is set from the PackageManager
+	package NativePath m_infoFile;
 	private {
 		NativePath m_path;
-		NativePath m_infoFile;
 		PackageRecipe m_info;
 		PackageRecipe m_rawRecipe;
 		Package m_parentPackage;
@@ -173,6 +174,7 @@ class Package {
 				determined by invoking the VCS (GIT currently).
 			mode = Whether to issue errors, warning, or ignore unknown keys in dub.json
 	*/
+	deprecated("Use `PackageManager.getOrLoadPackage` instead of loading packages directly")
 	static Package load(NativePath root, NativePath recipe_file = NativePath.init,
 		Package parent = null, string version_override = "",
 		StrictMode mode = StrictMode.Ignore)

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -289,27 +289,17 @@ package class TestPackageManager : PackageManager
         // Do nothing
     }
 
-    /**
-     * Looks up a specific package
-     *
-     * Unlike its parent class, no lazy loading is performed.
-     * Additionally, as they are already deprecated, overrides are
-     * disabled and not available.
-     */
-	public override Package getPackage(string name, Version vers, bool enable_overrides = false)
+	/**
+	 * Loads a `Package`
+	 *
+	 * This is currently not implemented, and any call to it will trigger
+	 * an assert, as that would otherwise be an access to the filesystem.
+	 */
+	protected override Package load(NativePath path, NativePath recipe = NativePath.init,
+		Package parent = null, string version_ = null,
+		StrictMode mode = StrictMode.Ignore) const
     {
-        //assert(!enable_overrides, "Overrides are not implemented for TestPackageManager");
-
-        // Implementation inspired from `PackageManager.lookup`,
-        // except we replaced `load` with `lookup`.
-        if (auto pkg = this.m_internal.lookup(name, vers, this))
-			return pkg;
-
-		foreach (ref location; this.m_repositories)
-			if (auto p = location.lookup(name, vers, this))
-				return p;
-
-		return null;
+        assert(0, "`TestPackageManager.load` is not implemented");
     }
 
 	/**


### PR DESCRIPTION
In order for the dependency injection approach to work, we need to be able to override every single instance of `Package.load`. We could not override `Package.load` itself as it is a static function.
However, in the process of adding support for path-based dependencies to the test suite, it became obvious that the functionality offered by `Package.load` is actually better suited for the `PackageManager`. Deprecating `Package.load` confirms this: Not a single call was outside of `PackageManager`, and no extra parameter had to be provided anywhere to make this work.
This also nicely simplifies the `TestPackageManager` implementation, as we can now overload `load` and let `getPackage` alone.