### PR TITLE
Refactor filesystem abstraction to and use it in production 

### DIFF
--- a/build-files.txt
+++ b/build-files.txt
@@ -47,6 +47,8 @@ source/dub/internal/dyaml/style.d
 source/dub/internal/dyaml/tagdirective.d
 source/dub/internal/dyaml/token.d
 source/dub/internal/git.d
+source/dub/internal/io/filesystem.d
+source/dub/internal/io/realfs.d
 source/dub/internal/libInputVisitor.d
 source/dub/internal/sdlang/ast.d
 source/dub/internal/sdlang/exception.d

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -376,15 +376,15 @@ class Dub {
 		import dub.test.base : TestDub;
 
 		scope (exit) environment.remove("DUB_REGISTRY");
-		auto dub = new TestDub(null, ".", null, SkipPackageSuppliers.configured);
+		auto dub = new TestDub(null, "/dub/project/", null, SkipPackageSuppliers.configured);
 		assert(dub.packageSuppliers.length == 0);
 		environment["DUB_REGISTRY"] = "http://example.com/";
-		dub = new TestDub(null, ".", null, SkipPackageSuppliers.configured);
+		dub = new TestDub(null, "/dub/project/", null, SkipPackageSuppliers.configured);
 		assert(dub.packageSuppliers.length == 1);
 		environment["DUB_REGISTRY"] = "http://example.com/;http://foo.com/";
-		dub = new TestDub(null, ".", null, SkipPackageSuppliers.configured);
+		dub = new TestDub(null, "/dub/project/", null, SkipPackageSuppliers.configured);
 		assert(dub.packageSuppliers.length == 2);
-		dub = new TestDub(null, ".", [new RegistryPackageSupplier(URL("http://bar.com/"))], SkipPackageSuppliers.configured);
+		dub = new TestDub(null, "/dub/project/", [new RegistryPackageSupplier(URL("http://bar.com/"))], SkipPackageSuppliers.configured);
 		assert(dub.packageSuppliers.length == 3);
 
 		dub = new TestDub();

--- a/source/dub/internal/io/filesystem.d
+++ b/source/dub/internal/io/filesystem.d
@@ -51,7 +51,12 @@ public interface Filesystem
     public abstract string readText (in NativePath path) const scope;
 
     /// Write to this file
-    public abstract void writeFile (in NativePath path, const(char)[] data) scope;
+    public final void writeFile (in NativePath path, const(char)[] data) scope
+    {
+        import std.string : representation;
+
+        this.writeFile(path, data.representation);
+    }
 
     /// Ditto
     public abstract void writeFile (in NativePath path, const(ubyte)[] data) scope;

--- a/source/dub/internal/io/filesystem.d
+++ b/source/dub/internal/io/filesystem.d
@@ -1,0 +1,91 @@
+/**
+ * An abstract filesystem representation
+ *
+ * This interface allows to represent the file system to various part of Dub.
+ * Instead of direct use of `std.file`, an implementation of this interface can
+ * be used, allowing to mock all I/O in unittest on a thread-local basis.
+ */
+module dub.internal.io.filesystem;
+
+public import std.datetime.systime;
+
+public import dub.internal.vibecompat.inet.path;
+
+/// Ditto
+public interface Filesystem
+{
+    static import dub.internal.vibecompat.core.file;
+
+    /// TODO: Remove, the API should be improved
+    public alias IterateDirDg = int delegate(
+        scope int delegate(ref dub.internal.vibecompat.core.file.FileInfo));
+
+    /// Ditto
+    public IterateDirDg iterateDirectory (in NativePath path) scope;
+
+    /// Returns: The `path` of this FSEntry
+    public abstract NativePath getcwd () const scope;
+
+    /**
+     * Implements `mkdir -p`: Create a directory and every intermediary
+     *
+     * There is no way to error out on intermediate directory,
+     * like standard mkdir does. If you want this behavior,
+     * simply check (`existsDirectory`) if the parent directory exists.
+     *
+     * Params:
+     *   path = The path of the directory to be created.
+     */
+    public abstract void mkdir (in NativePath path) scope;
+
+    /// Checks the existence of a file
+    public abstract bool existsFile (in NativePath path) const scope;
+
+    /// Checks the existence of a directory
+    public abstract bool existsDirectory (in NativePath path) const scope;
+
+    /// Reads a file, returns the content as `ubyte[]`
+    public abstract ubyte[] readFile (in NativePath path) const scope;
+
+    /// Reads a file, returns the content as text
+    public abstract string readText (in NativePath path) const scope;
+
+    /// Write to this file
+    public abstract void writeFile (in NativePath path, const(char)[] data) scope;
+
+    /// Ditto
+    public abstract void writeFile (in NativePath path, const(ubyte)[] data) scope;
+
+    /** Remove a file
+     *
+     * Always error if the target is a directory.
+     * Does not error if the target does not exists
+     * and `force` is set to `true`.
+     *
+     * Params:
+     *   path = Path to the file to remove
+     *   force = Whether to ignore non-existing file,
+     *           default to `false`.
+     */
+    public void removeFile (in NativePath path, bool force = false);
+
+    /** Remove a directory
+     *
+     * Remove an existing empty directory.
+     * If `force` is set to `true`, no error will be thrown
+     * if the directory is empty or non-existing.
+     *
+     * Params:
+     *   path = Path to the directory to remove
+     *   force = Whether to ignore non-existing / non-empty directories,
+     *           default to `false`.
+     */
+    public void removeDir (in NativePath path, bool force = false);
+
+    /// Implement `std.file.setTimes`
+    public void setTimes (in NativePath path, in SysTime accessTime,
+        in SysTime modificationTime);
+
+    /// Implement `std.file.setAttributes`
+    public void setAttributes (in NativePath path, uint attributes);
+}

--- a/source/dub/internal/io/mockfs.d
+++ b/source/dub/internal/io/mockfs.d
@@ -1,0 +1,505 @@
+/*******************************************************************************
+
+    An unittest implementation of `Filesystem`
+
+*******************************************************************************/
+
+module dub.internal.io.mockfs;
+
+public import dub.internal.io.filesystem;
+
+static import dub.internal.vibecompat.core.file;
+
+import std.algorithm;
+import std.exception;
+import std.range;
+import std.string;
+
+/// Ditto
+public final class MockFS : Filesystem {
+    ///
+    private FSEntry cwd;
+
+    ///
+    public this () scope
+    {
+        this.cwd = new FSEntry();
+    }
+
+    public override NativePath getcwd () const scope
+    {
+        return this.cwd.path();
+    }
+
+    ///
+    public override bool existsDirectory (in NativePath path) const scope
+    {
+        return this.cwd.existsDirectory(path);
+    }
+
+    /// Ditto
+    public override void mkdir (in NativePath path) scope
+    {
+        this.cwd.mkdir(path);
+    }
+
+    /// Ditto
+    public override bool existsFile (in NativePath path) const scope
+    {
+        return this.cwd.existsFile(path);
+    }
+
+    /// Ditto
+    public override void writeFile (in NativePath path, const(ubyte)[] data)
+        scope
+    {
+        return this.cwd.writeFile(path, data);
+    }
+
+    /// Ditto
+    public override void writeFile (in NativePath path, const(char)[] data)
+        scope
+    {
+        return this.cwd.writeFile(path, data);
+    }
+
+    /// Reads a file, returns the content as `ubyte[]`
+    public override ubyte[] readFile (in NativePath path) const scope
+    {
+        return this.cwd.readFile(path);
+    }
+
+    /// Ditto
+    public override string readText (in NativePath path) const scope
+    {
+        return this.cwd.readText(path);
+    }
+
+    /// Ditto
+    public override IterateDirDg iterateDirectory (in NativePath path) scope
+    {
+        enforce(this.cwd.existsDirectory(path),
+            path.toNativeString() ~ " does not exists or is not a directory");
+        auto dir = this.cwd.lookup(path);
+        int iterator(scope int delegate(ref dub.internal.vibecompat.core.file.FileInfo) del) {
+            foreach (c; dir.children) {
+                dub.internal.vibecompat.core.file.FileInfo fi;
+                fi.name = c.name;
+                fi.timeModified = c.attributes.modification;
+                final switch (c.attributes.type) {
+                case FSEntry.Type.File:
+                    fi.size = c.content.length;
+                    break;
+                case FSEntry.Type.Directory:
+                    fi.isDirectory = true;
+                    break;
+                }
+                if (auto res = del(fi))
+                    return res;
+            }
+            return 0;
+        }
+        return &iterator;
+    }
+
+    /// Ditto
+    public override void removeFile (in NativePath path, bool force = false) scope
+    {
+        return this.cwd.removeFile(path);
+    }
+
+    ///
+    public override void removeDir (in NativePath path, bool force = false)
+    {
+        this.cwd.removeDir(path, force);
+    }
+
+    /// Ditto
+    public override void setTimes (in NativePath path, in SysTime accessTime,
+        in SysTime modificationTime)
+    {
+        this.cwd.setTimes(path, accessTime, modificationTime);
+    }
+
+    /// Ditto
+    public override void setAttributes (in NativePath path, uint attributes)
+    {
+        this.cwd.setAttributes(path, attributes);
+    }
+
+    /**
+     * Converts an `Filesystem` and its children to a `ZipFile`
+     */
+    public ubyte[] serializeToZip (string rootPath) {
+        import std.path;
+        import std.zip;
+
+        scope z = new ZipArchive();
+        void addToZip(scope string dir, scope FSEntry e) {
+            auto m = new ArchiveMember();
+            m.name = dir.buildPath(e.name);
+            m.fileAttributes = e.attributes.attrs;
+            m.time = e.attributes.modification;
+
+            final switch (e.attributes.type) {
+            case FSEntry.Type.Directory:
+                // We need to ensure the directory entry ends with a slash
+                // otherwise it will be considered as a file.
+                if (m.name[$-1] != '/')
+                    m.name ~= '/';
+                z.addMember(m);
+                foreach (c; e.children)
+                    addToZip(m.name, c);
+                break;
+            case FSEntry.Type.File:
+                m.expandedData = e.content;
+                z.addMember(m);
+            }
+        }
+        addToZip(rootPath, this.cwd);
+        return cast(ubyte[]) z.build();
+    }
+}
+
+/// The backing logic behind `MockFS`
+public class FSEntry
+{
+    /// Type of file system entry
+    public enum Type : ubyte {
+        Directory,
+        File,
+    }
+
+    /// List FSEntry attributes
+    protected struct Attributes {
+        /// The type of FSEntry, see `FSEntry.Type`
+        public Type type;
+        /// System-specific attributes for this `FSEntry`
+        public uint attrs;
+        /// Last access time
+        public SysTime access;
+        /// Last modification time
+        public SysTime modification;
+    }
+    /// Ditto
+    protected Attributes attributes;
+
+    /// The name of this node
+    protected string name;
+    /// The parent of this entry (can be null for the root)
+    protected FSEntry parent;
+    union {
+        /// Children for this FSEntry (with type == Directory)
+        protected FSEntry[] children;
+        /// Content for this FDEntry (with type == File)
+        protected ubyte[] content;
+    }
+
+    /// Creates a new FSEntry
+    package(dub) this (FSEntry p, Type t, string n)
+    {
+        // Avoid 'DOS File Times cannot hold dates prior to 1980.' exception
+        import std.datetime.date;
+        SysTime DefaultTime = SysTime(DateTime(2020, 01, 01));
+
+        this.attributes.type = t;
+        this.parent = p;
+        this.name = n;
+        this.attributes.access = DefaultTime;
+        this.attributes.modification = DefaultTime;
+    }
+
+    /// Create the root of the filesystem, only usable from this module
+    package(dub) this ()
+    {
+        import std.datetime.date;
+        SysTime DefaultTime = SysTime(DateTime(2020, 01, 01));
+
+        this.attributes.type = Type.Directory;
+        this.attributes.access = DefaultTime;
+        this.attributes.modification = DefaultTime;
+    }
+
+    /// Get a direct children node, returns `null` if it can't be found
+    protected inout(FSEntry) lookup(string name) inout return scope
+    {
+        assert(!name.canFind('/'));
+        foreach (c; this.children)
+            if (c.name == name)
+                return c;
+        return null;
+    }
+
+    /// Get an arbitrarily nested children node
+    protected inout(FSEntry) lookup(NativePath path) inout return scope
+    {
+        auto relp = this.relativePath(path);
+        relp.normalize(); // try to get rid of `..`
+        if (relp.empty)
+            return this;
+        auto segments = relp.bySegment;
+        if (auto c = this.lookup(segments.front.name)) {
+            segments.popFront();
+            return !segments.empty ? c.lookup(NativePath(segments)) : c;
+        }
+        return null;
+    }
+
+    /** Get the parent `FSEntry` of a `NativePath`
+     *
+     * If the parent doesn't exist, an `Exception` will be thrown
+     * unless `silent` is provided. If the parent path is a file,
+     * an `Exception` will be thrown regardless of `silent`.
+     *
+     * Params:
+     *   path = The path to look up the parent for
+     *   silent = Whether to error on non-existing parent,
+     *            default to `false`.
+     */
+    protected inout(FSEntry) getParent(NativePath path, bool silent = false)
+        inout return scope
+    {
+        // Relative path in the current directory
+        if (!path.hasParentPath())
+            return this;
+
+        // If we're not in the right `FSEntry`, recurse
+        const parentPath = path.parentPath();
+        auto p = this.lookup(parentPath);
+        enforce(silent || p !is null,
+            "No such directory: " ~ parentPath.toNativeString());
+        enforce(p is null || p.attributes.type == Type.Directory,
+            "Parent path is not a directory: " ~ parentPath.toNativeString());
+        return p;
+    }
+
+    /// Returns: A path relative to `this.path`
+    protected NativePath relativePath(NativePath path) const scope
+    {
+        assert(!path.absolute() || path.startsWith(this.path),
+               "Calling relativePath with a differently rooted path");
+        return path.absolute() ? path.relativeTo(this.path) : path;
+    }
+
+    /*+*************************************************************************
+
+        Utility function
+
+        Below this banners are functions that are provided for the convenience
+        of writing tests for `Dub`.
+
+    ***************************************************************************/
+
+    /// Prints a visual representation of the filesystem to stdout for debugging
+    public void print(bool content = false) const scope
+    {
+        import std.range : repeat;
+        static import std.stdio;
+
+        size_t indent;
+        for (auto p = &this.parent; (*p) !is null; p = &p.parent)
+            indent++;
+        // Don't print anything (even a newline) for root
+        if (this.parent is null)
+            std.stdio.write('/');
+        else
+            std.stdio.write('|', '-'.repeat(indent), ' ', this.name, ' ');
+
+        final switch (this.attributes.type) {
+        case Type.Directory:
+            std.stdio.writeln('(', this.children.length, " entries):");
+            foreach (c; this.children)
+                c.print(content);
+            break;
+        case Type.File:
+            if (!content)
+                std.stdio.writeln('(', this.content.length, " bytes)");
+            else if (this.name.endsWith(".json") || this.name.endsWith(".sdl"))
+                std.stdio.writeln('(', this.content.length, " bytes): ",
+                    cast(string) this.content);
+            else
+                std.stdio.writeln('(', this.content.length, " bytes): ",
+                    this.content);
+            break;
+        }
+    }
+
+    /*+*************************************************************************
+
+        Public filesystem functions
+
+        Below this banners are functions which mimic the behavior of a file
+        system.
+
+    ***************************************************************************/
+
+    /// Returns: The `path` of this FSEntry
+    public NativePath path () const scope
+    {
+        if (this.parent is null)
+            return NativePath("/");
+        auto thisPath = this.parent.path ~ this.name;
+        thisPath.endsWithSlash = (this.attributes.type == Type.Directory);
+        return thisPath;
+    }
+
+    /// Implements `mkdir -p`, returns the created directory
+    public FSEntry mkdir (in NativePath path) scope
+    {
+        auto relp = this.relativePath(path);
+        // Check if the child already exists
+        auto segments = relp.bySegment;
+        auto child = this.lookup(segments.front.name);
+        if (child is null) {
+            child = new FSEntry(this, Type.Directory, segments.front.name);
+            this.children ~= child;
+        }
+        // Recurse if needed
+        segments.popFront();
+        return !segments.empty ? child.mkdir(NativePath(segments)) : child;
+    }
+
+    /// Checks the existence of a file
+    public bool existsFile (in NativePath path) const scope
+    {
+        auto entry = this.lookup(path);
+        return entry !is null && entry.attributes.type == Type.File;
+    }
+
+    /// Checks the existence of a directory
+    public bool existsDirectory (in NativePath path) const scope
+    {
+        auto entry = this.lookup(path);
+        return entry !is null && entry.attributes.type == Type.Directory;
+    }
+
+    /// Reads a file, returns the content as `ubyte[]`
+    public ubyte[] readFile (in NativePath path) const scope
+    {
+        auto entry = this.lookup(path);
+        enforce(entry !is null, "No such file: " ~ path.toNativeString());
+        enforce(entry.attributes.type == Type.File, "Trying to read a directory");
+        // This is a hack to make poisoning a file possible.
+        // However, it is rather crude and doesn't allow to poison directory.
+        // Consider introducing a derived type to allow it.
+        assert(entry.content != "poison".representation,
+            "Trying to access poisoned path: " ~ path.toNativeString());
+        return entry.content.dup;
+    }
+
+    /// Reads a file, returns the content as text
+    public string readText (in NativePath path) const scope
+    {
+        import std.utf : validate;
+
+        const content = this.readFile(path);
+        // Ignore BOM: If it's needed for a test, add support for it.
+        validate(cast(const(char[])) content);
+        // `readFile` just `dup` the content, so it's safe to cast.
+        return cast(string) content;
+    }
+
+    /// Write to this file
+    public void writeFile (in NativePath path, const(char)[] data) scope
+    {
+        this.writeFile(path, data.representation);
+    }
+
+    /// Ditto
+    public void writeFile (in NativePath path, const(ubyte)[] data) scope
+    {
+        enforce(!path.endsWithSlash(),
+            "Cannot write to directory: " ~ path.toNativeString());
+        if (auto file = this.lookup(path)) {
+            // If the file already exists, override it
+            enforce(file.attributes.type == Type.File,
+                "Trying to write to directory: " ~ path.toNativeString());
+            file.content = data.dup;
+        } else {
+            auto p = this.getParent(path);
+            auto file = new FSEntry(p, Type.File, path.head.name());
+            file.content = data.dup;
+            p.children ~= file;
+        }
+    }
+
+    /** Remove a file
+     *
+     * Always error if the target is a directory.
+     * Does not error if the target does not exists
+     * and `force` is set to `true`.
+     *
+     * Params:
+     *   path = Path to the file to remove
+     *   force = Whether to ignore non-existing file,
+     *           default to `false`.
+     */
+    public void removeFile (in NativePath path, bool force = false)
+    {
+        import std.algorithm.searching : countUntil;
+
+        assert(!path.empty, "Empty path provided to `removeFile`");
+        enforce(!path.endsWithSlash(),
+            "Cannot remove file with directory path: " ~ path.toNativeString());
+        auto p = this.getParent(path, force);
+        const idx = p.children.countUntil!(e => e.name == path.head.name());
+        if (idx < 0) {
+            enforce(force,
+                "removeFile: No such file: " ~ path.toNativeString());
+        } else {
+            enforce(p.children[idx].attributes.type == Type.File,
+                "removeFile called on a directory: " ~ path.toNativeString());
+            p.children = p.children[0 .. idx] ~ p.children[idx + 1 .. $];
+        }
+    }
+
+    /** Remove a directory
+     *
+     * Remove an existing empty directory.
+     * If `force` is set to `true`, no error will be thrown
+     * if the directory is empty or non-existing.
+     *
+     * Params:
+     *   path = Path to the directory to remove
+     *   force = Whether to ignore non-existing / non-empty directories,
+     *           default to `false`.
+     */
+    public void removeDir (in NativePath path, bool force = false)
+    {
+        import std.algorithm.searching : countUntil;
+
+        assert(!path.empty, "Empty path provided to `removeFile`");
+        auto p = this.getParent(path, force);
+        const idx = p.children.countUntil!(e => e.name == path.head.name());
+        if (idx < 0) {
+            enforce(force,
+                "removeDir: No such directory: " ~ path.toNativeString());
+        } else {
+            enforce(p.children[idx].attributes.type == Type.Directory,
+                "removeDir called on a file: " ~ path.toNativeString());
+            enforce(force || p.children[idx].children.length == 0,
+                "removeDir called on non-empty directory: " ~ path.toNativeString());
+            p.children = p.children[0 .. idx] ~ p.children[idx + 1 .. $];
+        }
+    }
+
+    /// Implement `std.file.setTimes`
+    public void setTimes (in NativePath path, in SysTime accessTime,
+        in SysTime modificationTime)
+    {
+        auto e = this.lookup(path);
+        enforce(e !is null,
+            "setTimes: No such file or directory: " ~ path.toNativeString());
+        e.attributes.access = accessTime;
+        e.attributes.modification = modificationTime;
+    }
+
+    /// Implement `std.file.setAttributes`
+    public void setAttributes (in NativePath path, uint attributes)
+    {
+        auto e = this.lookup(path);
+        enforce(e !is null,
+            "setTimes: No such file or directory: " ~ path.toNativeString());
+        e.attributes.attrs = attributes;
+    }
+}

--- a/source/dub/internal/io/mockfs.d
+++ b/source/dub/internal/io/mockfs.d
@@ -34,7 +34,8 @@ public final class MockFS : Filesystem {
     ///
     public override bool existsDirectory (in NativePath path) const scope
     {
-        return this.cwd.existsDirectory(path);
+        auto entry = this.cwd.lookup(path);
+        return entry !is null && entry.isDirectory();
     }
 
     /// Ditto
@@ -46,7 +47,8 @@ public final class MockFS : Filesystem {
     /// Ditto
     public override bool existsFile (in NativePath path) const scope
     {
-        return this.cwd.existsFile(path);
+        auto entry = this.cwd.lookup(path);
+        return entry !is null && entry.isFile();
     }
 
     /// Ditto
@@ -78,7 +80,7 @@ public final class MockFS : Filesystem {
     /// Ditto
     public override IterateDirDg iterateDirectory (in NativePath path) scope
     {
-        enforce(this.cwd.existsDirectory(path),
+        enforce(this.existsDirectory(path),
             path.toNativeString() ~ " does not exists or is not a directory");
         auto dir = this.cwd.lookup(path);
         int iterator(scope int delegate(ref dub.internal.vibecompat.core.file.FileInfo) del) {
@@ -365,18 +367,16 @@ public class FSEntry
         return !segments.empty ? child.mkdir(NativePath(segments)) : child;
     }
 
-    /// Checks the existence of a file
-    public bool existsFile (in NativePath path) const scope
+    ///
+    public bool isFile () const scope
     {
-        auto entry = this.lookup(path);
-        return entry !is null && entry.attributes.type == Type.File;
+        return this.attributes.type == Type.File;
     }
 
-    /// Checks the existence of a directory
-    public bool existsDirectory (in NativePath path) const scope
+    ///
+    public bool isDirectory () const scope
     {
-        auto entry = this.lookup(path);
-        return entry !is null && entry.attributes.type == Type.Directory;
+        return this.attributes.type == Type.Directory;
     }
 
     /// Reads a file, returns the content as `ubyte[]`

--- a/source/dub/internal/io/mockfs.d
+++ b/source/dub/internal/io/mockfs.d
@@ -118,13 +118,19 @@ public final class MockFS : Filesystem {
     public override void setTimes (in NativePath path, in SysTime accessTime,
         in SysTime modificationTime)
     {
-        this.cwd.setTimes(path, accessTime, modificationTime);
+        auto e = this.cwd.lookup(path);
+        enforce(e !is null,
+            "setTimes: No such file or directory: " ~ path.toNativeString());
+        e.setTimes(accessTime, modificationTime);
     }
 
     /// Ditto
     public override void setAttributes (in NativePath path, uint attributes)
     {
-        this.cwd.setAttributes(path, attributes);
+        auto e = this.cwd.lookup(path);
+        enforce(e !is null,
+            "setAttributes: No such file or directory: " ~ path.toNativeString());
+        e.setAttributes(attributes);
     }
 
     /**
@@ -484,22 +490,15 @@ public class FSEntry
     }
 
     /// Implement `std.file.setTimes`
-    public void setTimes (in NativePath path, in SysTime accessTime,
-        in SysTime modificationTime)
+    public void setTimes (in SysTime accessTime, in SysTime modificationTime)
     {
-        auto e = this.lookup(path);
-        enforce(e !is null,
-            "setTimes: No such file or directory: " ~ path.toNativeString());
-        e.attributes.access = accessTime;
-        e.attributes.modification = modificationTime;
+        this.attributes.access = accessTime;
+        this.attributes.modification = modificationTime;
     }
 
     /// Implement `std.file.setAttributes`
-    public void setAttributes (in NativePath path, uint attributes)
+    public void setAttributes (uint attributes)
     {
-        auto e = this.lookup(path);
-        enforce(e !is null,
-            "setTimes: No such file or directory: " ~ path.toNativeString());
-        e.attributes.attrs = attributes;
+        this.attributes.attrs = attributes;
     }
 }

--- a/source/dub/internal/io/mockfs.d
+++ b/source/dub/internal/io/mockfs.d
@@ -58,13 +58,6 @@ public final class MockFS : Filesystem {
         return this.cwd.writeFile(path, data);
     }
 
-    /// Ditto
-    public override void writeFile (in NativePath path, const(char)[] data)
-        scope
-    {
-        return this.cwd.writeFile(path, data);
-    }
-
     /// Reads a file, returns the content as `ubyte[]`
     public override ubyte[] readFile (in NativePath path) const scope
     {
@@ -403,12 +396,6 @@ public class FSEntry
         validate(cast(const(char[])) content);
         // `readFile` just `dup` the content, so it's safe to cast.
         return cast(string) content;
-    }
-
-    /// Write to this file
-    public void writeFile (in NativePath path, const(char)[] data) scope
-    {
-        this.writeFile(path, data.representation);
     }
 
     /// Ditto

--- a/source/dub/internal/io/realfs.d
+++ b/source/dub/internal/io/realfs.d
@@ -1,0 +1,109 @@
+/*******************************************************************************
+
+    An implementation of `Filesystem` using vibe.d functions
+
+*******************************************************************************/
+
+module dub.internal.io.realfs;
+
+public import dub.internal.io.filesystem;
+
+/// Ditto
+public final class RealFS : Filesystem {
+    static import dub.internal.vibecompat.core.file;
+    static import std.file;
+
+    ///
+    private NativePath path_;
+
+    ///
+    public this (NativePath cwd = NativePath(std.file.getcwd()))
+        scope @safe pure nothrow @nogc
+    {
+        this.path_ = cwd;
+    }
+
+    public override NativePath getcwd () const scope
+    {
+        return this.path_;
+    }
+
+    ///
+    protected override bool existsDirectory (in NativePath path) const scope
+	{
+		return dub.internal.vibecompat.core.file.existsDirectory(path);
+	}
+
+	/// Ditto
+	protected override void mkdir (in NativePath path) scope
+	{
+		dub.internal.vibecompat.core.file.ensureDirectory(path);
+	}
+
+	/// Ditto
+	protected override bool existsFile (in NativePath path) const scope
+	{
+		return dub.internal.vibecompat.core.file.existsFile(path);
+	}
+
+	/// Ditto
+	protected override void writeFile (in NativePath path, const(ubyte)[] data)
+        scope
+	{
+		return dub.internal.vibecompat.core.file.writeFile(path, data);
+	}
+
+	/// Ditto
+	protected override void writeFile (in NativePath path, const(char)[] data)
+        scope
+	{
+		return dub.internal.vibecompat.core.file.writeFile(path, data);
+	}
+
+    /// Reads a file, returns the content as `ubyte[]`
+    public override ubyte[] readFile (in NativePath path) const scope
+    {
+        return cast(ubyte[]) std.file.read(path.toNativeString());
+    }
+
+	/// Ditto
+	protected override string readText (in NativePath path) const scope
+	{
+		return dub.internal.vibecompat.core.file.readText(path);
+	}
+
+	/// Ditto
+	protected override IterateDirDg iterateDirectory (in NativePath path) scope
+	{
+		return dub.internal.vibecompat.core.file.iterateDirectory(path);
+	}
+
+	/// Ditto
+	protected override void removeFile (in NativePath path, bool force = false) scope
+	{
+		return std.file.remove(path.toNativeString());
+	}
+
+    ///
+    public override void removeDir (in NativePath path, bool force = false)
+    {
+        if (force)
+            std.file.rmdirRecurse(path.toNativeString());
+        else
+            std.file.rmdir(path.toNativeString());
+    }
+
+	/// Ditto
+	protected override void setTimes (in NativePath path, in SysTime accessTime,
+		in SysTime modificationTime)
+	{
+		std.file.setTimes(
+			path.toNativeString(), accessTime, modificationTime);
+	}
+
+	/// Ditto
+	protected override void setAttributes (in NativePath path, uint attributes)
+	{
+		std.file.setAttributes(path.toNativeString(), attributes);
+	}
+}

--- a/source/dub/internal/io/realfs.d
+++ b/source/dub/internal/io/realfs.d
@@ -53,13 +53,6 @@ public final class RealFS : Filesystem {
 		return dub.internal.vibecompat.core.file.writeFile(path, data);
 	}
 
-	/// Ditto
-	protected override void writeFile (in NativePath path, const(char)[] data)
-        scope
-	{
-		return dub.internal.vibecompat.core.file.writeFile(path, data);
-	}
-
     /// Reads a file, returns the content as `ubyte[]`
     public override ubyte[] readFile (in NativePath path) const scope
     {

--- a/source/dub/test/dependencies.d
+++ b/source/dub/test/dependencies.d
@@ -31,7 +31,7 @@ import dub.test.base;
 // Ensure that simple dependencies get resolved correctly
 unittest
 {
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
             root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "a"
 version "1.0.0"
 dependency "b" version="*"
@@ -55,7 +55,7 @@ version "1.0.0"`, PackageFormat.sdl);
 // Test that indirect dependencies get resolved correctly
 unittest
 {
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
             root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "a"
 dependency "b" version="*"`);
             root.writePackageFile("b", "1.0.0", `name "b"
@@ -77,7 +77,7 @@ version "1.0.0"`, PackageFormat.sdl);
 // Simple diamond dependency
 unittest
 {
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
             root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "a"
 dependency "b" version="*"
 dependency "c" version="*"`);
@@ -105,7 +105,7 @@ version "1.0.0"`, PackageFormat.sdl);
 // Missing dependencies trigger an error
 unittest
 {
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
             root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "a"
 dependency "b" version="*"`);
     });

--- a/source/dub/test/other.d
+++ b/source/dub/test/other.d
@@ -21,7 +21,7 @@ unittest
     const Template = `{"name": "%s", "version": "1.0.0", "dependencies": {
 "dep1": { "repository": "%s", "version": "%s" }}}`;
 
-    scope dub = new TestDub((scope FSEntry fs) {
+    scope dub = new TestDub((scope Filesystem fs) {
         // Invalid URL, valid hash
         fs.writePackageFile("a", "1.0.0", Template.format("a", "git+https://nope.nope", ValidHash));
         // Valid URL, invalid hash
@@ -53,7 +53,7 @@ unittest
 {
     const AddPathDir = TestDub.Paths.temp ~ "addpath/";
     const BDir = AddPathDir ~ "b/";
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
             root.writeFile(TestDub.ProjectPath ~ "dub.json",
                 `{ "name": "a", "dependencies": { "b": "~>1.0" } }`);
 
@@ -89,7 +89,7 @@ unittest
     const Template = `{"name": "%s", "version": "1.0.0", "dependencies": {
 "dep1": { "repository": "%s", "version": "%s" }}}`;
 
-    scope dub = new TestDub((scope FSEntry fs) {
+    scope dub = new TestDub((scope Filesystem fs) {
         // This should never be read
         fs.writePackageFile("poison", "1.0.0", `poison`);
         fs.writeFile(TestDub.ProjectPath ~ "dub.json",
@@ -106,7 +106,7 @@ unittest
 // Check that a simple build does not lead to the cache being scanned
 unittest
 {
-    scope dub = new TestDub((scope FSEntry fs) {
+    scope dub = new TestDub((scope Filesystem fs) {
         // This should never be read
         fs.writePackageFile("b", "1.0.0", `poison`);
         fs.writePackageFile("b", "1.1.0", `poison`);

--- a/source/dub/test/selections_from_parent_dir.d
+++ b/source/dub/test/selections_from_parent_dir.d
@@ -29,10 +29,12 @@ unittest
 }
 `;
 
-    scope dub = new TestDub((scope FSEntry fs) {
-        fs.mkdir(pkg1Dir).writeFile(NativePath("dub.sdl"), `name "pkg1"
+    scope dub = new TestDub((scope Filesystem fs) {
+        fs.mkdir(pkg1Dir);
+        fs.writeFile(pkg1Dir ~ "dub.sdl", `name "pkg1"
 targetType "none"`);
-        fs.mkdir(pkg2Dir).writeFile(NativePath("dub.sdl"), `name "pkg2"
+        fs.mkdir(pkg2Dir);
+        fs.writeFile(pkg2Dir ~ "dub.sdl", `name "pkg2"
 targetType "library"
 
 # don't specify a path, require inherited dub.selections.json to make it path-based (../pkg1)
@@ -66,9 +68,10 @@ unittest
     const root_a = root ~ "a";
     const root_a_b = root_a ~ "b";
 
-    scope dub_ = new TestDub((scope FSEntry fs) {
+    scope dub_ = new TestDub((scope Filesystem fs) {
         // inheritable root/dub.selections.json
-        fs.mkdir(root).writeFile(NativePath("dub.selections.json"), `{
+        fs.mkdir(root);
+        fs.writeFile(root ~ "dub.selections.json", `{
 	"fileVersion": 1,
 	"inheritable": true,
 	"versions": {
@@ -77,7 +80,8 @@ unittest
 }
 `);
         // non-inheritable root/a/dub.selections.json
-        fs.mkdir(root_a).writeFile(NativePath("dub.selections.json"), `{
+        fs.mkdir(root_a);
+        fs.writeFile(root_a ~ "dub.selections.json", `{
 	"fileVersion": 1,
 	"versions": {
 		"dub": "1.37.0"
@@ -133,7 +137,7 @@ unittest
 
     // after removing non-inheritable root/a/dub.selections.json: inherited root selections for root/a/b/
     {
-        auto dub = dub_.newTest((scope FSEntry fs) {
+        auto dub = dub_.newTest((scope Filesystem fs) {
             fs.removeFile(root_a ~ "dub.selections.json");
         });
         const result = dub.packageManager.readSelections(root_a_b);

--- a/source/dub/test/subpackages.d
+++ b/source/dub/test/subpackages.d
@@ -17,7 +17,7 @@ import dub.test.base;
 /// Test of the PackageManager APIs
 unittest
 {
-    scope dub = new TestDub((scope FSEntry root) {
+    scope dub = new TestDub((scope Filesystem root) {
         root.writeFile(TestDub.ProjectPath ~ "dub.json",
             `{ "name": "a", "dependencies": { "b:a": "~>1.0", "b:b": "~>1.0" } }`);
         root.writePackageFile("b", "1.0.0",


### PR DESCRIPTION
Extracted from #2941 

```
The filesystem abstraction needs to be known to production to avoid
too much code duplication. So far we have used functions in
`PackageManager` that the `TestPackageManager overrides.

With this change, we can remove them, and instead just pass an interface.
On the long run, we should be able to do dependency injection simply
by passing a different object (or overriding) the `Dub` class.

An initial attempt made `FSEntry` inherit from the `Filesystem` interface,
however that attempt was doomed as it conflates two different abstractions:
`FSEntry` is a "node" in the filesystem, which we want to act on in one
of multiple ways: move to another node, or take an action. On the other hand,
`Filesystem` is a more generic interface and takes a path as most of its
function's argument. A `path` and an `FSEntry` have a lot of overlap
(they are a reference to a node in a tree) and the resulting interface
would have been very clunky.
```