### PR TITLE
Trivial: Make PackageManager.addPackages protected

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -1020,7 +1020,7 @@ symlink_exit:
 	}
 
 	/// Adds the package and scans for sub-packages.
-	private void addPackages(ref Package[] dst_repos, Package pack)
+	protected void addPackages(ref Package[] dst_repos, Package pack)
 	{
 		// Add the main package.
 		dst_repos ~= pack;


### PR DESCRIPTION
So that it can be reused in the TestPackageManager.