### PR TITLE
Trivial: Make PackageManager.load non-const

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -364,7 +364,7 @@ class PackageManager {
 	 */
 	protected Package load(NativePath path, NativePath recipe = NativePath.init,
 		Package parent = null, string version_ = null,
-		StrictMode mode = StrictMode.Ignore) const
+		StrictMode mode = StrictMode.Ignore)
 	{
 		if (recipe.empty)
 			recipe = Package.findPackageFile(path);
@@ -1023,7 +1023,7 @@ symlink_exit:
 
 	/// Adds the package and scans for sub-packages.
 	private void addPackages(ref Package[] dst_repos, Package pack)
-	const {
+	{
 		// Add the main package.
 		dst_repos ~= pack;
 

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -291,7 +291,7 @@ package class TestPackageManager : PackageManager
 	 */
 	protected override Package load(NativePath path, NativePath recipe = NativePath.init,
 		Package parent = null, string version_ = null,
-		StrictMode mode = StrictMode.Ignore) const
+		StrictMode mode = StrictMode.Ignore)
     {
         assert(0, "`TestPackageManager.load` is not implemented");
     }


### PR DESCRIPTION
```
It was made const to satisfy PackageManager.addPackages, but that method actually takes a field of the PackageManager as ref parameter, so it can never be called from a 'const' context, and while implementing 'TestPackageManager.load', it was found that 'const' wasn't suitable.
```

Note that `PackageManager.load` isn't in a release yet, hence we can change the API.