### PR TITLE
Hoist imports and remove versioning in FilesystemPackageSupplier

### DIFF
--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -1,6 +1,10 @@
 module dub.packagesuppliers.filesystem;
 
+import dub.internal.logging;
+import dub.internal.vibecompat.inet.path;
 import dub.packagesuppliers.packagesupplier;
+
+import std.exception : enforce;
 
 /**
 	File system based package supplier.
@@ -9,10 +13,6 @@ import dub.packagesuppliers.packagesupplier;
 	the form "[package name]-[version].zip".
 */
 class FileSystemPackageSupplier : PackageSupplier {
-	import dub.internal.logging;
-
-	version (Have_vibe_core) import dub.internal.vibecompat.inet.path : toNativeString;
-	import std.exception : enforce;
 	private {
 		NativePath m_path;
 	}


### PR DESCRIPTION
Hoisting imports to have them all in the same place.
Also remove a version statement, as the client code should not
care if vibe-d is being used and just import the internal module.