### PR TITLE
Trivial: Silence buggy deprecation

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -64,7 +64,7 @@ deprecated("This function wasn't intended for public use - open an issue with Du
 PackageSupplier[] defaultPackageSuppliers()
 {
 	logDiagnostic("Using dub registry url '%s'", defaultRegistryURLs[0]);
-	return [new FallbackPackageSupplier(defaultRegistryURLs.map!getRegistryPackageSupplier.array)];
+	return [new FallbackPackageSupplier(defaultRegistryURLs.map!_getRegistryPackageSupplier.array)];
 }
 
 /** Returns a registry package supplier according to protocol.
@@ -73,6 +73,13 @@ PackageSupplier[] defaultPackageSuppliers()
 */
 deprecated("This function wasn't intended for public use - open an issue with Dub if you need it")
 PackageSupplier getRegistryPackageSupplier(string url)
+{
+    return _getRegistryPackageSupplier(url);
+}
+
+// Private to avoid a bug in `defaultPackageSuppliers` with `map` triggering a deprecation
+// even though the context is deprecated.
+private PackageSupplier _getRegistryPackageSupplier(string url)
 {
 	switch (url.startsWith("dub+", "mvn+", "file://"))
 	{


### PR DESCRIPTION
Deprecation was:
```
std/algorithm/iteration.d(475,42): Deprecation: function `dub.dub.getRegistryPackageSupplier` is deprecated - This function wasn't intended for public use - open an issue with Dub if you need it
source/dub/dub.d(68,57):        instantiated from here: `map!(immutable(string)[])`
std/algorithm/iteration.d(582,19): Deprecation: function `dub.dub.getRegistryPackageSupplier` is deprecated - This function wasn't intended for public use - open an issue with Dub if you need it
std/algorithm/iteration.d(479,16):        instantiated from here: `MapResult!(getRegistryPackageSupplier, immutable(string)[])`
source/dub/dub.d(68,57):        instantiated from here: `map!(immutable(string)[])`
std/algorithm/iteration.d(594,23): Deprecation: function `dub.dub.getRegistryPackageSupplier` is deprecated - This function wasn't intended for public use - open an issue with Dub if you need it
std/algorithm/iteration.d(479,16):        instantiated from here: `MapResult!(getRegistryPackageSupplier, immutable(string)[])`
source/dub/dub.d(68,57):        instantiated from here: `map!(immutable(string)[])`
```
Triggers with LDC v1.36 as of 2024-01-10.