### PR TITLE
Refactor getPackageConfigs

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -21,6 +21,7 @@ import std.conv : to;
 import std.exception : enforce;
 import std.file;
 import std.format;
+import std.range;
 import std.string : format;
 import std.process;
 import std.traits : isIntegral;
@@ -794,4 +795,42 @@ void deepCompareImpl (T) (
 			format("%s: result != expected: %s != %s", path, result, expected),
 			file, line);
 	}
+}
+
+/** Filters a forward range with the given predicate and returns a prefix range.
+
+	This function filters elements in-place, as opposed to returning a new
+	range. This can be particularly useful when working with arrays, as this
+	does not require any memory allocations.
+
+	This function guarantees that `pred` is called exactly once per element and
+	deterministically destroys any elements for which `pred` returns `false`.
+*/
+auto filterInPlace(alias pred, R)(R elems)
+	if (isForwardRange!R)
+{
+	import std.algorithm.mutation : move;
+
+	R telems = elems.save;
+	bool any_removed = false;
+	size_t nret = 0;
+	foreach (ref el; elems.save) {
+		if (pred(el)) {
+			if (any_removed) move(el, telems.front);
+			telems.popFront();
+			nret++;
+		} else any_removed = true;
+	}
+	return elems.takeExactly(nret);
+}
+
+///
+unittest {
+	int[] arr = [1, 2, 3, 4, 5, 6, 7, 8];
+
+	arr = arr.filterInPlace!(e => e % 2 == 0);
+	assert(arr == [2, 4, 6, 8]);
+
+	arr = arr.filterInPlace!(e => e < 5);
+	assert(arr == [2, 4]);
 }

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -697,21 +697,21 @@ class Project {
 			return (Vertex(pack_idx, config) in configs_set) !is null;
 		}
 
-		void removeConfig(size_t i) {
-			logDebug("Eliminating config %s for %s", configs[i].config, configs[i].pack);
+		void removeConfig(size_t config_index) {
+			logDebug("Eliminating config %s for %s", configs[config_index].config, configs[config_index].pack);
 			auto had_dep_to_pack = new bool[configs.length];
 			auto still_has_dep_to_pack = new bool[configs.length];
 
-			// eliminate all edges that connect to config 'i'
+			// eliminate all edges that connect to config 'config_index'
 			size_t eti = 0;
 			foreach (ei, e; edges) {
-				if (e.to == i) {
+				if (e.to == config_index) {
 					had_dep_to_pack[e.from] = true;
 					continue;
-				} else if (configs[e.to].pack == configs[i].pack) {
+				} else if (configs[e.to].pack == configs[config_index].pack) {
 					still_has_dep_to_pack[e.from] = true;
 				}
-				if (e.from == i) continue;
+				if (e.from == config_index) continue;
 
 				// keep edge
 				if (eti != ei) edges[eti] = edges[ei];
@@ -720,12 +720,12 @@ class Project {
 			edges = edges[0 .. eti];
 
 			// mark config as removed
-			configs_set.remove(configs[i]);
-			configs[i] = Vertex.init;
+			configs_set.remove(configs[config_index]);
+			configs[config_index] = Vertex.init;
 
 			// also remove any configs that cannot be satisfied anymore
 			foreach (j; 0 .. configs.length)
-				if (j != i && had_dep_to_pack[j] && !still_has_dep_to_pack[j])
+				if (j != config_index && had_dep_to_pack[j] && !still_has_dep_to_pack[j])
 					removeConfig(j);
 		}
 

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -725,15 +725,6 @@ class Project {
 					removeConfig(j);
 		}
 
-		bool isReachable(size_t pack, string conf) {
-			if (pack == configs[0].pack && configs[0].config == conf) return true;
-			foreach (e; edges)
-				if (configs[e.to].pack == pack && configs[e.to].config == conf)
-					return true;
-			return false;
-			//return (pack == configs[0].pack && conf == configs[0].config) || edges.canFind!(e => configs[e.to].pack == pack && configs[e.to].config == config);
-		}
-
 		bool[] reachable = new bool[package_list.length]; // reused to avoid continuous re-allocation
 		bool isReachableByAllParentPacks(size_t cidx) {
 			foreach (p; parents[configs[cidx].pack]) reachable[p] = false;

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -702,22 +702,18 @@ class Project {
 			auto had_dep_to_pack = new bool[configs.length];
 			auto still_has_dep_to_pack = new bool[configs.length];
 
-			// eliminate all edges that connect to config 'config_index'
-			size_t eti = 0;
-			foreach (ei, e; edges) {
+			// eliminate all edges that connect to config 'config_index' and
+			// track all connected configs
+			edges = edges.filterInPlace!((e) {
 				if (e.to == config_index) {
 					had_dep_to_pack[e.from] = true;
-					continue;
+					return false;
 				} else if (configs[e.to].pack == configs[config_index].pack) {
 					still_has_dep_to_pack[e.from] = true;
 				}
-				if (e.from == config_index) continue;
 
-				// keep edge
-				if (eti != ei) edges[eti] = edges[ei];
-				eti++;
-			}
-			edges = edges[0 .. eti];
+				return e.from != config_index;
+			});
 
 			// mark config as removed
 			configs_set.remove(configs[config_index]);


### PR DESCRIPTION
Cleans up `getPackageConfigs` to make it easier to follow. This is a follow-up of #2905. CC @atilaneves