### PR TITLE
feat: Upgrade macOS version from 12 to 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         # Latest stable version, update at will
-        os: [ macOS-12, ubuntu-20.04, windows-2019 ]
+        os: [ macOS-13, ubuntu-20.04, windows-2019 ]
         dc:
           # Always test latest as that is what we use to compile on release
           - dmd-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macOS-12, ubuntu-20.04, windows-2019 ]
+        os: [ macOS-13, ubuntu-20.04, windows-2019 ]
         arch: [ x86_64 ]
         include:
           - { os: windows-2019, arch: i686 }


### PR DESCRIPTION
macOS-12 is about to be EOL and is already starting to throw warnings in Homebrew, so upgrade it to 13 before the deadline which should be in the next couple months.