### PR TITLE
CI: Only attempt to upload coverage reports with COVERAGE: true

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,4 +133,5 @@ jobs:
       shell: bash
 
     - name: Codecov
+      if: matrix.do_test && runner.os != 'Windows'
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
Otherwise we get a flurry of warning in GitHub.