### PR TITLE
Add overrideCachePaths alongside customCachePaths

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -160,6 +160,10 @@ class Dub {
 		if (ccps.length)
 			m_packageManager.customCachePaths = ccps;
 
+		auto ocps = m_config.overrideCachePaths;
+		if (ocps.length)
+			m_packageManager.overrideCachePaths = ocps;
+
 		// TODO: Move this environment read out of the ctor
 		if (auto p = environment.get("DUBPATH")) {
 			version(Windows) enum pathsep = ";";

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -167,6 +167,25 @@ class PackageManager {
 		this.refresh();
 	}
 
+	/** Override (read-only) package cache paths to search for packages.
+
+		Cache paths have the same structure as the default cache paths, such as
+		".dub/packages/".
+
+		Note that previously set custom paths will be removed when setting this
+		property.
+	*/
+	@property void overrideCachePaths(NativePath[] override_cache_paths)
+	{
+		import std.algorithm.iteration : map;
+		import std.array : array;
+
+		m_repositories.length = PlacementLocation.max+1;
+		m_repositories = override_cache_paths.map!(p => Location(p)).array;
+
+		this.refresh();
+	}
+
 	/**
 	 * Looks up a package, first in the list of loaded packages,
 	 * then directly on the file system.

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -286,6 +286,12 @@ package class TestPackageManager : PackageManager
         assert(0, "Function not implemented");
     }
 
+    /// Disabled as semantic are not implementable unless a virtual FS is created
+	public override @property void overrideCachePaths(NativePath[] override_cache_paths)
+    {
+        assert(0, "Function not implemented");
+    }
+
     /// Ditto
     public override Package store(NativePath src, PlacementLocation dest, string name, Version vers)
     {


### PR DESCRIPTION
This is needed in a scenario where all third-party dependencies of project are vendored under an in-repo directory tree mimicing the structure of `~/.dub/packages`.