### PR TITLE
Simplify PackageManager.getPackagePath

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -335,8 +335,6 @@ package class TestPackageManager : PackageManager
 
 		string gitReference = repo.ref_.chompPrefix("~");
 		NativePath destination = this.getPackagePath(PlacementLocation.user, name, repo.ref_);
-		destination ~= name;
-		destination.endsWithSlash = true;
 
 		foreach (p; getPackageIterator(name))
 			if (p.path == destination)


### PR DESCRIPTION
All callers ended up appending to the returned path, so just do it in getPackagePath and save ourself some trouble.