### PR TITLE
Clear up unprinted deprecation for overrides

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -2646,7 +2646,7 @@ class ListOverridesCommand : Command {
 			logInfoNoTag("# %s", caption);
 			foreach (ovr; overrides)
 				ovr.target.match!(
-					t => logInfoNoTag("%s %s => %s", ovr.package_.color(Mode.bold), ovr.version_, t));
+					t => logInfoNoTag("%s %s => %s", ovr.package_.color(Mode.bold), ovr.source, t));
 		}
 		printList(dub.packageManager.getOverrides_(PlacementLocation.user), "User wide overrides");
 		printList(dub.packageManager.getOverrides_(PlacementLocation.system), "System wide overrides");


### PR DESCRIPTION
This code should have triggered a deprecation, however it didn't get printed for some unknown reason. Turning on '-de' leads to seeing it. The fix is fairly straightforward and doesn't affect the code.