### PR TITLE
Speed up configuration resolution

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -887,15 +887,19 @@ class Project {
 		}
 
 		// check for conflicts (packages missing in the final configuration graph)
-		void checkPacksRec(in Package pack) {
-			auto pc = pack.name in ret;
-			enforce(pc !is null, "Could not resolve configuration for package "~pack.name);
-			foreach (p, dep; pack.getDependencies(*pc)) {
+		auto visited = new bool[](package_list.length);
+		void checkPacksRec(size_t pack_idx) {
+			if (visited[pack_idx]) return;
+			visited[pack_idx] = true;
+			auto pname = package_names[pack_idx];
+			auto pc = pname in ret;
+			enforce(pc !is null, "Could not resolve configuration for package "~pname);
+			foreach (p, dep; package_list[pack_idx].getDependencies(*pc)) {
 				auto deppack = getDependency(p, dep.optional);
-				if (deppack) checkPacksRec(deppack);
+				if (deppack) checkPacksRec(package_list.countUntil(deppack));
 			}
 		}
-		checkPacksRec(m_rootPackage);
+		checkPacksRec(0);
 
 		return ret;
 	}

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -43,6 +43,7 @@ class Project {
 		PackageManager m_packageManager;
 		Package m_rootPackage;
 		Package[] m_dependencies;
+		Package[string] m_dependenciesByName;
 		Package[][Package] m_dependees;
 		SelectedVersions m_selections;
 		string[] m_missingDependencies;
@@ -227,9 +228,8 @@ class Project {
 	*/
 	inout(Package) getDependency(string name, bool is_optional)
 	inout {
-		foreach(dp; m_dependencies)
-			if( dp.name == name )
-				return dp;
+		if (auto pp = name in m_dependenciesByName)
+			return *pp;
 		if (!is_optional) throw new Exception("Unknown dependency: "~name);
 		else return null;
 	}
@@ -519,8 +519,10 @@ class Project {
 	void reinit()
 	{
 		m_dependencies = null;
+		m_dependenciesByName = null;
 		m_missingDependencies = [];
 		collectDependenciesRec(m_rootPackage);
+		foreach (p; m_dependencies) m_dependenciesByName[p.name] = p;
 		m_missingDependencies.sort();
 	}
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -698,18 +698,25 @@ class Project {
 			auto had_dep_to_pack = new bool[configs.length];
 			auto still_has_dep_to_pack = new bool[configs.length];
 
-			edges = edges.filter!((e) {
-					if (e.to == i) {
-						had_dep_to_pack[e.from] = true;
-						return false;
-					} else if (configs[e.to].pack == configs[i].pack) {
-						still_has_dep_to_pack[e.from] = true;
-					}
-					if (e.from == i) return false;
-					return true;
-				}).array;
+			// eliminate all edges that connect to config 'i'
+			size_t eti = 0;
+			foreach (ei, e; edges) {
+				if (e.to == i) {
+					had_dep_to_pack[e.from] = true;
+					continue;
+				} else if (configs[e.to].pack == configs[i].pack) {
+					still_has_dep_to_pack[e.from] = true;
+				}
+				if (e.from == i) continue;
 
-			configs[i] = Vertex.init; // mark config as removed
+				// keep edge
+				if (eti != ei) edges[eti] = edges[ei];
+				eti++;
+			}
+			edges = edges[0 .. eti];
+
+			// mark config as removed
+			configs[i] = Vertex.init;
 
 			// also remove any configs that cannot be satisfied anymore
 			foreach (j; 0 .. configs.length)

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -697,14 +697,6 @@ class Project {
 			return (Vertex(pack_idx, config) in configs_set) !is null;
 		}
 
-		size_t createEdge(size_t from, size_t to) {
-			auto idx = edges.countUntil(Edge(from, to));
-			if (idx >= 0) return idx;
-			logDebug("Including %s %s -> %s %s", configs[from].pack, configs[from].config, configs[to].pack, configs[to].config);
-			edges ~= Edge(from, to);
-			return edges.length-1;
-		}
-
 		void removeConfig(size_t i) {
 			logDebug("Eliminating config %s for %s", configs[i].config, configs[i].pack);
 			auto had_dep_to_pack = new bool[configs.length];
@@ -762,6 +754,15 @@ class Project {
 		string[][] depconfigs = new string[][](package_list.length);
 		void determineDependencyConfigs(size_t pack_idx, string c)
 		{
+			void[0][Edge] edges_set;
+			void createEdge(size_t from, size_t to) {
+				if (Edge(from, to) in edges_set)
+					return;
+				logDebug("Including %s %s -> %s %s", configs[from].pack, configs[from].config, configs[to].pack, configs[to].config);
+				edges ~= Edge(from, to);
+				edges_set[Edge(from, to)] = (void[0]).init;
+			}
+
 			auto p = package_list[pack_idx];
 			auto pname = package_names[pack_idx];
 			auto pdeps = package_dependencies[pack_idx];

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -798,7 +798,10 @@ class Project {
 			auto idx = allconfigs_path.countUntil(pname);
 			enforce(idx < 0, format("Detected dependency cycle: %s", (allconfigs_path[idx .. $] ~ pname).join("->")));
 			allconfigs_path ~= pname;
-			scope (exit) allconfigs_path.length--;
+			scope (exit) {
+				allconfigs_path.length--;
+				allconfigs_path.assumeSafeAppend;
+			}
 
 			// first, add all dependency configurations
 			foreach (d; pdeps) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -733,14 +733,16 @@ class Project {
 			//return (pack == configs[0].pack && conf == configs[0].config) || edges.canFind!(e => configs[e.to].pack == pack && configs[e.to].config == config);
 		}
 
+		bool[string] reachable; // reused to avoid continuous re-allocation
 		bool isReachableByAllParentPacks(size_t cidx) {
-			bool[string] r;
-			foreach (p; parents[configs[cidx].pack]) r[p] = false;
+			foreach (p; parents[configs[cidx].pack]) reachable[p] = false;
 			foreach (e; edges) {
 				if (e.to != cidx) continue;
-				if (auto pp = configs[e.from].pack in r) *pp = true;
+				if (auto pp = configs[e.from].pack in reachable) *pp = true;
 			}
-			foreach (bool v; r) if (!v) return false;
+			foreach (p; parents[configs[cidx].pack])
+				if (!reachable[p])
+					return false;
 			return true;
 		}
 


### PR DESCRIPTION
This speeds up the `getPackageConfigs` call issued by `getDefaultConfiguration` from 14.8 ms to 3.6 ms for the particular project that I'm benchmarking. There is still a lot more to gain, but this is a good start.