### PR TITLE
Upgrade checkout and codecov to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install latest DMD
         uses: dlang-community/setup-dlang@v1
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         run: |
           # check for trailing whitespace
@@ -133,4 +133,4 @@ jobs:
       shell: bash
 
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
Get rid of a deprecation message about Node 16.