### PR TITLE
CI: Correct version for sticky-pull-request-comment action

### DIFF
--- a/.github/workflows/pr_info_intro.yml
+++ b/.github/workflows/pr_info_intro.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Prepare sticky comment'
-      uses: marocchino/sticky-pull-request-comment@2.9.0
+      uses: marocchino/sticky-pull-request-comment@v2.9.0
       with:
         message: |
           Thanks for your Pull Request and making D better!

--- a/.github/workflows/pr_info_post.yml
+++ b/.github/workflows/pr_info_post.yml
@@ -46,7 +46,7 @@ jobs:
         echo "PR_ID=$PR_ID" >> $GITHUB_ENV
 
     - name: Update GitHub comment
-      uses: marocchino/sticky-pull-request-comment@2.9.0
+      uses: marocchino/sticky-pull-request-comment@v2.9.0
       with:
         path: ./comment.txt
         number: ${{ env.PR_ID }}


### PR DESCRIPTION
This was not caught by CI because it doesn't take effect before merging.