### PR TITLE
Tests: Fix writeFile implementation with vibe-d

### DIFF
--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -185,6 +185,8 @@ struct NativePath {
 
 	/// The parent path
 	@property NativePath parentPath() const { return this[0 .. length-1]; }
+	/// Forward compatibility with vibe-d
+	@property bool hasParentPath() const { return length > 1; }
 
 	/// The list of path entries of which this path is composed
 	@property immutable(PathEntry)[] nodes() const { return m_nodes; }


### PR DESCRIPTION
This was triggering an assert error with vibe-d path. The recursion logic was a bit murky, so the function is now split in 3 different part and better documented.