### PR TITLE
CI: Run all tests when coverage is enabled

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -15,7 +15,8 @@ if [ "$COVERAGE" = true ]; then
     dub test --compiler=${DC} -b unittest-cov
     ./build.d -cov
 else
+    dub test --compiler=${DC} -b unittest-cov
     ./build.d
-    DUB=`pwd`/bin/dub DC=${DC} dub --single ./test/run-unittest.d
-    DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh
 fi
+DUB=`pwd`/bin/dub DC=${DC} dub --single ./test/run-unittest.d
+DUB=`pwd`/bin/dub DC=${DC} test/run-unittest.sh


### PR DESCRIPTION
A recent change in the CI enabled coverage, however it did so on the latest tags, meaning we were no longer running the other tests (from the testsuite). This corrects it.