### PR TITLE
Improve unittest framework to have a virtual FS

### DIFF
--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -47,7 +47,7 @@ struct NativePath {
 	}
 
 	/// Constructs a path object from a list of PathEntry objects.
-	this(immutable(PathEntry)[] nodes, bool absolute)
+	this(immutable(PathEntry)[] nodes, bool absolute = false)
 	{
 		m_nodes = nodes;
 		m_absolute = absolute;

--- a/source/dub/test/dependencies.d
+++ b/source/dub/test/dependencies.d
@@ -39,9 +39,9 @@ dependency "c" version="*"
     const c = `name "c"`;
 
     scope dub = new TestDub();
-    dub.addTestPackage(c, Version("1.0.0"), PackageFormat.sdl);
-    dub.addTestPackage(b, Version("1.0.0"), PackageFormat.sdl);
-    dub.loadPackage(dub.addTestPackage(a, Version("1.0.0"), PackageFormat.sdl));
+    dub.addTestPackage(`c`, Version("1.0.0"), c, PackageFormat.sdl);
+    dub.addTestPackage(`b`, Version("1.0.0"), b, PackageFormat.sdl);
+    dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a, PackageFormat.sdl));
 
     dub.upgrade(UpgradeOptions.select);
 
@@ -63,9 +63,9 @@ dependency "c" version="*"
     const c = `name "c"`;
 
     scope dub = new TestDub();
-    dub.addTestPackage(c, Version("1.0.0"), PackageFormat.sdl);
-    dub.addTestPackage(b, Version("1.0.0"), PackageFormat.sdl);
-    dub.loadPackage(dub.addTestPackage(a, Version("1.0.0"), PackageFormat.sdl));
+    dub.addTestPackage(`c`, Version("1.0.0"), c, PackageFormat.sdl);
+    dub.addTestPackage(`b`, Version("1.0.0"), b, PackageFormat.sdl);
+    dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a, PackageFormat.sdl));
 
     dub.upgrade(UpgradeOptions.select);
 
@@ -91,10 +91,10 @@ dependency "d" version="*"
     const d = `name "d"`;
 
     scope dub = new TestDub();
-    dub.addTestPackage(d, Version("1.0.0"), PackageFormat.sdl);
-    dub.addTestPackage(c, Version("1.0.0"), PackageFormat.sdl);
-    dub.addTestPackage(b, Version("1.0.0"), PackageFormat.sdl);
-    dub.loadPackage(dub.addTestPackage(a, Version("1.0.0"), PackageFormat.sdl));
+    dub.addTestPackage(`d`, Version("1.0.0"), d, PackageFormat.sdl);
+    dub.addTestPackage(`c`, Version("1.0.0"), c, PackageFormat.sdl);
+    dub.addTestPackage(`b`, Version("1.0.0"), b, PackageFormat.sdl);
+    dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a, PackageFormat.sdl));
 
     dub.upgrade(UpgradeOptions.select);
 
@@ -113,7 +113,7 @@ dependency "b" version="*"
 `;
 
     scope dub = new TestDub();
-    dub.loadPackage(dub.addTestPackage(a, Version("1.0.0"), PackageFormat.sdl));
+    dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a, PackageFormat.sdl));
 
     try
         dub.upgrade(UpgradeOptions.select);
@@ -125,7 +125,7 @@ dependency "b" version="*"
     assert(dub.project.getDependency("no", true) is null, "Returned unexpected dependency");
 
     // Add the missing dependency to our PackageManager
-    dub.addTestPackage(`name "b"`, Version("1.0.0"), PackageFormat.sdl);
+    dub.addTestPackage(`b`, Version("1.0.0"), `name "b"`, PackageFormat.sdl);
     dub.upgrade(UpgradeOptions.select);
     assert(dub.project.hasAllDependencies(), "project have missing dependencies");
     assert(dub.project.getDependency("b", true), "Missing 'b' dependency");

--- a/source/dub/test/other.d
+++ b/source/dub/test/other.d
@@ -31,20 +31,20 @@ unittest
     // Invalid URL, valid hash
     const a = Template.format("a", "git+https://nope.nope", ValidHash);
     try
-        dub.loadPackage(dub.addTestPackage(a, Version("1.0.0")));
+        dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a));
     catch (Exception exc)
         assert(exc.message.canFind("Unable to fetch"));
 
     // Valid URL, invalid hash
     const b = Template.format("b", ValidURL, "invalid");
     try
-        dub.loadPackage(dub.addTestPackage(b, Version("1.0.0")));
+        dub.loadPackage(dub.addTestPackage(`b`, Version("1.0.0"), b));
     catch (Exception exc)
         assert(exc.message.canFind("Unable to fetch"));
 
     // Valid URL, valid hash
     const c = Template.format("c", ValidURL, ValidHash);
-    dub.loadPackage(dub.addTestPackage(c, Version("1.0.0")));
+    dub.loadPackage(dub.addTestPackage(`c`, Version("1.0.0"), c));
     assert(dub.project.hasAllDependencies());
     assert(dub.project.getDependency("dep1", true), "Missing 'dep1' dependency");
 }

--- a/source/dub/test/subpackages.d
+++ b/source/dub/test/subpackages.d
@@ -1,0 +1,39 @@
+/*******************************************************************************
+
+    Test for subpackages
+
+    Subpackages are packages that are part of a 'main' packages. Their version
+    is that of their main (parent) package. They are referenced using a column,
+    e.g. `mainpkg:subpkg`. Nested subpackages are disallowed.
+
+*******************************************************************************/
+
+module dub.test.subpackages;
+
+version(unittest):
+
+import dub.test.base;
+
+/// Test of the PackageManager APIs
+unittest
+{
+    const a = `{ "name": "a", "dependencies": { "b:a": "~>1.0", "b:b": "~>1.0" } }`;
+    const b = `{ "name": "b", "subPackages": [ { "name": "a" }, { "name": "b" } ] }`;
+
+    scope dub = new TestDub();
+    dub.addTestPackage(`b`, Version("1.0.0"), b);
+    auto mainPackage = dub.addTestPackage(`a`, Version("1.0.0"), a);
+    dub.loadPackage(mainPackage);
+    dub.upgrade(UpgradeOptions.select);
+
+    assert(dub.project.hasAllDependencies(), "project has missing dependencies");
+    assert(dub.project.getDependency("b:b", true), "Missing 'b:b' dependency");
+    assert(dub.project.getDependency("b:a", true), "Missing 'b:a' dependency");
+    assert(dub.project.getDependency("no", true) is null, "Returned unexpected dependency");
+
+    assert(dub.packageManager().getPackage(PackageName("b:a"), Version("1.0.0")).name == "b:a");
+    assert(dub.packageManager().getPackage(PackageName("b:b"), Version("1.0.0")).name == "b:b");
+    assert(dub.packageManager().getPackage(PackageName("b"), Version("1.0.0")).name == "b");
+
+    assert(!dub.packageManager().getPackage(PackageName("b:b"), Version("1.1.0")));
+}


### PR DESCRIPTION
This gets the unittest framework closer to the actual behavior, and allows us to mock basic FS operations such as mkdir and writeFile. Further improvements can be made to support more operations, and to have package setup done before `TestDub` instantiation.