### PR TITLE
Deprecate Package.getInternalSubPackage, simplify DepedencyResolver

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -1843,18 +1843,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 			if (!basepack) return null;
 			if (auto sp = m_dub.m_packageManager.getSubPackage(basepack, subname, true))
 				return sp;
-			if (!basepack.subPackages.canFind!(p => p.path.length)) {
-				// note: external sub packages are handled further below
-				auto spr = basepack.getInternalSubPackage(subname);
-				if (!spr.isNull) {
-					auto sp = new Package(spr.get, basepack.path, basepack);
-					m_remotePackages[sp.name] = sp;
-					return sp;
-				}
-				logDiagnostic("Sub package %s doesn't exist in %s %s.", name, name.main, dep);
-				return null;
-			}
-			logDiagnostic("External sub package %s %s not found.", name, dep);
+			logDiagnostic("Subpackage %s@%s not found.", name, dep);
 			return null;
 		}
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -312,13 +312,7 @@ class Package {
 		writeJsonFile(filename, m_info.toJson());
 	}
 
-	/** Returns the package recipe of a non-path-based sub package.
-
-		For sub packages that are declared within the package recipe of the
-		parent package, this function will return the corresponding recipe. Sub
-		packages declared using a path must be loaded manually (or using the
-		`PackageManager`).
-	*/
+	deprecated("Use `PackageManager.getSubPackage` instead")
 	Nullable!PackageRecipe getInternalSubPackage(string name)
 	{
 		foreach (ref p; m_info.subPackages)

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -515,9 +515,6 @@ class PackageManager {
 
 	/** Gets the a specific sub package.
 
-		In contrast to `Package.getSubPackage`, this function supports path
-		based sub packages.
-
 		Params:
 			base_package = The package from which to get a sub package
 			sub_name = Name of the sub package (not prefixed with the base


### PR DESCRIPTION
The PackageManager will always eagerly load subpackages, whether they are path based or embedded (see addPackages). So calling getInternalSubPackage if getSubPackage returned null will never yield a non-Nullable object.
In short, we can simplify that code greatly, and as Package.getInternalSubPackage does not handle all use case and require using the PackageManager anyway, just deprecate it and direct people to the right function.