### PR TITLE
fix: Do not append empty recipePath to list of dependencies

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -525,8 +525,12 @@ class BuildGenerator : ProjectGenerator {
 		allfiles ~= buildsettings.stringImportFiles;
 		allfiles ~= buildsettings.extraDependencyFiles;
 		// TODO: add library files
-		foreach (p; packages)
-			allfiles ~= (p.recipePath != NativePath.init ? p : p.basePackage).recipePath.toNativeString();
+		foreach (p; packages) {
+			if (p.recipePath != NativePath.init)
+				allfiles ~= p.recipePath.toNativeString();
+			else if (p.basePackage.recipePath != NativePath.init)
+				allfiles ~= p.basePackage.recipePath.toNativeString();
+		}
 		foreach (f; additional_dep_files) allfiles ~= f.toNativeString();
 		bool checkSelectedVersions = !settings.single;
 		if (checkSelectedVersions && main_pack is m_project.rootPackage && m_project.rootPackage.getAllDependencies().length > 0)


### PR DESCRIPTION
This can happen for single-file package, which do not have a recipePath, leading (under the new path module) to always rebuilding.