### PR TITLE
fix(tests): Give a non-root CWD to tests

### DIFF
--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -235,6 +235,7 @@ public class TestDub : Dub
         fs_.mkdir(Paths.userPackages);
         fs_.mkdir(Paths.cache);
         fs_.mkdir(ProjectPath);
+        fs_.chdir(Root);
         if (dg !is null) dg(fs_);
         this(fs_, root, extras, skip);
     }


### PR DESCRIPTION
In the real world, it's unlikely Dub is ever started from the root path. However, in our current unittest framework, that is always the case.