### PR TITLE
Remove support for OMF, make MsCOFF be x86

### DIFF
--- a/test/win32_default.d
+++ b/test/win32_default.d
@@ -6,10 +6,6 @@
            "versions": [ "Default" ]
        },
        {
-           "name": "OMF",
-           "versions": [ "OMF" ]
-       },
-       {
            "name": "MsCoff",
            "versions": [ "MsCoff" ]
        },
@@ -25,12 +21,7 @@ module dynlib.app;
 pragma(msg, "Frontend: ", __VERSION__);
 
 // Object format should match the expectation
-version (OMF)
-{
-    enum expSize = 4;
-    enum expFormat = "omf";
-}
-else version (MsCoff)
+version (MsCoff)
 {
     // Should be a 32 bit build
     version (Is64)  enum expSize = 8;

--- a/test/win32_default.script.d
+++ b/test/win32_default.script.d
@@ -63,7 +63,7 @@ int main()
 		// Test with different --arch
 		const string[2][] tests = [
 			[ "x86",        "Default"	],
-			[ "x86_omf",    "OMF"		],
+			[ "x86_omf",    "MsCoff"	],
 			[ "x86_mscoff", "MsCoff"	],
 			[ "x86_64",		"MsCoff64"	],
 		];


### PR DESCRIPTION
Now that OMF support is being removed, dmd-latest is broken in the CI. Since DMD no longer supports it, and we are mostly concerned about supporting the latest 10 releases, we're keeping x86_omf and x86_mscoff available but making them aliases to x86.