### PR TITLE
Deprecate system flag for registration, use cache instead

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2339,8 +2339,8 @@ abstract class RegistrationCommand : Command {
 	override void prepare(scope CommandArgs args)
 	{
 		args.getopt("system", &m_system, [
-			"Register system-wide instead of user-wide"
-		]);
+			"DEPRECATED: Use --cache=system instead"
+		], true);
 	}
 
 	abstract override int execute(Dub dub, string[] free_args, string[] app_args);
@@ -2367,7 +2367,12 @@ class AddPathCommand : RegistrationCommand {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		enforceUsage(free_args.length == 1, "Missing search path.");
-		dub.addSearchPath(free_args[0], m_system);
+		enforceUsage(!this.m_system || dub.defaultPlacementLocation == PlacementLocation.user,
+			"Cannot use both --system and --cache, prefer --cache");
+		if (this.m_system)
+			dub.addSearchPath(free_args[0], PlacementLocation.system);
+		else
+			dub.addSearchPath(free_args[0], dub.defaultPlacementLocation);
 		return 0;
 	}
 }
@@ -2384,7 +2389,12 @@ class RemovePathCommand : RegistrationCommand {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		enforceUsage(free_args.length == 1, "Expected one argument.");
-		dub.removeSearchPath(free_args[0], m_system);
+		enforceUsage(!this.m_system || dub.defaultPlacementLocation == PlacementLocation.user,
+			"Cannot use both --system and --cache, prefer --cache");
+		if (this.m_system)
+			dub.removeSearchPath(free_args[0], PlacementLocation.system);
+		else
+			dub.removeSearchPath(free_args[0], dub.defaultPlacementLocation);
 		return 0;
 	}
 }
@@ -2406,9 +2416,16 @@ class AddLocalCommand : RegistrationCommand {
 
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
-		enforceUsage(free_args.length == 1 || free_args.length == 2, "Expecting one or two arguments.");
+		enforceUsage(free_args.length == 1 || free_args.length == 2,
+			"Expecting one or two arguments.");
+		enforceUsage(!this.m_system || dub.defaultPlacementLocation == PlacementLocation.user,
+			"Cannot use both --system and --cache, prefer --cache");
+
 		string ver = free_args.length == 2 ? free_args[1] : null;
-		dub.addLocalPackage(free_args[0], ver, m_system);
+		if (this.m_system)
+			dub.addLocalPackage(free_args[0], ver, PlacementLocation.system);
+		else
+			dub.addLocalPackage(free_args[0], ver, dub.defaultPlacementLocation);
 		return 0;
 	}
 }
@@ -2425,8 +2442,15 @@ class RemoveLocalCommand : RegistrationCommand {
 	override int execute(Dub dub, string[] free_args, string[] app_args)
 	{
 		enforceUsage(free_args.length >= 1, "Missing package path argument.");
-		enforceUsage(free_args.length <= 1, "Expected the package path to be the only argument.");
-		dub.removeLocalPackage(free_args[0], m_system);
+		enforceUsage(free_args.length <= 1,
+			"Expected the package path to be the only argument.");
+		enforceUsage(!this.m_system || dub.defaultPlacementLocation == PlacementLocation.user,
+			"Cannot use both --system and --cache, prefer --cache");
+
+		if (this.m_system)
+			dub.removeLocalPackage(free_args[0], PlacementLocation.system);
+		else
+			dub.removeLocalPackage(free_args[0], dub.defaultPlacementLocation);
 		return 0;
 	}
 }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1104,10 +1104,17 @@ class Dub {
 
 		See_Also: `removeLocalPackage`
 	*/
+	deprecated("Use `addLocalPackage(string, string, PlacementLocation)` instead")
 	void addLocalPackage(string path, string ver, bool system)
 	{
+		this.addLocalPackage(path, ver, system ? PlacementLocation.system : PlacementLocation.user);
+	}
+
+	/// Ditto
+	void addLocalPackage(string path, string ver, PlacementLocation loc)
+	{
 		if (m_dryRun) return;
-		m_packageManager.addLocalPackage(makeAbsolute(path), ver, system ? PlacementLocation.system : PlacementLocation.user);
+		this.m_packageManager.addLocalPackage(makeAbsolute(path), ver, loc);
 	}
 
 	/** Removes a directory from the list of locally known packages.
@@ -1121,10 +1128,17 @@ class Dub {
 
 		See_Also: `addLocalPackage`
 	*/
+	deprecated("Use `removeLocalPackage(string, string, PlacementLocation)` instead")
 	void removeLocalPackage(string path, bool system)
 	{
+		this.removeLocalPackage(path, system ? PlacementLocation.system : PlacementLocation.user);
+	}
+
+	/// Ditto
+	void removeLocalPackage(string path, PlacementLocation loc)
+	{
 		if (m_dryRun) return;
-		m_packageManager.removeLocalPackage(makeAbsolute(path), system ? PlacementLocation.system : PlacementLocation.user);
+		this.m_packageManager.removeLocalPackage(makeAbsolute(path), loc);
 	}
 
 	/** Registers a local directory to search for packages to use for satisfying
@@ -1137,10 +1151,17 @@ class Dub {
 
 		See_Also: `removeSearchPath`
 	*/
+	deprecated("Use `addSearchPath(string, PlacementLocation)` instead")
 	void addSearchPath(string path, bool system)
 	{
+		this.addSearchPath(path, system ? PlacementLocation.system : PlacementLocation.user);
+	}
+
+	/// Ditto
+	void addSearchPath(string path, PlacementLocation loc)
+	{
 		if (m_dryRun) return;
-		m_packageManager.addSearchPath(makeAbsolute(path), system ? PlacementLocation.system : PlacementLocation.user);
+		this.m_packageManager.addSearchPath(makeAbsolute(path), loc);
 	}
 
 	/** Deregisters a local directory search path.
@@ -1152,10 +1173,17 @@ class Dub {
 
 		See_Also: `addSearchPath`
 	*/
+	deprecated("Use `removeSearchPath(string, PlacementLocation)` instead")
 	void removeSearchPath(string path, bool system)
 	{
+		this.removeSearchPath(path, system ? PlacementLocation.system : PlacementLocation.user);
+	}
+
+	/// Ditto
+	void removeSearchPath(string path, PlacementLocation loc)
+	{
 		if (m_dryRun) return;
-		m_packageManager.removeSearchPath(makeAbsolute(path), system ? PlacementLocation.system : PlacementLocation.user);
+		this.m_packageManager.removeSearchPath(makeAbsolute(path), loc);
 	}
 
 	/** Queries all package suppliers with the given query string.


### PR DESCRIPTION
The system flag likely predates the global 'cache' option. Logic dictates that 'dub add-path --cache=system' should behave the same as 'dub add-path --system' but that is not the case. However the PackageManager already has the right API in place, so it is just a matter of deprecating the layers in front.