### PR TITLE
Clear an unprinted deprecation during dub build

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -878,10 +878,10 @@ class Command {
 				// should simply retry over all registries instead of using a special
 				// FallbackPackageSupplier.
 				auto urls = url.splitter(' ');
-				PackageSupplier ps = getRegistryPackageSupplier(urls.front);
+				PackageSupplier ps = _getRegistryPackageSupplier(urls.front);
 				urls.popFront;
 				if (!urls.empty)
-					ps = new FallbackPackageSupplier(ps ~ urls.map!getRegistryPackageSupplier.array);
+					ps = new FallbackPackageSupplier(ps ~ urls.map!_getRegistryPackageSupplier.array);
 				return ps;
 			})
 			.array;

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -77,7 +77,10 @@ PackageSupplier getRegistryPackageSupplier(string url)
 
 // Private to avoid a bug in `defaultPackageSuppliers` with `map` triggering a deprecation
 // even though the context is deprecated.
-private PackageSupplier _getRegistryPackageSupplier(string url)
+// Also used from `commandline`. Note that this is replaced by a method
+// in the `Dub` class, to allow for proper dependency injection,
+// but `commandline` is currently completely excluded.
+package(dub) PackageSupplier _getRegistryPackageSupplier(string url)
 {
 	switch (url.startsWith("dub+", "mvn+", "file://"))
 	{


### PR DESCRIPTION
This deprecation is currently not printed by DMD,
but shows up if '-de' is used while compiling.
This solution is a workaround, as a proper fix
would mean not using the function in the first place, but that requires a more in-depth rework.