### PR TITLE
Build the tests and binary with -cov on POSIX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,7 @@ jobs:
     - name: '[POSIX] Test'
       if: runner.os != 'Windows'
       env:
-        COVERAGE: false
-        # The value doesn't matter as long as it's > 2.087
-        FRONTEND: 2.095.0
+        COVERAGE: true
       run: |
         dub build --compiler=${{ env.DC }}
         if [[ ${{ matrix.do_test }} == 'true' ]]; then

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -8,24 +8,12 @@ dub test --compiler=${DC} -c library-nonet
 
 export DMD="$(command -v $DMD)"
 
-if [ "$FRONTEND" \> 2.087.z ]; then
-    ./build.d -preview=dip1000 -preview=in -w -g -debug
-fi
-
-function clean() {
-    # Hard reset of the DUB local folder is necessary as some tests
-    # currently don't properly clean themselves
-    rm -rf ~/.dub
-    git clean -dxf -- test
-}
+./build.d -preview=dip1000 -preview=in -w -g -debug
 
 if [ "$COVERAGE" = true ]; then
     # library-nonet fails to build with coverage (Issue 13742)
     dub test --compiler=${DC} -b unittest-cov
     ./build.d -cov
-
-    wget https://codecov.io/bash -O codecov.sh
-    bash codecov.sh
 else
     ./build.d
     DUB=`pwd`/bin/dub DC=${DC} dub --single ./test/run-unittest.d


### PR DESCRIPTION
The CI was sending empty coverage reports because nothing was being generated, as the variable was always false. In the process, a bit of dead code was removed.