### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/pr_info_untrusted.yml
+++ b/.github/workflows/pr_info_untrusted.yml
@@ -62,7 +62,7 @@ jobs:
         echo ${{ github.event.number }} > ./pr/NR
 
     - name: upload comment to high-trust action making the comment
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pr
         path: pr/


### PR DESCRIPTION
Because v2 is EOL and the pipeline now fails.