### PR TITLE
Respect skipRegistry value from configuration files

### DIFF
--- a/source/dub/data/settings.d
+++ b/source/dub/data/settings.d
@@ -17,6 +17,7 @@ public enum SkipPackageSuppliers {
     standard,   /// Does not use the default package suppliers (`defaultPackageSuppliers`).
     configured, /// Does not use default suppliers or suppliers configured in DUB's configuration file
     all,        /// Uses only manually specified package suppliers.
+    default_,   /// The value wasn't specified. It is provided in order to know when it is safe to ignore it
 }
 
 /**
@@ -39,7 +40,22 @@ package(dub) struct Settings {
     @Optional string[] registryUrls;
     @Optional NativePath[] customCachePaths;
 
-    SetInfo!(SkipPackageSuppliers) skipRegistry;
+    private struct SkipRegistry {
+	    SkipPackageSuppliers skipRegistry;
+	    static SkipRegistry fromString (string value) {
+		    import std.conv : to;
+		    auto result = value.to!SkipPackageSuppliers;
+		    if (result == SkipPackageSuppliers.default_) {
+			    throw new Exception(
+				"skipRegistry value `default_` is only meant for interal use."
+				~ " Instead, use one of `none`, `standard`, `configured`, or `all`."
+						);
+		    }
+		    return SkipRegistry(result);
+	    }
+	    alias skipRegistry this;
+    }
+    SetInfo!(SkipRegistry) skipRegistry;
     SetInfo!(string) defaultCompiler;
     SetInfo!(string) defaultArchitecture;
     SetInfo!(bool) defaultLowMemory;
@@ -170,4 +186,16 @@ unittest {
 
      auto m3 = Settings.init.merge(c1);
      assert(m3 == c1);
+}
+
+unittest {
+    // Test that SkipPackageRegistry.default_ is not allowed
+
+    import dub.internal.configy.Read;
+    import std.exception : assertThrown;
+
+    const str1 = `{
+  "skipRegistry": "all"
+`;
+    assertThrown!Exception(parseConfigString!Settings(str1, "/dev/null"));
 }

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -157,6 +157,13 @@ class Dub {
 
 		init();
 
+		if (skip == SkipPackageSuppliers.default_) {
+			// If unspecified on the command line, take
+			// the value from the configuration files, or
+			// default to none.
+			skip = m_config.skipRegistry.set ? m_config.skipRegistry.value : SkipPackageSuppliers.none;
+		}
+
 		const registry_var = environment.get("DUB_REGISTRY", null);
 		m_packageSuppliers = this.makePackageSuppliers(base, skip, registry_var);
 		m_packageManager = this.makePackageManager();


### PR DESCRIPTION
Currently, the skipRegistry value in configuration files is ignored, the final value is either the one the user passed on the command line, which is the intended behavior, or the value `none` if the user didn't pass a --skip-registry argument.

This commit fixes this by introducing the new value `default_` to the SkippackageSuppliers enum to know when the user didn't pass the skip-registry argument and the value should be taken from the configuration files.

Be aware that the output of an invalid `skipRegistry` value in `dub.settings.json` has changed:
Before this PR:
```
     Warning SkipPackageSuppliers does not have a member named 'blah'
```
After this PR:
```
     Warning /tmp/test/dub.settings.json(1:17): skipRegistry: SkipPackageSuppliers does not have a member named 'blah'
```