### PR TITLE
[stable] Upgrade CI configuration following macOS-11 deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         # Latest stable version, update at will
-        os: [ macOS-11, ubuntu-20.04, windows-2019 ]
+        os: [ macOS-12, ubuntu-20.04, windows-2019 ]
         dc:
           # Always test latest as that is what we use to compile on release
           - dmd-latest
@@ -62,9 +62,9 @@ jobs:
           - ldc-master
           # Test some intermediate versions
           - ldc-1.26.0
-          - dmd-2.098.1
-          - dmd-2.101.1
-          - dmd-2.104.2
+          - dmd-2.099.1
+          - dmd-2.102.2
+          - dmd-2.105.3
         include:
           - { do_test: false }
           - { dc: dmd-latest, do_test: true }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macOS-11, ubuntu-20.04, windows-2019 ]
+        os: [ macOS-12, ubuntu-20.04, windows-2019 ]
         arch: [ x86_64 ]
         include:
           - { os: windows-2019, arch: i686 }
+          - { os: macOS-latest, arch: arm64 }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           GITVER: ${{ github.event.release.tag_name }}
           DMD: "ldmd2"
-          ARCH_TRIPLE: ${{ matrix.arch }}-${{ runner.os == 'linux' &&  'pc-linux' || 'apple-darwin' }}
+          ARCH_TRIPLE: ${{ matrix.arch }}-${{ runner.os == 'linux' && 'pc-linux' || 'apple-darwin' }}
         run: |
           ldc2 -run ./build.d -release -mtriple=${ARCH_TRIPLE}
           pushd bin

--- a/test/issue2377-dynLib-dep-extra-files/parent/dub.sdl
+++ b/test/issue2377-dynLib-dep-extra-files/parent/dub.sdl
@@ -25,4 +25,5 @@ configuration "exe_dynamic" {
     subConfiguration "dep1" "dynlib"
     dflags "-link-defaultlib-shared" platform="ldc"
     dflags "-defaultlib=libphobos2.so" platform="linux-dmd"
+    lflags "-rpath" "@executable_path" platform="osx"
 }


### PR DESCRIPTION
macOS-11 is going away at the end of June.