### PR TITLE
Remove PackageName alias this to toString

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1559,7 +1559,7 @@ class BuildCommand : GenerateCommand {
 
 		const baseName = PackageName(packageParts.name).main;
 		// Found locally
-		if (dub.packageManager.getBestPackage(baseName, packageParts.range))
+		if (dub.packageManager.getBestPackage(baseName.toString(), packageParts.range))
 			return 0;
 
 		// Non-interactive, either via flag, or because a version was provided
@@ -1569,8 +1569,8 @@ class BuildCommand : GenerateCommand {
 		}
 		// Otherwise we go the long way of asking the user.
 		// search for the package and filter versions for exact matches
-		auto search = dub.searchPackages(baseName)
-			.map!(tup => tup[1].find!(p => p.name == baseName))
+		auto search = dub.searchPackages(baseName.toString())
+			.map!(tup => tup[1].find!(p => p.name == baseName.toString()))
 			.filter!(ps => !ps.empty);
 		if (search.empty) {
 			logWarn("Package '%s' was neither found locally nor online.", packageParts);
@@ -3133,7 +3133,7 @@ private bool addDependency(Dub dub, ref PackageRecipe recipe, string depspec)
 	}
 	else
 		dep = Dependency(parts.range);
-	recipe.buildSettings.dependencies[depname] = dep;
+	recipe.buildSettings.dependencies[depname.toString()] = dep;
 	logInfo("Adding dependency %s %s", depname, dep.toString());
 	return true;
 }

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -26,9 +26,6 @@ public struct PackageName
 	/// Where the separator lies, if any
 	private size_t separator;
 
-	/// For compatibility in `PackageDependency`
-	alias toString this;
-
 	/// Creates a new instance of this struct
 	public this(string fn) @safe pure
 	{

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -432,7 +432,7 @@ class PackageManager {
 		string gitReference = repo.ref_.chompPrefix("~");
 		NativePath destination = this.getPackagePath(PlacementLocation.user, name, repo.ref_);
 
-		foreach (p; getPackageIterator(name)) {
+		foreach (p; getPackageIterator(name.toString())) {
 			if (p.path == destination) {
 				return p;
 			}
@@ -1474,7 +1474,8 @@ package struct Location {
 	 */
 	NativePath getPackagePath (in PackageName name, string vers)
 	{
-		NativePath result = this.packagePath ~ name.main ~ vers ~ name.main;
+		NativePath result = this.packagePath ~ name.main.toString() ~ vers ~
+			name.main.toString();
 		result.endsWithSlash = true;
 		return result;
 	}

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -31,7 +31,7 @@ class FileSystemPackageSupplier : PackageSupplier {
         const zipFileGlob = name.main.toString() ~ "*.zip";
 		foreach (DirEntry d; dirEntries(m_path.toNativeString(), zipFileGlob, SpanMode.shallow)) {
 			NativePath p = NativePath(d.name);
-			auto vers = p.head.name[name.main.length+1..$-4];
+			auto vers = p.head.name[name.main.toString().length+1..$-4];
 			if (!isValidVersion(vers)) {
 				logDebug("Ignoring entry '%s' because it isn't a version of package '%s'", p, name.main);
 				continue;

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -106,12 +106,18 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 			else throw e;
 		}
 
-		auto json = Json(["name": Json(name.main), "versions": Json.emptyArray]);
+		auto json = Json([
+			"name": Json(name.main.toString()),
+			"versions": Json.emptyArray
+		]);
 		auto xml = new DocumentParser(xmlData);
 
 		xml.onStartTag["versions"] = (ElementParser xml) {
 			 xml.onEndTag["version"] = (in Element e) {
-				json["versions"] ~= serializeToJson(["name": name.main, "version": e.text]);
+				json["versions"] ~= serializeToJson([
+					"name": name.main.toString(),
+					"version": e.text,
+				]);
 			 };
 			 xml.parse();
 		};

--- a/source/dub/packagesuppliers/registry.d
+++ b/source/dub/packagesuppliers/registry.d
@@ -60,7 +60,8 @@ class RegistryPackageSupplier : PackageSupplier {
 		if (best.type != Json.Type.null_)
 		{
 			auto vers = best["version"].get!string;
-			ret = m_registryUrl ~ NativePath(PackagesPath~"/"~name.main~"/"~vers~".zip");
+			ret = m_registryUrl ~ NativePath(
+				"%s/%s/%s.zip".format(PackagesPath, name.main, vers));
 		}
 		return ret;
 	}
@@ -106,7 +107,8 @@ class RegistryPackageSupplier : PackageSupplier {
 		auto url = m_registryUrl ~ NativePath("api/packages/infos");
 
 		url.queryString = "packages=" ~
-				encodeComponent(`["` ~ name.main ~ `"]`) ~ "&include_dependencies=true&minimize=true";
+			encodeComponent(`["` ~ name.main.toString() ~ `"]`) ~
+			"&include_dependencies=true&minimize=true";
 
 		logDebug("Downloading metadata for %s", name.main);
 		string jsonData;
@@ -119,7 +121,7 @@ class RegistryPackageSupplier : PackageSupplier {
 			logDebug("adding %s to metadata cache", pkg);
 			m_metadataCache[PackageName(pkg)] = CacheEntry(info, now);
 		}
-		return json[name.main];
+		return json[name.main.toString()];
 	}
 
 	SearchResult[] searchPackages(string query) {

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -23,17 +23,13 @@ import std.string : startsWith, format;
 deprecated("Use `parseSDL(PackageRecipe, string, PackageName, string)` instead")
 void parseSDL(ref PackageRecipe recipe, string sdl, string parent_name, string filename)
 {
-	// Work around broken compiler overload resolution (seen at v2.106)
-	scope void function(ref PackageRecipe, Tag, in PackageName) func = &parseSDL;
-	func(recipe, parseSource(sdl, filename), PackageName(parent_name));
+	parseSDL(recipe, parseSource(sdl, filename), PackageName(parent_name));
 }
 
 deprecated("Use `parseSDL(PackageRecipe, Tag, PackageName)` instead")
 void parseSDL(ref PackageRecipe recipe, Tag sdl, string parent_name)
 {
-	// Work around broken compiler overload resolution (seen at v2.106)
-	scope void function(ref PackageRecipe, Tag, in PackageName) func = &parseSDL;
-	func(recipe, sdl, PackageName(parent_name));
+	parseSDL(recipe, sdl, PackageName(parent_name));
 }
 
 void parseSDL(ref PackageRecipe recipe, string sdl, in PackageName parent,
@@ -449,9 +445,7 @@ private void enforceSDL(bool condition, lazy string message, Tag tag, string fil
 // Just a wrapper around `parseSDL` for easier testing
 version (unittest) private void parseSDLTest(ref PackageRecipe recipe, string sdl)
 {
-	// Work around broken compiler overload resolution (seen at v2.106)
-	scope void function(ref PackageRecipe, Tag, in PackageName) func = &parseSDL;
-	func(recipe, parseSource(sdl, "testfile"), PackageName.init);
+	parseSDL(recipe, parseSource(sdl, "testfile"), PackageName.init);
 }
 
 unittest { // test all possible fields


### PR DESCRIPTION
The alias this was originally added to make the transition less painful, however due to an overload resolution bug, it makes it harder at the moment, as thje compiler prefers calling the deprecated `string` overloads over the `in PackageName` ones. So remove it and a few hacks along the way.