### PR TITLE
Fix skipRegistry parsing unittest

### DIFF
--- a/source/dub/data/settings.d
+++ b/source/dub/data/settings.d
@@ -195,7 +195,7 @@ unittest {
     import std.exception : assertThrown;
 
     const str1 = `{
-  "skipRegistry": "all"
-`;
+  "skipRegistry": "default_"
+}`;
     assertThrown!Exception(parseConfigString!Settings(str1, "/dev/null"));
 }


### PR DESCRIPTION
Contrary to the comment in the unittest, the code is checking for the wrong value, should be `default_` not `all`. The unittest passed because the function threw an exception not because of the value of skipRegistry but because there's a missing '}'.

I don't even know how I've managed to skip over this.