### PR TITLE
Use the proper constructor for PackageDependency

### DIFF
--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -578,7 +578,7 @@ class Package {
 				this.recipe.configurations.map!(c => c.buildSettings.dependencies.byKeyValue)
 			)
 			.joiner()
-			.map!(d => PackageDependency(d.key, d.value));
+			.map!(d => PackageDependency(PackageName(d.key), d.value));
 	}
 
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -194,7 +194,7 @@ class Project {
 				if (!cfg.length) deps = p.getAllDependencies();
 				else {
 					auto depmap = p.getDependencies(cfg);
-					deps = depmap.byKey.map!(k => PackageDependency(k, depmap[k])).array;
+					deps = depmap.byKey.map!(k => PackageDependency(PackageName(k), depmap[k])).array;
 				}
 				deps.sort!((a, b) => a.name.toString() < b.name.toString());
 


### PR DESCRIPTION
This code was using a deprecated constructor, but as it was in lambda, it didn't trigger a deprecation message, however '-de' points us to the issue.