### PR TITLE
Tests: FSEntry.writeFile write to wrong directory

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -775,7 +775,7 @@ public class FSEntry
             return parent.writeFile(NativePath(path.head), data);
         } else {
             // We're in the right `FSEntry`, create the file
-            auto file = new FSEntry(parent, Type.File, path.head.name());
+            auto file = new FSEntry(this, Type.File, path.head.name());
             file.content = data.dup;
             this.children ~= file;
         }


### PR DESCRIPTION
This was a subtle bug hidden by the fact that 'parent' exists in the class. It was causing problems when calling 'print', but luckily didn't affect anything else.