### PR TITLE
PackageManager: Make lookup lazy again

### DIFF
--- a/source/dub/test/other.d
+++ b/source/dub/test/other.d
@@ -102,3 +102,21 @@ unittest
     dub.loadPackage();
     assert(dub.project.hasAllDependencies());
 }
+
+// Check that a simple build does not lead to the cache being scanned
+unittest
+{
+    scope dub = new TestDub((scope FSEntry fs) {
+        // This should never be read
+        fs.writePackageFile("b", "1.0.0", `poison`);
+        fs.writePackageFile("b", "1.1.0", `poison`);
+        // Dependency resolution may trigger scan, so we need a selections file
+        fs.writeFile(TestDub.ProjectPath ~ "dub.json",
+             `{ "name": "a", "dependencies": {"b":"~>1.0"}}`);
+        fs.writeFile(TestDub.ProjectPath ~ "dub.selections.json",
+             `{"fileVersion":1,"versions":{"b":"1.0.4"}}`);
+        fs.writePackageFile("b", "1.0.4", `{"name":"b","version":"1.0.4"}`);
+    });
+    dub.loadPackage();
+    assert(dub.project.hasAllDependencies());
+}


### PR DESCRIPTION
We want to avoid loading the whole cache whenever lookup is called, as most invocations of dub should result in a call to lookup, since dependency resolution is much rarer than building with an existing dub.selections.json.