### PR TITLE
Allow tests to call customCachePaths

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -335,12 +335,6 @@ package class TestPackageManager : PackageManager
     // Re-introduce hidden/deprecated overloads
     public alias store = PackageManager.store;
 
-    /// Disabled as semantic are not implementable unless a virtual FS is created
-	public override @property void customCachePaths(NativePath[] custom_cache_paths)
-    {
-        assert(0, "Function not implemented");
-    }
-
     /// Ditto
     public override Package store(NativePath src, PlacementLocation dest, in PackageName name, in Version vers)
     {


### PR DESCRIPTION
This is now possible, as refresh has been mostly implemented.