### PR TITLE
Tests: Use TestDub FSEntry constructor for more accurate tests

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -144,15 +144,23 @@ public class TestDub : Dub
 {
     /// The virtual filesystem that this instance acts on
     public FSEntry fs;
-    /// Convenience constants for use in unittets
-    public static immutable ProjectPath = NativePath("/dub/project/");
+
+    /// Convenience constants for use in unittests
+    version (Windows)
+        public static immutable Root = NativePath("T:\\dub\\");
+    else
+        public static immutable Root = NativePath("/dub/");
+
+    /// Ditto
+    public static immutable ProjectPath = Root ~ "project";
+
     /// Ditto
     public static immutable SpecialDirs Paths = {
-        temp: "/dub/temp/",
-        systemSettings: "/dub/system/",
-        userSettings: "/dub/user/",
-        userPackages: "/dub/user/",
-        cache: "/dub/user/cache/",
+        temp: Root ~ "temp/",
+        systemSettings: Root ~ "system/",
+        userSettings: Root ~ "user/",
+        userPackages: Root ~ "user/",
+        cache: Root ~ "user/" ~ "cache/",
     };
 
     /// Forward to base constructor

--- a/source/dub/test/other.d
+++ b/source/dub/test/other.d
@@ -18,30 +18,31 @@ unittest
     const ValidURL = `git+https://example.com/dlang/dub`;
     // Taken from a commit in the dub repository
     const ValidHash = "54339dff7ce9ec24eda550f8055354f712f15800";
-    const Template = `{"name": "%s", "dependencies": {
+    const Template = `{"name": "%s", "version": "1.0.0", "dependencies": {
 "dep1": { "repository": "%s", "version": "%s" }}}`;
 
-    scope dub = new TestDub();
+    scope dub = new TestDub((scope FSEntry fs) {
+        // Invalid URL, valid hash
+        fs.writePackageFile("a", "1.0.0", Template.format("a", "git+https://nope.nope", ValidHash));
+        // Valid URL, invalid hash
+        fs.writePackageFile("b", "1.0.0", Template.format("b", ValidURL, "invalid"));
+        // Valid URL, valid hash
+        fs.writePackageFile("c", "1.0.0", Template.format("c", ValidURL, ValidHash));
+    });
     dub.packageManager.addTestSCMPackage(
         Repository(ValidURL, ValidHash), `{ "name": "dep1" }`);
 
-    // Invalid URL, valid hash
-    const a = Template.format("a", "git+https://nope.nope", ValidHash);
     try
-        dub.loadPackage(dub.addTestPackage(`a`, Version("1.0.0"), a));
+        dub.loadPackage(dub.packageManager.getPackage(PackageName("a"), Version("1.0.0")));
+    catch (Exception exc)
+         assert(exc.message.canFind("Unable to fetch"));
+
+    try
+        dub.loadPackage(dub.packageManager.getPackage(PackageName("b"), Version("1.0.0")));
     catch (Exception exc)
         assert(exc.message.canFind("Unable to fetch"));
 
-    // Valid URL, invalid hash
-    const b = Template.format("b", ValidURL, "invalid");
-    try
-        dub.loadPackage(dub.addTestPackage(`b`, Version("1.0.0"), b));
-    catch (Exception exc)
-        assert(exc.message.canFind("Unable to fetch"));
-
-    // Valid URL, valid hash
-    const c = Template.format("c", ValidURL, ValidHash);
-    dub.loadPackage(dub.addTestPackage(`c`, Version("1.0.0"), c));
+    dub.loadPackage(dub.packageManager.getPackage(PackageName("c"), Version("1.0.0")));
     assert(dub.project.hasAllDependencies());
     assert(dub.project.getDependency("dep1", true), "Missing 'dep1' dependency");
 }

--- a/source/dub/test/subpackages.d
+++ b/source/dub/test/subpackages.d
@@ -17,13 +17,14 @@ import dub.test.base;
 /// Test of the PackageManager APIs
 unittest
 {
-    const a = `{ "name": "a", "dependencies": { "b:a": "~>1.0", "b:b": "~>1.0" } }`;
-    const b = `{ "name": "b", "subPackages": [ { "name": "a" }, { "name": "b" } ] }`;
+    scope dub = new TestDub((scope FSEntry root) {
+        root.writeFile(TestDub.ProjectPath ~ "dub.json",
+            `{ "name": "a", "dependencies": { "b:a": "~>1.0", "b:b": "~>1.0" } }`);
+        root.writePackageFile("b", "1.0.0",
+            `{ "name": "b", "version": "1.0.0", "subPackages": [ { "name": "a" }, { "name": "b" } ] }`);
+    });
+    dub.loadPackage();
 
-    scope dub = new TestDub();
-    dub.addTestPackage(`b`, Version("1.0.0"), b);
-    auto mainPackage = dub.addTestPackage(`a`, Version("1.0.0"), a);
-    dub.loadPackage(mainPackage);
     dub.upgrade(UpgradeOptions.select);
 
     assert(dub.project.hasAllDependencies(), "project has missing dependencies");


### PR DESCRIPTION
The previous approach added Packages in the PackageManager directly, completely sidestepping the scanning the PackageManager does, which is a behavior we absolutely want to test.

By setting up the filesystem before we instantiate our `TestDub` instance, we can remove a bunch of exceptions / overrides, and get a much closer behavior to the final product.