### PR TITLE
Tests: Implement the ability to mock the registry too

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -408,7 +408,7 @@ class Dub {
 	 * Returns:
 	 *	 A new instance of a `PackageSupplier`.
 	 */
-	protected PackageSupplier makePackageSupplier(string url) const
+	protected PackageSupplier makePackageSupplier(string url)
 	{
 		switch (url.startsWith("dub+", "mvn+", "file://"))
 		{

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -840,7 +840,7 @@ class PackageManager {
 
 	/// Backward-compatibility for deprecated overload, simplify once `storeFetchedPatch`
 	/// is removed
-	private Package store_(ubyte[] data, NativePath destination,
+	protected Package store_(ubyte[] data, NativePath destination,
 		in PackageName name, in Version vers)
 	{
 		import dub.recipe.json : toJson;

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -843,6 +843,7 @@ class PackageManager {
 	private Package store_(ubyte[] data, NativePath destination,
 		in PackageName name, in Version vers)
 	{
+		import dub.recipe.json : toJson;
 		import std.range : walkLength;
 
 		logDebug("Placing package '%s' version '%s' to location '%s'",
@@ -929,7 +930,9 @@ symlink_exit:
 		if (pack.recipePath.head != defaultPackageFilename)
 			// Storeinfo saved a default file, this could be different to the file from the zip.
 			this.removeFile(pack.recipePath);
-		pack.storeInfo();
+		auto app = appender!string();
+		app.writePrettyJsonString(pack.recipe.toJson());
+		this.writeFile(pack.recipePath.parentPath ~ defaultPackageFilename, app.data);
 		addPackages(this.m_internal.localPackages, pack);
 		return pack;
 	}

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -709,6 +709,8 @@ private VersionRange parseDMDDependency(string dep)
 	import std.array : join;
 
 	if (dep == "no") return VersionRange.Invalid;
+	// `dmdLikeVersionToSemverLike` does not handle this, VersionRange does
+	if (dep == "*")	 return VersionRange.Any;
 	return VersionRange.fromString(dep
 		.splitter(' ')
 		.map!(r => dmdLikeVersionToSemverLike(r))

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -359,6 +359,21 @@ package class TestPackageManager : PackageManager
         this.scm[GitReference(repo)] = dub_json;
     }
 
+	/// Overriden because we currently don't have a way to do dependency
+    /// injection on `dub.internal.utils : lockFile`.
+	public override Package store(ubyte[] data, PlacementLocation dest,
+		in PackageName name, in Version vers)
+	{
+        // Most of the code is copied from the base method
+		assert(!name.sub.length, "Cannot store a subpackage, use main package instead");
+		NativePath dstpath = this.getPackagePath(dest, name, vers.toString());
+		this.ensureDirectory(dstpath.parentPath());
+
+		if (this.existsFile(dstpath))
+			return this.getPackage(name, vers, dest);
+		return this.store_(data, dstpath, name, vers);
+	}
+
     ///
     protected override bool existsDirectory(NativePath path)
     {

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -559,15 +559,26 @@ public class FSEntry
     /// Creates a new FSEntry
     private this (FSEntry p, Type t, string n)
     {
+        // Avoid 'DOS File Times cannot hold dates prior to 1980.' exception
+        import std.datetime.date;
+        SysTime DefaultTime = SysTime(DateTime(2020, 01, 01));
+
         this.attributes.type = t;
         this.parent = p;
         this.name = n;
+        this.attributes.access = DefaultTime;
+        this.attributes.modification = DefaultTime;
     }
 
     /// Create the root of the filesystem, only usable from this module
     private this ()
     {
+        import std.datetime.date;
+        SysTime DefaultTime = SysTime(DateTime(2020, 01, 01));
+
         this.attributes.type = Type.Directory;
+        this.attributes.access = DefaultTime;
+        this.attributes.modification = DefaultTime;
     }
 
     /// Get a direct children node, returns `null` if it can't be found


### PR DESCRIPTION
Originally implemented the fix for #2901 using this before settling on the much simpler unittest.
Here's what the test would have looked like:
```D
// Erased version specification for dependency
// https://github.com/dlang/dub/issues/2901
unittest
{
    scope dub = new TestDub((scope FSEntry fs) {
        // We just need to fetch a package
        fs.writeFile(TestDub.ProjectPath ~ "dub.json",
             `{ "name": "a", "dependencies": {"b":"~>1.0"}}`);
    });
    dub.getRegistry.add(Version("1.0.4"), (scope FSEntry pkg) {
        pkg.writeFile(NativePath(`dub.sdl`), `name "b"
dependency "c" version=">0.0.0" optional=true`);
    });
    dub.getRegistry.add(Version("1.0.0"), (scope FSEntry pkg) {
        pkg.writeFile(NativePath(`dub.sdl`), `name "c"`);
    });

    dub.loadPackage();
    assert(!dub.project.hasAllDependencies());
    dub.upgrade(UpgradeOptions.select);
    assert(dub.project.hasAllDependencies());
}
```