### PR TITLE
Fix #2840:  Build collision for single-package and FILE_FULL_PATH

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -216,7 +216,7 @@ class BuildGenerator : ProjectGenerator {
 		auto cwd = settings.toolWorkingDirectory;
 		bool generate_binary = !(buildsettings.options & BuildOption.syntaxOnly);
 
-		auto build_id = buildsettings.computeBuildID(config, settings);
+		auto build_id = buildsettings.computeBuildID(pack.path, config, settings);
 
 		// make all paths relative to shrink the command line
 		string makeRelative(string path) { return shrinkPath(NativePath(path), cwd); }

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -828,7 +828,8 @@ package(dub) NativePath targetCacheDir(NativePath cachePath, in Package pkg, str
  * library-debug-Z7qINYX4IxM8muBSlyNGrw
  * ```
  */
-package(dub) string computeBuildID(in BuildSettings buildsettings, string config, GeneratorSettings settings)
+package(dub) string computeBuildID(in BuildSettings buildsettings,
+	in NativePath packagePath, string config, GeneratorSettings settings)
 {
 	import std.conv : to;
 
@@ -843,6 +844,8 @@ package(dub) string computeBuildID(in BuildSettings buildsettings, string config
 		settings.platform.architecture,
 		[
 			(cast(uint)(buildsettings.options & ~BuildOption.color)).to!string, // exclude color option from id
+			// Needed for things such as `__FULL_FILE_PATH__`
+			packagePath.toNativeString(),
 			settings.platform.compilerBinary,
 			settings.platform.compiler,
 			settings.platform.compilerVersion,

--- a/source/dub/generators/targetdescription.d
+++ b/source/dub/generators/targetdescription.d
@@ -45,7 +45,7 @@ class TargetDescriptionGenerator : ProjectGenerator {
 			d.packages = ti.packages.map!(p => p.name).array;
 			d.rootConfiguration = ti.config;
 			d.buildSettings = ti.buildSettings.dup;
-			const buildId = computeBuildID(d.buildSettings, ti.config, settings);
+			const buildId = computeBuildID(d.buildSettings, ti.pack.path, ti.config, settings);
 			const filename = settings.compiler.getTargetFileName(d.buildSettings, settings.platform);
 			d.cacheArtifactPath = (targetCacheDir(settings.cache, ti.pack, buildId) ~ filename).toNativeString();
 			d.dependencies = ti.dependencies.dup;

--- a/test/issue2840-build-collision.sh
+++ b/test/issue2840-build-collision.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+pushd $(dirname "${BASH_SOURCE[0]}")/issue2840-build-collision
+# Copy before building, as dub uses timestamp to check for rebuild
+rm -rf nested/ && mkdir -p nested/ && cp -v build.d nested/
+
+$DUB ./build.d $(pwd)/build.d
+pushd nested
+$DUB ./build.d $(pwd)/build.d
+popd
+
+popd

--- a/test/issue2840-build-collision/build.d
+++ b/test/issue2840-build-collision/build.d
@@ -1,0 +1,16 @@
+#!/usr/bin/env dub
+/++ dub.json:
+   {
+       "name": "build"
+   }
++/
+
+import std.format;
+
+immutable FullPath = __FILE_FULL_PATH__;
+
+void main (string[] args)
+{
+    assert(args.length == 2, "Expected a single argument");
+    assert(args[1] == FullPath, format("%s != %s -- %s", args[1], FullPath, args[0]));
+}


### PR DESCRIPTION
By including the package path in the buildid we avoid the problem,
at the expense of not sharing the cache for packages that could be
shared, but we would need to know if the code depends on __FILE__
and __FILE_FULL_PATH__ or not.
