### PR TITLE
packagesuppliers/filesystem.d: Fix out of bounds on invalid pkg names

### DIFF
--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -28,7 +28,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		import std.conv : to;
 		import dub.semver : isValidVersion;
 		Version[] ret;
-        const zipFileGlob = name.main.toString() ~ "*.zip";
+        const zipFileGlob = name.main.toString() ~ "?*.zip";
 		foreach (DirEntry d; dirEntries(m_path.toNativeString(), zipFileGlob, SpanMode.shallow)) {
 			NativePath p = NativePath(d.name);
 			auto vers = p.head.name[name.main.toString().length+1..$-4];


### PR DESCRIPTION
If a user ran `dub fetch foo-1.1.1` instead of `dub fetch foo@1.1.1` over a filesystem package supplier, assuming that the archive exists, the code that slices the filename tries to create an invalid slice as it assumes that the filename will contain at least the package name, a one character version separator, and the archive suffix which wouldn't be the case with a package name like `foo-1.1.1` and an archive name of `foo-1.1.1.zip`.

The fix is to require one more character in the glob to account for the version separator.

For context, this is the error I get:
```
$ ../bin/dub --skip-registry=all --registry=file:///var/cache/distfiles fetch test_allocator-0.3.4 --cache=local

core.exception.ArraySliceError@../source/dub/packagesuppliers/filesystem.d(34): slice [21 .. 20] has a larger lower index than upper index
----------------
??:? onArraySliceError [0x7f3ee2c1397e]
??:? _d_arraybounds_slicep [0x7f3ee2c13f72]
../source/dub/packagesuppliers/filesystem.d:34 dub.dependency.Version[] dub.packagesuppliers.filesystem.FileSystemPackageSupplier.getVersions(in ref dub.dependency.PackageName) [0x561890c9b6cf]
../source/dub/packagesuppliers/filesystem.d:95 dub.internal.vibecompat.inet.path.NativePath dub.packagesuppliers.filesystem.FileSystemPackageSupplier.bestPackageFile(in ref dub.dependency.PackageName, in ref dub.dependency.VersionRange, bool) [0x561890c9be7b]
../source/dub/packagesuppliers/filesystem.d:67 dub.internal.vibecompat.data.json.Json dub.packagesuppliers.filesystem.FileSystemPackageSupplier.fetchPackageRecipe(in ref dub.dependency.PackageName, in ref dub.dependency.VersionRange, bool) [0x561890c9bafc]
../source/dub/dub.d:982 dub.package_.Package dub.dub.Dub.fetch(in ref dub.dependency.PackageName, in ref dub.dependency.VersionRange, dub.dub.FetchOptions, dub.packagemanager.PlacementLocation, immutable(char)[]) [0x561890a7fc91]
../source/dub/dub.d:971 dub.package_.Package dub.dub.Dub.fetch(in ref dub.dependency.PackageName, in ref dub.dependency.VersionRange, dub.dub.FetchOptions, immutable(char)[]) [0x561890a7fbac]
../source/dub/commandline.d:2277 dub.commandline.FetchCommand.FetchStatus dub.commandline.FetchCommand.fetchSinglePackage(dub.dub.Dub, dub.commandline.UserPackageDesc) [0x561890878da4]
../source/dub/commandline.d:2241 void dub.commandline.FetchCommand.fetchPackage(dub.dub.Dub, dub.commandline.UserPackageDesc) [0x561890878a99]
../source/dub/commandline.d:2227 int dub.commandline.FetchCommand.execute(dub.dub.Dub, immutable(char)[][], immutable(char)[][]) [0x561890878919]
../source/dub/commandline.d:535 int dub.commandline.runDubCommandLine(immutable(char)[][]) [0x56189086f8e5]
../source/app.d:39 _Dmain [0x56189084a1c7]
```