### PR TITLE
Enhancement of integration test for windows

### DIFF
--- a/test/run-unittest.d
+++ b/test/run-unittest.d
@@ -10,12 +10,13 @@ import common;
 
 int main(string[] args)
 {
-	import std.algorithm : among, endsWith;
+	import std.algorithm : among, endsWith, startsWith, count;
 	import std.file : dirEntries, DirEntry, exists, getcwd, readText, SpanMode;
 	import std.format : format;
 	import std.stdio : File, writeln;
-	import std.path : absolutePath, buildNormalizedPath, baseName, dirName;
-	import std.process : environment, spawnProcess, wait;
+	import std.path : absolutePath, buildPath, baseName, dirName, stripExtension, globMatch;
+	import std.process : environment, spawnProcess, spawnShell, wait, ProcessConfig = Config;
+	import std.string: cmp, splitLines;
 
 	//** if [ -z ${DUB:-} ]; then
 	//**     die $LINENO 'Variable $DUB must be defined to run the tests.'
@@ -46,12 +47,15 @@ int main(string[] args)
 	//** DC_BIN=$(basename "$DC")
 	//** CURR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 	//** FRONTEND="${FRONTEND:-}"
-	const dc_bin = baseName(dc);
+	const dc_bin = baseName(dc).stripExtension;
 	const curr_dir = __FILE_FULL_PATH__.dirName();
-	const frontend = environment.get("FRONTEND", "");
+	const frontend = environment.get("FRONTEND", __VERSION__.format!"%04d");
 
 	//** if [ "$#" -gt 0 ]; then FILTER=$1; else FILTER=".*"; fi
 	auto filter = (args.length > 1) ? args[1] : "*";
+	version (linux)   auto os = "linux";
+	version (Windows) auto os = "windows";
+	version (OSX)     auto os = "osx";
 
 	version (Posix)
 	{
@@ -62,31 +66,131 @@ int main(string[] args)
 		//**     log "Running $script..."
 		//**     DUB=$DUB DC=$DC CURR_DIR="$CURR_DIR" $script || logError "Script failure."
 		//** done
-		foreach(DirEntry script; dirEntries(curr_dir, (args.length > 1) ? args[1] : "*.sh", SpanMode.shallow))
+		foreach(DirEntry script; dirEntries(curr_dir, "*.sh", SpanMode.shallow))
 		{
+			if (!script.name.baseName.globMatch(filter)) continue;
 			if (!script.name.endsWith(".sh"))
 				continue;
 			if (baseName(script.name).among("run-unittest.sh", "common.sh")) continue;
 			const min_frontend = script.name ~ ".min_frontend";
-			if (exists(min_frontend) && frontend.length && frontend < min_frontend.readText) continue;
+			if (exists(min_frontend) && frontend.length && cmp(frontend, min_frontend.readText) < 0) continue;
 			log("Running " ~ script ~ "...");
-			if (spawnProcess(script.name, ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir]).wait)
+			if (spawnShell(script.name, ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir]).wait)
 				logError("Script failure.");
+			else
+				log(script.name.baseName, " status: Ok");
 		}
 	}
 
-	foreach (DirEntry script; dirEntries(curr_dir, (args.length > 1) ? args[1] : "*.script.d", SpanMode.shallow))
+	foreach (DirEntry script; dirEntries(curr_dir, "*.script.d", SpanMode.shallow))
 	{
+		if (!script.name.baseName.globMatch(filter)) continue;
 		if (!script.name.endsWith(".d"))
 			continue;
 		const min_frontend = script.name ~ ".min_frontend";
-		if (frontend.length && exists(min_frontend) && frontend < min_frontend.readText) continue;
+		if (frontend.length && exists(min_frontend) && cmp(frontend, min_frontend.readText) < 0) continue;
 		log("Running " ~ script ~ "...");
 		if (spawnProcess([dub, script.name], ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir]).wait)
 			logError("Script failure.");
 		else
 			log(script.name, " status: Ok");
 	}
+
+	//for pack in $(ls -d $CURR_DIR/*/); do
+	foreach (DirEntry pack; dirEntries(curr_dir, SpanMode.shallow))
+	{
+		//if [[ ! "$pack" =~ $FILTER ]]; then continue; fi
+		if (!pack.name.baseName.globMatch(filter)) continue;
+		if (!pack.isDir || pack.name.baseName.startsWith(".")) continue;
+		if (!pack.name.buildPath("dub.json").exists && !pack.name.buildPath("dub.sdl").exists && !pack.name.buildPath("package.json").exists) continue;
+		//if [ -e $pack/.min_frontend ] && [ ! -z "$FRONTEND" -a "$FRONTEND" \< $(cat $pack/.min_frontend) ]; then continue; fi
+		if (pack.name.buildPath(".min_frontend").exists && cmp(frontend, pack.name.buildPath(".min_frontend").readText) < 0) continue;
+
+		//#First we build the packages
+		//if [ ! -e $pack/.no_build ] && [ ! -e $pack/.no_build_$DC_BIN ]; then # For sourceLibrary
+		bool build;
+		if (!pack.name.buildPath(".no_build").exists
+			&& !pack.name.buildPath(".no_build_" ~ dc_bin).exists
+			&& !pack.name.buildPath(".no_build_" ~ os).exists)
+		{
+			//build=1
+			build = true;
+			//if [ -e $pack/.fail_build ]; then
+			//    log "Building $pack, expected failure..."
+			//    $DUB build --force --root=$pack --compiler=$DC 2>/dev/null && logError "Error: Failure expected, but build passed."
+			//else
+			//    log "Building $pack..."
+			//    $DUB build --force --root=$pack --compiler=$DC || logError "Build failure."
+			//fi
+			//if [ -e $pack/.fail_build ]; then
+			if (pack.name.buildPath(".fail_build").exists)
+			{
+				log("Building " ~ pack.name.baseName ~ ", expected failure...");
+				if (spawnProcess([dub, "build", "--force", "--compiler", dc], ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir], ProcessConfig.none, pack.name).wait)
+					log(pack.name.baseName, " status: Ok");
+				else
+					logError("Failure expected, but build passed.");
+			}
+			else
+			{
+				log("Building ", pack.name.baseName, "...");
+				if (spawnProcess([dub, "build", "--force", "--compiler", dc], ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir], ProcessConfig.none, pack.name).wait)
+					logError("Script failure.");
+				else
+					log(pack.name.baseName, " status: Ok");
+			}
+		}
+		//else
+		//    build=0
+		//fi
+
+		//# We run the ones that are supposed to be run
+		//if [ $build -eq 1 ] && [ ! -e $pack/.no_run ] && [ ! -e $pack/.no_run_$DC_BIN ]; then
+		//    log "Running $pack..."
+		//    $DUB run --force --root=$pack --compiler=$DC || logError "Run failure."
+		//fi
+		if (build
+			&& !pack.name.buildPath(".no_run").exists
+			&& !pack.name.buildPath(".no_run_" ~ dc_bin).exists
+			&& !pack.name.buildPath(".no_run_" ~ os).exists)
+		{
+			log("Running ", pack.name.baseName, "...");
+			if (spawnProcess([dub, "run", "--force", "--compiler", dc], ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir], ProcessConfig.none, pack.name).wait)
+				logError("Run failure.");
+			else
+				log(pack.name.baseName, " status: Ok");
+		}
+
+		//# Finally, the unittest part
+		//if [ $build -eq 1 ] && [ ! -e $pack/.no_test ] && [ ! -e $pack/.no_test_$DC_BIN ]; then
+		//    log "Testing $pack..."
+		//    $DUB test --force --root=$pack --compiler=$DC || logError "Test failure."
+		//fi
+		if (build
+			&& !pack.name.buildPath(".no_test").exists
+			&& !pack.name.buildPath(".no_test_" ~ dc_bin).exists
+			&& !pack.name.buildPath(".no_test_" ~ os).exists)
+		{
+			log("Testing ", pack.name.baseName, "...");
+			if (spawnProcess([dub, "test", "--force", "--root", pack.name, "--compiler", dc], ["DUB":dub, "DC":dc, "CURR_DIR":curr_dir]).wait)
+				logError("Test failure.");
+			else
+				log(pack.name.baseName, " status: Ok");
+		}
+	//done
+	}
+
+	//echo
+	//echo 'Testing summary:'
+	//cat $(dirname "${BASH_SOURCE[0]}")/test.log
+	writeln();
+	writeln("Testing summary:");
+	auto logLines = readText("test.log").splitLines;
+	foreach (line; logLines)
+		writeln(line);
+	auto errCnt = logLines.count!(a => a.startsWith("[ERROR]"));
+	auto passCnt = logLines.count!(a => a.startsWith("[INFO]") && a.endsWith("status: Ok"));
+	writeln(passCnt , "/", errCnt + passCnt, " tests were successed.");
 
 	return any_errors;
 }

--- a/test/run-unittest.d
+++ b/test/run-unittest.d
@@ -10,13 +10,8 @@ import common;
 
 int main(string[] args)
 {
-	import std.algorithm : among, endsWith, startsWith, count;
-	import std.file : dirEntries, DirEntry, exists, getcwd, readText, SpanMode;
-	import std.format : format;
-	import std.stdio : File, writeln;
-	import std.path : absolutePath, buildPath, baseName, dirName, stripExtension, globMatch;
-	import std.process : environment, spawnProcess, spawnShell, wait, ProcessConfig = Config;
-	import std.string: cmp, splitLines;
+	import std.algorithm, std.file, std.format, std.stdio, std.path, std.process, std.string;
+	alias ProcessConfig = std.process.Config;
 
 	//** if [ -z ${DUB:-} ]; then
 	//**     die $LINENO 'Variable $DUB must be defined to run the tests.'
@@ -108,13 +103,12 @@ int main(string[] args)
 
 		//#First we build the packages
 		//if [ ! -e $pack/.no_build ] && [ ! -e $pack/.no_build_$DC_BIN ]; then # For sourceLibrary
-		bool build;
-		if (!pack.name.buildPath(".no_build").exists
+		bool build = (!pack.name.buildPath(".no_build").exists
 			&& !pack.name.buildPath(".no_build_" ~ dc_bin).exists
-			&& !pack.name.buildPath(".no_build_" ~ os).exists)
+			&& !pack.name.buildPath(".no_build_" ~ os).exists);
+		if (build)
 		{
 			//build=1
-			build = true;
 			//if [ -e $pack/.fail_build ]; then
 			//    log "Building $pack, expected failure..."
 			//    $DUB build --force --root=$pack --compiler=$DC 2>/dev/null && logError "Error: Failure expected, but build passed."


### PR DESCRIPTION
Modified `run-unittest.d` to run integration tests for Windows.
Also, since OMF was removed in the latest release (2.109.0), the OMF build test was removed.

With this PR, it is likely that `run-unittest.sh` will become unnecessary, but it has been left in place. This is to ensure that all tests can still be executed as before. As a result, some tests are currently being run twice. If there are no issues after some time, it would be preferable to remove it.