### PR TITLE
Trivial: Simplify ensureDirectory

### DIFF
--- a/source/dub/internal/vibecompat/core/file.d
+++ b/source/dub/internal/vibecompat/core/file.d
@@ -252,8 +252,7 @@ FileInfo getFileInfo(string path)
 */
 void ensureDirectory(NativePath path)
 {
-	if (!existsDirectory(path))
-		mkdirRecurse(path.toNativeString());
+	mkdirRecurse(path.toNativeString());
 }
 
 /**


### PR DESCRIPTION
mkdirRecurse will not do anything if the directory already exists, so there is no need to call existsDirectory.