### PR TITLE
[stable] Drop support for LDC v1.26.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           - dmd-master
           - ldc-master
           # Test some intermediate versions
-          - ldc-1.26.0
+          - ldc-1.29.0
           - dmd-2.099.1
           - dmd-2.102.2
           - dmd-2.105.3

--- a/source/app.d
+++ b/source/app.d
@@ -32,8 +32,7 @@ version (DigitalMars) version (D_Coverage)
  *
  * https://dlang.org/changelog/2.087.0.html#gc_parallel
  */
-static if (__VERSION__ >= 2087)
-    extern(C) __gshared string[] rt_options = [ "gcopt=parallel:0" ];
+extern(C) __gshared string[] rt_options = [ "gcopt=parallel:0" ];
 
 int main(string[] args)
 {


### PR DESCRIPTION
We only support the last 10 versions, so LDC should have been upgraded in the previous PR. In addition, we can remove a superfluous __VERSION__ statement, which haseen superfluous for quite a while now.