### PR TITLE
Simplify mocking IO in PackageManager, add a test for `add-path`

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -896,7 +896,7 @@ class Command {
 
 	private bool loadCwdPackage(Dub dub, bool warn_missing_package)
 	{
-		auto filePath = Package.findPackageFile(dub.rootPath);
+		auto filePath = dub.packageManager.findPackageFile(dub.rootPath);
 
 		if (filePath.empty) {
 			if (warn_missing_package) {

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -153,6 +153,7 @@ class Package {
 			Returns the full path to the package file, if any was found.
 			Otherwise returns an empty path.
 	*/
+	deprecated("Use `PackageManager.findPackageFile`")
 	static NativePath findPackageFile(NativePath directory)
 	{
 		foreach (file; packageInfoFiles) {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -1066,7 +1066,7 @@ symlink_exit:
 			repository.scan(this, refresh);
 
 		foreach (ref repository; this.m_repositories)
-			repository.loadOverrides();
+			repository.loadOverrides(this);
 		this.m_initialized = true;
 	}
 
@@ -1378,17 +1378,17 @@ package struct Location {
 		this.packagePath = path;
 	}
 
-	void loadOverrides()
+	void loadOverrides(PackageManager mgr)
 	{
-		import dub.internal.vibecompat.core.file;
-
 		this.overrides = null;
 		auto ovrfilepath = this.packagePath ~ LocalOverridesFilename;
-		if (existsFile(ovrfilepath)) {
+		if (mgr.existsFile(ovrfilepath)) {
 			logWarn("Found local override file: %s", ovrfilepath);
 			logWarn(OverrideDepMsg);
 			logWarn("Replace with a path-based dependency in your project or a custom cache path");
-			foreach (entry; jsonFromFile(ovrfilepath)) {
+			const text = mgr.readText(ovrfilepath);
+			auto json = parseJsonString(text, ovrfilepath.toNativeString());
+			foreach (entry; json) {
 				PackageOverride_ ovr;
 				ovr.package_ = entry["name"].get!string;
 				ovr.source = VersionRange.fromString(entry["version"].get!string);

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -381,7 +381,7 @@ class PackageManager {
 		StrictMode mode = StrictMode.Ignore)
 	{
 		if (recipe.empty)
-			recipe = Package.findPackageFile(path);
+			recipe = this.findPackageFile(path);
 
 		enforce(!recipe.empty,
 			"No package file found in %s, expected one of %s"
@@ -394,6 +394,24 @@ class PackageManager {
 		auto ret = new Package(content, path, parent, version_);
 		ret.m_infoFile = recipe;
 		return ret;
+	}
+
+	/** Searches the given directory for package recipe files.
+	 *
+	 * Params:
+	 *   directory = The directory to search
+	 *
+	 * Returns:
+	 *   Returns the full path to the package file, if any was found.
+	 *   Otherwise returns an empty path.
+	 */
+	public NativePath findPackageFile(NativePath directory)
+	{
+		foreach (file; packageInfoFiles) {
+			auto filename = directory ~ file.filename;
+			if (this.existsFile(filename)) return filename;
+		}
+		return NativePath.init;
 	}
 
 	/** For a given SCM repository, returns the corresponding package.
@@ -1452,7 +1470,7 @@ package struct Location {
 						}
 
 						if (!pp) {
-							auto infoFile = Package.findPackageFile(path);
+							auto infoFile = manager.findPackageFile(path);
 							if (!infoFile.empty) pp = manager.load(path, infoFile);
 							else {
 								logWarn("Locally registered package %s %s was not found. Please run 'dub remove-local \"%s\"'.",
@@ -1533,7 +1551,7 @@ package struct Location {
 			if (!pdir.isDirectory) continue;
 
 			const pack_path = path ~ (pdir.name ~ "/");
-			auto packageFile = Package.findPackageFile(pack_path);
+			auto packageFile = mgr.findPackageFile(pack_path);
 
 			if (isManaged(path)) {
 				// Old / flat directory structure, used in non-standard path
@@ -1554,7 +1572,7 @@ package struct Location {
 						if (!versdir.isDirectory) continue;
 						auto vers_path = pack_path ~ versdir.name ~ (pdir.name ~ "/");
 						if (!mgr.existsDirectory(vers_path)) continue;
-						packageFile = Package.findPackageFile(vers_path);
+						packageFile = mgr.findPackageFile(vers_path);
 						loadInternal(vers_path, packageFile);
 					}
 				}

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -1448,8 +1448,6 @@ package struct Location {
 	// load locally defined packages
 	void scanLocalPackages(bool refresh, PackageManager manager)
 	{
-		import dub.internal.vibecompat.core.file;
-
 		NativePath list_path = this.packagePath;
 		Package[] packs;
 		NativePath[] paths;
@@ -1458,7 +1456,9 @@ package struct Location {
 			if (!manager.existsFile(local_package_file)) return;
 
 			logDiagnostic("Loading local package map at %s", local_package_file.toNativeString());
-			auto packlist = jsonFromFile(local_package_file);
+			const text = manager.readText(local_package_file);
+			auto packlist = parseJsonString(
+				text, local_package_file.toNativeString());
 			enforce(packlist.type == Json.Type.array, LocalPackagesFilename ~ " must contain an array.");
 			foreach (pentry; packlist) {
 				try {

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -390,7 +390,9 @@ class PackageManager {
 
 		const PackageName pname = parent
 			? PackageName(parent.name) : PackageName.init;
-		auto content = readPackageRecipe(recipe, pname, mode);
+		string text = this.readText(recipe);
+		auto content = parsePackageRecipe(
+			text, recipe.toNativeString(), pname, null, mode);
 		auto ret = new Package(content, path, parent, version_);
 		ret.m_infoFile = recipe;
 		return ret;
@@ -1219,6 +1221,13 @@ symlink_exit:
 	{
 		static import dub.internal.vibecompat.core.file;
 		return dub.internal.vibecompat.core.file.writeFile(path, data);
+	}
+
+	/// Ditto
+	protected string readText(NativePath path)
+	{
+		static import dub.internal.vibecompat.core.file;
+		return dub.internal.vibecompat.core.file.readText(path);
 	}
 
 	/// Ditto

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -345,29 +345,6 @@ package class TestPackageManager : PackageManager
         assert(0, "Function not implemented");
     }
 
-    /**
-     * This function usually scans the filesystem for packages.
-     *
-     * We don't want to do IO access and rely on users adding the packages
-     * before the test starts instead.
-     *
-     * Note: Deprecated `refresh(bool)` does IO, but it's deprecated
-     */
-	public override void refresh()
-	{
-		// Local packages are not yet implemented
-		version (none) {
-			foreach (ref repository; this.m_repositories)
-				repository.scanLocalPackages(false, this);
-		}
-		this.m_internal.scan(this, false);
-		foreach (ref repository; this.m_repositories)
-			repository.scan(this, false);
-
-		// Removed override loading usually done here as they are deprecated
-		this.m_initialized = true;
-	}
-
 	/**
 	 * Re-Implementation of `gitClone`.
 	 *

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -374,6 +374,12 @@ package class TestPackageManager : PackageManager
     }
 
     ///
+    protected override void ensureDirectory(NativePath path)
+    {
+        this.fs.mkdir(path);
+    }
+
+    ///
     protected override bool existsFile(NativePath path)
     {
         return this.fs.existsFile(path);

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -369,36 +369,6 @@ package class TestPackageManager : PackageManager
 	}
 
 	/**
-	 * Loads a `Package`
-	 *
-	 * This is currently not implemented, and any call to it will trigger
-	 * an assert, as that would otherwise be an access to the filesystem.
-	 */
-	protected override Package load(NativePath path, NativePath recipe = NativePath.init,
-		Package parent = null, string version_ = null,
-		StrictMode mode = StrictMode.Ignore)
-	{
-		if (recipe.empty)
-			recipe = this.findPackageFile(path);
-
-		enforce(!recipe.empty,
-			"No package file found in %s, expected one of %s"
-				.format(path.toNativeString(),
-					packageInfoFiles.map!(f => cast(string)f.filename).join("/")));
-
-		const PackageName parent_name = parent
-			? PackageName(parent.name) : PackageName.init;
-
-		string text = this.fs.readText(recipe);
-		auto content = parsePackageRecipe(text, recipe.toNativeString(),
-			parent_name, null, mode);
-
-		auto ret = new Package(content, path, parent, version_);
-		ret.m_infoFile = recipe;
-		return ret;
-	}
-
-	/**
 	 * Re-Implementation of `gitClone`.
 	 *
 	 * The base implementation will do a `git` clone, to the file-system.
@@ -442,6 +412,12 @@ package class TestPackageManager : PackageManager
     protected override void writeFile(NativePath path, const(char)[] data)
     {
         return this.fs.writeFile(path, data);
+    }
+
+    ///
+    protected override string readText(NativePath path)
+    {
+        return this.fs.readText(path);
     }
 
     ///

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -60,7 +60,7 @@ public import dub.dependency;
 public import dub.dub;
 public import dub.package_;
 import dub.internal.vibecompat.core.file : FileInfo;
-import dub.internal.vibecompat.inet.path;
+public import dub.internal.vibecompat.inet.path;
 import dub.packagemanager;
 import dub.packagesuppliers.packagesupplier;
 import dub.project;

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -398,16 +398,6 @@ package class TestPackageManager : PackageManager
 		return ret;
 	}
 
-	/// Reimplementation of `Package.findPackageFile`
-	public NativePath findPackageFile(NativePath directory)
-	{
-		foreach (file; packageInfoFiles) {
-			auto filename = directory ~ file.filename;
-			if (this.fs.existsFile(filename)) return filename;
-		}
-		return NativePath.init;
-	}
-
 	/**
 	 * Re-Implementation of `gitClone`.
 	 *


### PR DESCRIPTION
@s-ludwig : I would like to remove the scanning behavior in `PackageManager`. This is a source of pain for us, as it slows down builds, including with @atilaneves Reggae.

Last time that introduced a regression which you fixed in https://github.com/dlang/dub/pull/2481 .
This simplifies mocking quite a bit and introduces a test for it (see last commit / `source/dub/test/other.d` in the diff).
If you could have a quick look at the test and confirm that it covers your use case ?