### PR TITLE
Test: Re-enable 'scan' behavior in TestPackageManager

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -290,7 +290,7 @@ package class TestPackageManager : PackageManager
         NativePath user = TestDub.Paths.userSettings;
         NativePath system = TestDub.Paths.systemSettings;
         this.fs = filesystem;
-        super(local, user, system, false);
+        super(local, user, system);
     }
 
     // Re-introduce hidden/deprecated overloads


### PR DESCRIPTION
Now that 'scan' is implemented in the TestPackageManager, there is no reason to deviate from what the base class and Dub binary does.