### PR TITLE
VersionRange: Always output minor version for ~> and ^

### DIFF
--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -729,7 +729,10 @@ unittest {
 unittest {
 	assert(VersionRange.fromString("~>1.0.4").toString() == "~>1.0.4");
 	assert(VersionRange.fromString("~>1.4").toString() == "~>1.4");
-	assert(VersionRange.fromString("~>2").toString() == "~>2");
+	// https://github.com/dlang/dub/issues/2830
+	assert(VersionRange.fromString("~>2").toString() == "~>2.0");
+	assert(VersionRange.fromString("~>5.0").toString() == "~>5.0");
+
 	assert(VersionRange.fromString("~>1.0.4+1.2.3").toString() == "~>1.0.4");
 	assert(VersionRange.fromString("^0.1.2").toString() == "^0.1.2");
 	assert(VersionRange.fromString("^1.2.3").toString() == "^1.2.3");
@@ -1132,7 +1135,10 @@ public struct VersionRange
 			auto parts = va.splitter('.').array;
 			assert(parts.length == 3, "Version string with a digit group count != 3: "~va);
 
-			foreach (i; 0 .. 3) {
+			// Start at 1 because the notation `~>1` and `^1` are equivalent
+			// to `~>1.0` and `^1.0`, and the latter are better understood
+			// and recognized by users. See for example issue 2830.
+			foreach (i; 1 .. 3) {
 				auto vp = parts[0 .. i+1].join(".");
 				auto ve = Version(expandVersion(vp));
 				auto veb = Version(bumpVersion(vp) ~ "-0");


### PR DESCRIPTION
```
Dub was correct in outputting only the major version, however this can lead to some confusion for users
as pointed out in 2830. Accepting ~>5 but only exposing two states (~>5.0 and ~>5.0.0) will hopefully make things a bit more obvious.
```

@s-ludwig : I was about to close #2830 as WONTFIX but thinking about it more reducing possible state is probably best. Thoughts ?