### PR TITLE
Speed up Package.getPackageConfigs

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -99,6 +99,12 @@ struct PackageDependency {
 		this.spec = s;
 	}
 
+	int opCmp(in typeof(this) other) @safe const {
+		return name == other.name
+			? spec.opCmp(other.spec)
+			: name.opCmp(other.name);
+	}
+
 	/// Name of the referenced package.
 	PackageName name;
 

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -573,13 +573,18 @@ class Package {
 	// Left as package until the final API for this has been found
 	package auto getAllDependenciesRange()
 	const {
+		import std.algorithm: sort, uniq;
+		import std.array: array;
 		return
 			chain(
 				only(this.recipe.buildSettings.dependencies.byKeyValue),
 				this.recipe.configurations.map!(c => c.buildSettings.dependencies.byKeyValue)
 			)
 			.joiner()
-			.map!(d => PackageDependency(PackageName(d.key), d.value));
+			.map!(d => PackageDependency(PackageName(d.key), d.value))
+			.array
+			.sort
+			.uniq;
 	}
 
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -724,6 +724,13 @@ class Project {
 
 		void determineDependencyConfigs(in Package p, string c)
 		{
+
+			// below we call createConfig for the main package if
+			// config.length is not zero.  Carry on for that case,
+			// otherwise we've handle the pair (p, c) already
+			if(haveConfig(p.name, c) && !(config.length && p.name == m_rootPackage.name && config == c))
+				return;
+
 			string[][string] depconfigs;
 			foreach (d; p.getAllDependencies()) {
 				auto dp = getDependency(d.name.toString(), true);


### PR DESCRIPTION
`Package.getPackageConfigs` was taking 3 *seconds* for a particular dub package, which was made worse by the fact it was called multiple times with different arguments. The changes in this PR bring it down to just under 200ms, which IMHO is still slow.

Investigating led me to realise that `determineDependencyConfigs` was being called over and over again for the exact same packages, especially common dependencies like `mir-algorithm` and `unit-threaded`. This PR does two things:

First, it makes the array of package dependencies smaller via `.sort.uniq`.  This cut down the time by half to 1.5s.

Secondly, after taking a while to understand the inner workings of the function, it returns early for packages that have already been analysed. This brought it further down to the 100ms range.