### PR TITLE
Build only the "application" configuration with -preview=in

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,10 +7,6 @@ license "MIT"
 
 targetPath "bin"
 
-dflags "-preview=in" platform="dmd"
-dflags "-preview=in" platform="ldc"
-//Disabled due to ICEs in gdc.
-//dflags "-fpreview=in" platform="gdc"
 // Deprecated module(s)
 excludedSourceFiles "source/dub/packagesupplier.d"
 
@@ -21,6 +17,11 @@ configuration "application" {
 	// Uncomment to get rich output about the file parsing and json <-> YAML
 	// integrity checks
 	//debugVersions "ConfigFillerDebug"
+
+	dflags "-preview=in" platform="dmd"
+	dflags "-preview=in" platform="ldc"
+	//Disabled due to ICEs in gdc.
+	//dflags "-fpreview=in" platform="gdc"
 }
 
 configuration "library" {


### PR DESCRIPTION
Otherwise leads to linker errors when building together with other code that uses `in` parameters. See also vibe-d/vibe-core#411