### PR TITLE
Adapt getPackagePath to PackageName API

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -333,8 +333,9 @@ package class TestPackageManager : PackageManager
 		if (!repo.ref_.startsWith("~") && !repo.ref_.isGitHash)
 			return null;
 
+		const name_ = PackageName(name);
 		string gitReference = repo.ref_.chompPrefix("~");
-		NativePath destination = this.getPackagePath(PlacementLocation.user, name, repo.ref_);
+		NativePath destination = this.getPackagePath(PlacementLocation.user, name_, repo.ref_);
 
 		foreach (p; getPackageIterator(name))
 			if (p.path == destination)


### PR DESCRIPTION
Now that we have the PackageName type, we need to
go through API and decide what the string means.
Multiple places expect a main package, and only
some expect a subpackage. Starting from the bottom, it is impossible to call getPackagePath with
a subpackage, as the package path of that subpackage depends on the main package. However, we want to be lax here, so always return the main package path.