### PR TITLE
Trivial: Upgrade remaining actions/checkout to v4

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     # Checkout the repository
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
 
     # Checkout the repository
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: '[POSIX] Test'
       if: runner.os != 'Windows'

--- a/.github/workflows/pr_info_untrusted.yml
+++ b/.github/workflows/pr_info_untrusted.yml
@@ -29,7 +29,7 @@ jobs:
         compiler: ldc-latest
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Avoid deprecated Node 16.