### PR TITLE
Introduce PackageName, to fully type a package name

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1557,7 +1557,7 @@ class BuildCommand : GenerateCommand {
 		if (packageParts.name.startsWith(":"))
 			return 0;
 
-		const baseName = getBasePackageName(packageParts.name);
+		const baseName = PackageName(packageParts.name).main;
 		// Found locally
 		if (dub.packageManager.getBestPackage(baseName, packageParts.range))
 			return 0;
@@ -2788,7 +2788,7 @@ class DustmiteCommand : PackageBuildCommand {
 			static void fixPathDependency(string pack, ref Dependency dep) {
 				dep.visit!(
 					(NativePath path) {
-						auto mainpack = getBasePackageName(pack);
+						auto mainpack = PackageName(pack).main;
 						dep = Dependency(NativePath("../") ~ mainpack);
 					},
 					(any) { /* Nothing to do */ },

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -188,7 +188,7 @@ class PackageManager {
 	 * Returns:
 	 *	 A `Package` if one was found, `null` if none exists.
 	 */
-	protected Package lookup (string name, Version vers) {
+	protected Package lookup (PackageName name, Version vers) {
 		if (!this.m_initialized)
 			this.refresh();
 
@@ -240,7 +240,7 @@ class PackageManager {
 					}
 		}
 
-		return this.lookup(name, ver);
+		return this.lookup(PackageName(name), ver);
 	}
 
 	/// ditto
@@ -268,7 +268,7 @@ class PackageManager {
 		// Bare mode
 		if (loc >= this.m_repositories.length)
 			return null;
-		return this.m_repositories[loc].load(name, ver, this);
+		return this.m_repositories[loc].load(PackageName(name), ver, this);
 	}
 
 	/// ditto
@@ -374,7 +374,9 @@ class PackageManager {
 				.format(path.toNativeString(),
 					packageInfoFiles.map!(f => cast(string)f.filename).join("/")));
 
-		auto content = readPackageRecipe(recipe, parent ? parent.name : null, mode);
+		const PackageName pname = parent
+			? PackageName(parent.name) : PackageName.init;
+		auto content = readPackageRecipe(recipe, pname, mode);
 		auto ret = new Package(content, path, parent, version_);
 		ret.m_infoFile = recipe;
 		return ret;
@@ -1433,13 +1435,13 @@ package struct Location {
 	 * Returns:
 	 *	 A `Package` if one was found, `null` if none exists.
 	 */
-	Package load (string name, Version vers, PackageManager mgr)
+	Package load (PackageName name, Version vers, PackageManager mgr)
 	{
 		if (auto pkg = this.lookup(name, vers))
 			return pkg;
 
 		string versStr = vers.toString();
-		const lookupName = getBasePackageName(name);
+		const lookupName = name.main;
 		const path = this.getPackagePath(lookupName, versStr) ~ (lookupName ~ "/");
 		if (!path.existsDirectory())
 			return null;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -462,7 +462,7 @@ class Project {
 			pack.simpleLint();
 
 			foreach (d; pack.getAllDependencies()) {
-				auto basename = getBasePackageName(d.name);
+				auto basename = d.name.main;
 				d.spec.visit!(
 					(NativePath path) { /* Valid */ },
 					(Repository repo) { /* Valid */ },
@@ -517,8 +517,8 @@ class Project {
 			Dependency vspec = dep.spec;
 			Package p;
 
-			auto basename = getBasePackageName(dep.name);
-			auto subname = getSubPackageName(dep.name);
+			auto basename = dep.name.main;
+			auto subname = dep.name.sub;
 
 			// non-optional and optional-default dependencies (if no selections file exists)
 			// need to be satisfied

--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -7,6 +7,7 @@
 */
 module dub.recipe.io;
 
+import dub.dependency : PackageName;
 import dub.recipe.packagerecipe;
 import dub.internal.logging;
 import dub.internal.vibecompat.core.file;
@@ -19,7 +20,7 @@ import dub.internal.configy.Read;
 
 	Params:
 		filename = NativePath of the package recipe file
-		parent_name = Optional name of the parent package (if this is a sub package)
+		parent = Optional name of the parent package (if this is a sub package)
 		mode = Whether to issue errors, warning, or ignore unknown keys in dub.json
 
 	Returns: Returns the package recipe contents
@@ -27,19 +28,28 @@ import dub.internal.configy.Read;
 */
 deprecated("Use the overload that accepts a `NativePath` as first argument")
 PackageRecipe readPackageRecipe(
-	string filename, string parent_name = null, StrictMode mode = StrictMode.Ignore)
+	string filename, string parent = null, StrictMode mode = StrictMode.Ignore)
 {
-	return readPackageRecipe(NativePath(filename), parent_name, mode);
+	return readPackageRecipe(NativePath(filename), parent, mode);
 }
 
 /// ditto
+deprecated("Use the overload that accepts a `PackageName` as second argument")
 PackageRecipe readPackageRecipe(
-	NativePath filename, string parent_name = null, StrictMode mode = StrictMode.Ignore)
+	NativePath filename, string parent, StrictMode mode = StrictMode.Ignore)
+{
+	return readPackageRecipe(filename, parent.length ? PackageName(parent) : PackageName.init, mode);
+}
+
+
+/// ditto
+PackageRecipe readPackageRecipe(NativePath filename,
+	in PackageName parent = PackageName.init, StrictMode mode = StrictMode.Ignore)
 {
 	import dub.internal.utils : stripUTF8Bom;
 
 	string text = stripUTF8Bom(cast(string)readFile(filename));
-	return parsePackageRecipe(text, filename.toNativeString(), parent_name, null, mode);
+	return parsePackageRecipe(text, filename.toNativeString(), parent, null, mode);
 }
 
 /** Parses an in-memory package recipe.
@@ -50,7 +60,7 @@ PackageRecipe readPackageRecipe(
 		contents = The contents of the recipe file
 		filename = Name associated with the package recipe - this is only used
 			to determine the file format from the file extension
-		parent_name = Optional name of the parent package (if this is a sub
+		parent = Optional name of the parent package (if this is a sub
 		package)
 		default_package_name = Optional default package name (if no package name
 		is found in the recipe this value will be used)
@@ -59,7 +69,18 @@ PackageRecipe readPackageRecipe(
 	Returns: Returns the package recipe contents
 	Throws: Throws an exception if an I/O or syntax error occurs
 */
-PackageRecipe parsePackageRecipe(string contents, string filename, string parent_name = null,
+deprecated("Use the overload that accepts a `PackageName` as 3rd argument")
+PackageRecipe parsePackageRecipe(string contents, string filename, string parent,
+	string default_package_name = null, StrictMode mode = StrictMode.Ignore)
+{
+    return parsePackageRecipe(contents, filename, parent.length ?
+        PackageName(parent) : PackageName.init,
+        default_package_name, mode);
+}
+
+/// Ditto
+PackageRecipe parsePackageRecipe(string contents, string filename,
+    in PackageName parent = PackageName.init,
 	string default_package_name = null, StrictMode mode = StrictMode.Ignore)
 {
 	import std.algorithm : endsWith;
@@ -83,7 +104,7 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 			logWarn("Error was: %s", exc);
 			// Fallback to JSON parser
 			ret = PackageRecipe.init;
-			parseJson(ret, parseJsonString(contents, filename), parent_name);
+			parseJson(ret, parseJsonString(contents, filename), parent);
 		} catch (Exception exc) {
 			logWarn("Your `dub.json` file use non-conventional features that are deprecated");
 			logWarn("This is most likely due to duplicated keys.");
@@ -91,7 +112,7 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 			logWarn("Error was: %s", exc);
 			// Fallback to JSON parser
 			ret = PackageRecipe.init;
-			parseJson(ret, parseJsonString(contents, filename), parent_name);
+			parseJson(ret, parseJsonString(contents, filename), parent);
 		}
 		// `debug = ConfigFillerDebug` also enables verbose parser output
 		debug (ConfigFillerDebug)
@@ -112,7 +133,7 @@ PackageRecipe parsePackageRecipe(string contents, string filename, string parent
 			}
 		}
 	}
-	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent_name, filename);
+	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent, filename);
 	else assert(false, "readPackageRecipe called with filename with unknown extension: "~filename);
 
 	// Fix for issue #711: `targetType` should be inherited, or default to library

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -50,6 +50,7 @@ deprecated @safe unittest
 
 	In case of a top level package, the qualified name is returned unmodified.
 */
+deprecated("Use `dub.dependency : PackageName(arg).main` instead")
 string getBasePackageName(string package_name) @safe pure
 {
 	return package_name.findSplit(":")[0];
@@ -62,12 +63,13 @@ string getBasePackageName(string package_name) @safe pure
 	This is the part of the package name excluding the base package
 	name. See also $(D getBasePackageName).
 */
+deprecated("Use `dub.dependency : PackageName(arg).sub` instead")
 string getSubPackageName(string package_name) @safe pure
 {
 	return package_name.findSplit(":")[2];
 }
 
-@safe unittest
+deprecated @safe unittest
 {
 	assert(getBasePackageName("packa:packb:packc") == "packa");
 	assert(getBasePackageName("pack") == "pack");


### PR DESCRIPTION
```
Package names being passed around in the Dub codebase are string, which is problematic as it suffers from validation / semantic issues. Validation because we cannot impose restrictions on characters or length easily, and semantic because some functions expect a main package while some would accept a subpackage. Introducing a type will remedy both those issues.
```

Note that this just replaces use of the two functions that deal with package names as string. Deprecating / replacing the API is another undertaking that I felt was best done separately.