### PR TITLE
Let uesr $DFLAGS override build settings as much as possible

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -230,6 +230,11 @@ config    /etc/dmd.conf
 	{
 		enforceBuildRequirements(settings);
 
+		// Keep the current dflags at the end of the array so that they will overwrite other flags.
+		// This allows user $DFLAGS to modify flags added by us.
+		const dflagsTail = settings.dflags;
+		settings.dflags = [];
+
 		if (!(fields & BuildSetting.options)) {
 			foreach (t; s_options)
 				if (settings.options & t[0])
@@ -281,6 +286,8 @@ config    /etc/dmd.conf
 
 		if (platform.platform.canFind("posix") && (settings.options & BuildOption.pic))
 			settings.addDFlags("-fPIC");
+
+		settings.addDFlags(dflagsTail);
 
 		assert(fields & BuildSetting.dflags);
 		assert(fields & BuildSetting.copyFiles);

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -89,6 +89,11 @@ class GDCCompiler : Compiler {
 	{
 		enforceBuildRequirements(settings);
 
+		// Keep the current dflags at the end of the array so that they will overwrite other flags.
+		// This allows user $DFLAGS to modify flags added by us.
+		const dflagsTail = settings.dflags;
+		settings.dflags = [];
+
 		if (!(fields & BuildSetting.options)) {
 			foreach (t; s_options)
 				if (settings.options & t[0])
@@ -137,6 +142,8 @@ class GDCCompiler : Compiler {
 
 		if (settings.options & BuildOption.pic)
 			settings.addDFlags("-fPIC");
+
+		settings.addDFlags(dflagsTail);
 
 		assert(fields & BuildSetting.dflags);
 		assert(fields & BuildSetting.copyFiles);

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -107,6 +107,11 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		import std.format : format;
 		enforceBuildRequirements(settings);
 
+		// Keep the current dflags at the end of the array so that they will overwrite other flags.
+		// This allows user $DFLAGS to modify flags added by us.
+		const dflagsTail = settings.dflags;
+		settings.dflags = [];
+
 		if (!(fields & BuildSetting.options)) {
 			foreach (t; s_options)
 				if (settings.options & t[0])
@@ -169,6 +174,8 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 				settings.addDFlags("-relocation-model=pic");
 			}
 		}
+
+		settings.addDFlags(dflagsTail);
 
 		assert(fields & BuildSetting.dflags);
 		assert(fields & BuildSetting.copyFiles);

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -422,10 +422,6 @@ class Package {
 	*/
 	void addBuildTypeSettings(ref BuildSettings settings, in BuildPlatform platform, string build_type)
 	const {
-		import std.process : environment;
-		string dflags = environment.get("DFLAGS", "");
-		settings.addDFlags(dflags.split());
-
 		if (auto pbt = build_type in m_info.buildTypes) {
 			logDiagnostic("Using custom build type '%s'.", build_type);
 			pbt.getPlatformSettings(settings, platform, this.path);
@@ -450,6 +446,11 @@ class Package {
 				case "syntax": settings.addOptions(syntaxOnly); break;
 			}
 		}
+
+		// Add environment DFLAGS last so that user specified values are not overriden by us.
+		import std.process : environment;
+		string dflags = environment.get("DFLAGS", "");
+		settings.addDFlags(dflags.split());
 	}
 
 	/** Returns the selected configuration for a certain dependency.


### PR DESCRIPTION
This change is mostly about being able to build programs without `-Werror` or `-w`.

`dub` setting up so that warnings are errors by default can be nice for developers making their code more correct but it is useless for consumers. Currently, there is no way to disable that without modifying the project configuration to add `allowWarnings` to `buildRequirements`. Users should, at least, be able to add `-wi` to `DFLAGS` and have the preference respected.

This isn't so much a problem with `dmd` or `ldc` in my experience as they mostly report deprecations, the problem is with `gdc` where every deprecation is a warning and the `-Werror` makes builds fail where they otherwise should have succeeded with only some warnings.