### PR TITLE
ci: Bump setup-dlang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install latest DMD
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run tests
@@ -89,7 +89,7 @@ jobs:
 
     # Compiler to test with
     - name: Prepare compiler
-      uses: dlang-community/setup-dlang@v1
+      uses: dlang-community/setup-dlang@v2
       with:
         compiler: ${{ matrix.dc }}
 
@@ -113,10 +113,10 @@ jobs:
       env:
         DUB: ${{ github.workspace }}\bin\dub.exe
       run: |
-        dub build --compiler=${{ env.DC }}
+        dub build --compiler="${{ env.DC }}"
         if [[ ${{ matrix.do_test }} == 'true' ]]; then
-          dub test  --compiler=${{ env.DC }}
-          dub run   --compiler=${{ env.DC }} --single test/issue2051_running_unittests_from_dub_single_file_packages_fails.d
+          dub test  --compiler="${{ env.DC }}"
+          dub run   --compiler="${{ env.DC }}" --single test/issue2051_running_unittests_from_dub_single_file_packages_fails.d
           dub --single test/run-unittest.d
 
           # FIXME: DMD fails a few tests on Windows; remove them for now

--- a/.github/workflows/pr_info_untrusted.yml
+++ b/.github/workflows/pr_info_untrusted.yml
@@ -24,7 +24,7 @@ jobs:
 
     # Compiler to test with
     - name: Prepare compiler
-      uses: dlang-community/setup-dlang@v1
+      uses: dlang-community/setup-dlang@v2
       with:
         compiler: ldc-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       ## Boileterplate (compiler/repo)
       - name: Install compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ldc-latest
       - name: Checkout repository

--- a/test/issue2012-dc-env/app.d
+++ b/test/issue2012-dc-env/app.d
@@ -4,6 +4,8 @@
 +/
 
 import std.format;
+import std.path : baseName;
+import std.algorithm : canFind;
 
 void main(string[] args)
 {
@@ -14,5 +16,6 @@ void main(string[] args)
     version (GNU)
         immutable expected = "gdc";
 
-    assert(expected == args[1], format!"Expected '%s' but got '%s'"(expected, args[1]));
+    assert(args[1].baseName.canFind(expected),
+	   format!"Expected '%s' but got '%s'"(expected, args[1]));
 }


### PR DESCRIPTION
Update the setup-dlang action.

It's probably best to do this after the new release so that `release.yml` doesn't break as I've only tested it once.