### PR TITLE
Make 'Dependency.init' invalid and align Any/Invalid property

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -124,14 +124,19 @@ struct Dependency {
 	// Shortcut to create >=0.0.0
 	private enum ANY_IDENT = "*";
 
-	private Value m_value;
+	private Value m_value = Value(VersionRange.Invalid);
 	private bool m_optional;
 	private bool m_default;
 
 	/// A Dependency, which matches every valid version.
-	static @property Dependency any() @safe { return Dependency(VersionRange.Any); }
+	public static immutable Dependency Any = Dependency(VersionRange.Any);
 
 	/// An invalid dependency (with no possible version matches).
+	public static immutable Dependency Invalid = Dependency(VersionRange.Invalid);
+
+	deprecated("Use `Dependency.Any` instead")
+	static @property Dependency any() @safe { return Dependency(VersionRange.Any); }
+	deprecated("Use `Dependency.Invalid` instead")
 	static @property Dependency invalid() @safe
 	{
 		return Dependency(VersionRange.Invalid);
@@ -510,11 +515,11 @@ struct Dependency {
 	*/
 	Dependency merge(ref const(Dependency) o) const @trusted {
 		alias Merger = match!(
-			(const NativePath a, const NativePath b) => a == b ? this : invalid,
+			(const NativePath a, const NativePath b) => a == b ? this : Invalid,
 			(const NativePath a,       any         ) => o,
 			(      any         , const NativePath b) => this,
 
-			(const Repository a, const Repository b) => a.m_ref == b.m_ref ? this : invalid,
+			(const Repository a, const Repository b) => a.m_ref == b.m_ref ? this : Invalid,
 			(const Repository a,       any         ) => this,
 			(      any         , const Repository b) => o,
 
@@ -524,7 +529,7 @@ struct Dependency {
 
 				VersionRange copy = a;
 				copy.merge(b);
-				if (!copy.isValid()) return invalid;
+				if (!copy.isValid()) return Invalid;
 				return Dependency(copy);
 			}
 		);
@@ -682,7 +687,7 @@ unittest {
 	assert(a.valid);
 	assert(a.version_ == Version("~d2test"));
 
-	a = Dependency.any;
+	a = Dependency.Any;
 	assert(!a.optional);
 	assert(a.valid);
 	assertThrown(a.version_);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -483,7 +483,7 @@ class Project {
 					(VersionRange vers) {
 						if (m_selections.hasSelectedVersion(basename)) {
 							auto selver = m_selections.getSelectedVersion(basename);
-							if (d.spec.merge(selver) == Dependency.invalid) {
+							if (d.spec.merge(selver) == Dependency.Invalid) {
 								logWarn(`Selected package %s@%s does not match ` ~
 								   `the dependency specification %s in ` ~
 								   `package %s. Need to "%s"?`,

--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -202,7 +202,7 @@ private void parseDependency(Tag t, ref BuildSettingsTemplate bs, in PackageName
 	auto pkg = expandPackageName(t.values[0].expect!string(t), name, t);
 	enforceSDL(pkg !in bs.dependencies, "The dependency '"~pkg~"' is specified more than once.", t);
 
-	Dependency dep = Dependency.any;
+	Dependency dep = Dependency.Any;
 	auto attrs = t.attributes;
 
 	if ("path" in attrs) {


### PR DESCRIPTION
VersionRange has Invalid and Any while Dependency has invalid and any. One has to go, and it's going to be Dependency's.
In addition, make sure that the 'init' state of Dependency is a known state.