### PR TITLE
chore(path): Make a commonly triggered assert more verbose

### DIFF
--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -221,7 +221,8 @@ struct NativePath {
 		ret.m_endsWithSlash = rhs.m_endsWithSlash;
 		ret.normalize(); // needed to avoid "."~".." become "" instead of ".."
 
-		assert(!rhs.absolute, "Trying to append absolute path.");
+		assert(!rhs.absolute, "Trying to append absolute path: " ~
+			this.toNativeString() ~ " ~ " ~ rhs.toNativeString());
 		foreach(folder; rhs.m_nodes){
 			switch(folder.toString()){
 				default: ret.m_nodes = ret.m_nodes ~ folder; break;


### PR DESCRIPTION
We see this assert triggered frequently, even sometimes in production, so at least make it easier to track down the data involved.