### PR TITLE
fix: Do not install pkg-config via brew as it's already installed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         # We need to install GNU utils as the test-suite scripts expect it.
         # Without them we may get slightly different behavior in tests and hard-to-track failures
-        brew install pkg-config coreutils diffutils
+        brew install coreutils diffutils
         echo "PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig/" >> $GITHUB_ENV
 
     - name: '[Linux] Install dependencies'


### PR DESCRIPTION
Installing pkg-config led to the following warning for each macOS pipeline:
pkgconf 2.3.0_1 is already installed and up-to-date. To reinstall 2.3.0_1, run: brew reinstall pkgconf