### PR TITLE
Tests: Mock IO in the `Dub` class too

### DIFF
--- a/source/dub/internal/io/mockfs.d
+++ b/source/dub/internal/io/mockfs.d
@@ -75,6 +75,13 @@ public final class MockFS : Filesystem {
 
         const abs = path.absolute();
         auto segments = this.adaptPath(path);
+        // A path such as `C:\foo` gets turned into `[ "C:", "foo" ]`,
+        // so check if the root (drive) matches before we do comparison
+        version (Windows) if (abs && !segments.empty) {
+            enforce(this.root.name == segments.front.name,
+                "Cannot mkdir new drive '" ~ segments.front.name ~ `'`);
+            segments.popFront();
+        }
         reduce!((FSEntry dir, segment) => dir.mkdir(segment.name))(
             (abs ? this.root : this.cwd), segments);
     }
@@ -315,6 +322,13 @@ public final class MockFS : Filesystem {
 
         const abs = path.absolute();
         auto segments = this.adaptPath(path);
+        // A path such as `C:\foo` gets turned into `[ "C:", "foo" ]`.
+        // We need to do the root comparison before comparing the paths
+        version (Windows) if (abs && !segments.empty) {
+            if (this.root.name != segments.front.name)
+                return null;
+            segments.popFront();
+        }
         // Casting away constness because no good way to do this with `inout`,
         // but `FSEntry.lookup` is `inout` too.
         return cast(inout(FSEntry)) reduce!(
@@ -322,7 +336,16 @@ public final class MockFS : Filesystem {
             (cast() (abs ? this.root : this.cwd), segments);
     }
 
-    /// helper function for code common between `mkdir` and `lookup`
+    /**
+      * Adapt a path to work around various platform & library issues
+      *
+      * This helper function is for code common between `mkdir` and `lookup`,
+      * and need to be read in the context of those. The various adaptations
+      * done to the path to make it uniform are described within the function.
+      *
+      * Params:
+      *   path = The path to adapt
+      */
     private auto adaptPath (in NativePath path) const scope {
         if (!path.absolute()) return path.bySegment;
         auto segments = path.bySegment;
@@ -330,13 +353,6 @@ public final class MockFS : Filesystem {
         // while our built-in module (in vibecompat) does not.
         if (segments.front.name.length == 0)
             segments.popFront();
-        // A path such as `C:\foo` gets turned into `[ "", "C:", "foo" ]`,
-        // so after dropping the empty segment we need to drop the drive
-        version (Windows) if (!segments.empty) {
-            enforce(this.root.name == segments.front.name,
-                "Cannot mkdir new drive '" ~ segments.front.name ~ '"');
-            segments.popFront();
-        }
         return segments;
     }
 }
@@ -558,4 +574,12 @@ unittest {
         fs.chdir(NativePath("/foo/bar/../"));
         assert(fs.getcwd == P("/foo/"));
     }
+}
+
+version (Windows) unittest {
+    scope fs = new MockFS('X');
+    assert(fs.existsDirectory(NativePath(`X:\`)));
+    assert(!fs.existsDirectory(NativePath(`C:\`)));
+    assert(!fs.existsDirectory(NativePath(`C:\foo\bar`)));
+    assert(!fs.existsFile(NativePath(`C:/foo/bar.exe`)));
 }

--- a/source/dub/internal/io/realfs.d
+++ b/source/dub/internal/io/realfs.d
@@ -86,10 +86,12 @@ public final class RealFS : Filesystem {
     ///
     public override void removeDir (in NativePath path, bool force = false)
     {
+        const str = path.toNativeString();
+        if (!std.file.exists(str)) return;
         if (force)
-            std.file.rmdirRecurse(path.toNativeString());
+            std.file.rmdirRecurse(str);
         else
-            std.file.rmdir(path.toNativeString());
+            std.file.rmdir(str);
     }
 
 	/// Ditto

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -130,14 +130,15 @@ class PackageManager {
 	   Params:
 		 path = Path of the single repository
 	 */
-	this(NativePath path)
+	this(NativePath path, Filesystem fs = null)
 	{
 		import dub.internal.io.realfs;
-		this.fs = new RealFS();
+		this.fs = fs !is null ? fs : new RealFS();
 		this.m_internal.searchPath = [ path ];
 		this.refresh();
 	}
 
+	deprecated("Use the overload that accepts a `Filesystem`")
 	this(NativePath package_path, NativePath user_path, NativePath system_path, bool refresh_packages = true)
 	{
 		import dub.internal.io.realfs;

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -175,9 +175,6 @@ public void disableLogging()
  */
 public class TestDub : Dub
 {
-    /// The virtual filesystem that this instance acts on
-    public MockFS fs;
-
     /**
      * Redundant reference to the registry
      *
@@ -237,7 +234,7 @@ public class TestDub : Dub
         fs_.mkdir(ProjectPath);
         fs_.chdir(Root);
         if (dg !is null) dg(fs_);
-        this(fs_, root, extras, skip);
+        super(fs_, root, extras, skip);
     }
 
     /// Workaround https://issues.dlang.org/show_bug.cgi?id=24388 when called
@@ -252,11 +249,10 @@ public class TestDub : Dub
     }
 
     /// Internal constructor
-    private this(MockFS fs_, string root, PackageSupplier[] extras,
+    private this(Filesystem fs_, string root, PackageSupplier[] extras,
         SkipPackageSuppliers skip)
     {
-        this.fs = fs_;
-        super(root, extras, skip);
+        super(fs_, root, extras, skip);
     }
 
     /***************************************************************************
@@ -333,6 +329,14 @@ public class TestDub : Dub
         // This will not work with `SkipPackageSupplier`.
         assert(this.registry !is null, "The registry hasn't been instantiated?");
 		return this.registry;
+    }
+
+    /**
+     * Exposes our test filesystem to unittests
+     */
+    public @property inout(Filesystem) fs() inout
+    {
+        return super.fs;
     }
 }
 


### PR DESCRIPTION
This will allow to write more tests for the Dub class. In particular I am interested in being able to write unittests around the config file, which require `loadConfig` to be callable. We still need to call `thisExePath` at the moment but that can be solved later as it has no visible side effect.