### PR TITLE
Trivial: Remove internal deprecations

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -568,11 +568,6 @@ struct CommonOptions {
 	SkipPackageSuppliers skipRegistry = SkipPackageSuppliers.default_;
 	PlacementLocation placementLocation = PlacementLocation.user;
 
-	deprecated("Use `Color` instead, the previous naming was a limitation of error message formatting")
-	alias color = Color;
-	deprecated("Use `colorMode` instead")
-	alias color_mode = colorMode;
-
 	private void parseColor(string option, string value) @safe
 	{
 		// `automatic`, `on`, `off` are there for backwards compatibility

--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -146,21 +146,9 @@ void atomicWriteJsonFile(NativePath path, Json json)
 	moveFile(tmppath, path);
 }
 
-deprecated("specify a working directory explicitly")
-void runCommand(string command, string[string] env = null)
-{
-	runCommands((&command)[0 .. 1], env, null);
-}
-
 void runCommand(string command, string[string] env, string workDir)
 {
 	runCommands((&command)[0 .. 1], env, workDir);
-}
-
-deprecated("specify a working directory explicitly")
-void runCommands(in string[] commands, string[string] env = null)
-{
-	runCommands(commands, env, null);
 }
 
 void runCommands(in string[] commands, string[string] env, string workDir)


### PR DESCRIPTION
Neither commandline not dub.internal are part of the public API for the library, hence those deprecations were unnecessary.