### PR TITLE
FSEntry: Throw an Exception when trying to read non-existent file

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -736,6 +736,7 @@ public class FSEntry
     public ubyte[] readFile (NativePath path) const scope
     {
         auto entry = this.lookup(path);
+        enforce(entry !is null, "No such file: " ~ path.toNativeString());
         enforce(entry.attributes.type == Type.File, "Trying to read a directory");
         // This is a hack to make poisoning a file possible.
         // However, it is rather crude and doesn't allow to poison directory.


### PR DESCRIPTION
FSEntry.lookup can return null, and it would lead to a SEGV with the attribute check, so add the forgotten check first.