### PR TITLE
Dub.loadPackage: Error out if no recipe is found

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -499,7 +499,9 @@ class Dub {
 	/// Loads the package from the specified path as the main project package.
 	void loadPackage(NativePath path)
 	{
-		m_project = new Project(m_packageManager, path);
+		auto pack = this.m_packageManager.getOrLoadPackage(
+			path, NativePath.init, false, StrictMode.Warn);
+		this.loadPackage(pack);
 	}
 
 	/// Loads a specific package as the main project package (can be a sub package)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -57,6 +57,7 @@ class Project {
 			project_path = Path of the root package to load
 			pack = An existing `Package` instance to use as the root package
 	*/
+	deprecated("Load the package using `PackageManager.getOrLoadPackage` then call the `(PackageManager, Package)` overload")
 	this(PackageManager package_manager, NativePath project_path)
 	{
 		Package pack;

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -152,12 +152,6 @@ public class TestDub : Dub
         return new MockPackageSupplier(url);
     }
 
-	/// Loads the package from the specified path as the main project package.
-	public override void loadPackage(NativePath path)
-	{
-		assert(0, "Not implemented");
-	}
-
 	/// Loads a specific package as the main project package (can be a sub package)
 	public override void loadPackage(Package pack)
 	{


### PR DESCRIPTION
First commit turns a soft failure into a hard failure. Second commit deprecates the functionality in the constructor.