### PR TITLE
Deprecate Package JSON constructor

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1793,6 +1793,8 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 	private Package getPackageRaw(string name, Dependency dep)
 	{
+		import dub.recipe.json;
+
 		auto basename = getBasePackageName(name);
 
 		// for sub packages, first try to get them from the base package
@@ -1854,7 +1856,9 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 					auto desc = ps.fetchPackageRecipe(name, VersionRange(vers, vers), prerelease);
 					if (desc.type == Json.Type.null_)
 						continue;
-					auto ret = new Package(desc);
+					PackageRecipe recipe;
+					parseJson(recipe, desc, null);
+					auto ret = new Package(recipe);
 					m_remotePackages[key] = ret;
 					return ret;
 				} catch (Exception e) {

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -101,6 +101,7 @@ class Package {
 				instead of the one declared in the package recipe, or the one
 				determined by invoking the VCS (GIT currently).
 	*/
+	deprecated("Provide an already parsed PackageRecipe instead of a JSON object")
 	this(Json json_recipe, NativePath root = NativePath(), Package parent = null, string version_override = "")
 	{
 		import dub.recipe.json;


### PR DESCRIPTION
Over the last year, various JSON overloads have been deprecated, leaving space for more typed interfaces.
This Package constructor had resisted for long,
as the PackageSupplier interface returns JSON itself. While changing it would be a breaking change and is not currently possible, we can at least hoist the parsing one level.