### PR TITLE
Do dependency resolution after checking valid configs

### DIFF
--- a/source/dub/test/dependencies.d
+++ b/source/dub/test/dependencies.d
@@ -129,3 +129,49 @@ version "1.0.0"`, PackageFormat.sdl);
     assert(dub.project.getDependency("b", true), "Missing 'b' dependency");
     assert(dub.project.getDependency("no", true) is null, "Returned unexpected dependency");
 }
+
+// Issue 2695 - Nonsensical dependencies
+// Dependencies should resolve versions correctly regardless of the order they get requested
+unittest
+{
+    scope dub = new TestDub((scope Filesystem root) {
+            root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "main"
+dependency "a" version="*"
+dependency "b" version="*"`);
+            root.writePackageFile("a", "0.0.0", `name "a"
+dependency "c" version="~>0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("b", "0.0.0", `name "b"
+dependency "c" version="0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("c", "0.0.0", `name "c"
+version "0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("c", "0.0.1", `name "c"
+version "0.0.1"`, PackageFormat.sdl);
+    });
+    dub.loadPackage();
+
+    dub.upgrade(UpgradeOptions.select);
+
+    assert(dub.project.hasAllDependencies(), "project have missing dependencies");
+}
+
+unittest
+{
+    scope dub = new TestDub((scope Filesystem root) {
+            root.writeFile(TestDub.ProjectPath ~ "dub.sdl", `name "main"
+dependency "a" version="*"
+dependency "b" version="*"`);
+            root.writePackageFile("a", "1.0.0", `name "a"
+dependency "c" version="0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("b", "1.0.0", `name "b"
+dependency "c" version="~>0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("c", "0.0.0", `name "c"
+version "0.0.0"`, PackageFormat.sdl);
+            root.writePackageFile("c", "0.0.1", `name "c"
+version "0.0.1"`, PackageFormat.sdl);
+    });
+    dub.loadPackage();
+
+    dub.upgrade(UpgradeOptions.select);
+
+    assert(dub.project.hasAllDependencies(), "project have missing dependencies");
+}

--- a/source/dub/test/dependencies.d
+++ b/source/dub/test/dependencies.d
@@ -152,6 +152,7 @@ version "0.0.1"`, PackageFormat.sdl);
     dub.upgrade(UpgradeOptions.select);
 
     assert(dub.project.hasAllDependencies(), "project have missing dependencies");
+    assert(dub.project.getDependency("c", true).version_ == Version("0.0.0"));
 }
 
 unittest
@@ -174,4 +175,5 @@ version "0.0.1"`, PackageFormat.sdl);
     dub.upgrade(UpgradeOptions.select);
 
     assert(dub.project.hasAllDependencies(), "project have missing dependencies");
+    assert(dub.project.getDependency("c", true).version_ == Version("0.0.0"));
 }


### PR DESCRIPTION
This is my attempt to fix #2695 

This PR changes the dependency resolver algorithm so that it marks which resulting config is going to be used after all the incompatible configs have been discarded.