### PR TITLE
CI: Adapt pr_info_post to github-script v7 breaking changes

### DIFF
--- a/.github/workflows/pr_info_post.yml
+++ b/.github/workflows/pr_info_post.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: ${{github.event.workflow_run.id }},
@@ -30,7 +30,7 @@ jobs:
           var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "pr"
           })[0];
-          var download = await github.actions.downloadArtifact({
+          var download = await github.rest.actions.downloadArtifact({
             owner: context.repo.owner,
             repo: context.repo.repo,
             artifact_id: matchArtifact.id,


### PR DESCRIPTION
Since v5, the method have been moved. This is not caught by CI as it only uses the workflow in the master branch.