### PR TITLE
fix(convert): Validate the package format passed to 'dub convert'

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -34,6 +34,7 @@ import std.path : absolutePath, buildNormalizedPath, expandTilde, setExtension;
 import std.process : environment, spawnProcess, wait;
 import std.stdio;
 import std.string;
+import std.traits : EnumMembers;
 import std.typecons : Tuple, tuple;
 
 /** Retrieves a list of all available commands.
@@ -2969,6 +2970,12 @@ class ConvertCommand : Command {
 		enforceUsage(app_args.length == 0, "Unexpected application arguments.");
 		enforceUsage(free_args.length == 0, "Unexpected arguments: "~free_args.join(" "));
 		enforceUsage(m_format.length > 0, "Missing target format file extension (--format=...).");
+		try this.m_format.to!PackageFormat;
+		catch (Exception exc)
+			enforceUsage(false,
+				"Unsupported format type '%s', supported values are: %(%s, %)"
+				.format(m_format, [ EnumMembers!PackageFormat ]));
+
 		if (!loadCwdPackage(dub, true)) return 2;
 		dub.convertRecipe(m_format, m_stdout);
 		return 0;

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -468,11 +468,14 @@ public class MockPackageSupplier : PackageSupplier
         scope pkgRoot = new MockFS();
         dg(pkgRoot);
 
-        string recipe = pkgRoot.existsFile(NativePath("dub.json")) ? "dub.json" : null;
-        if (recipe is null)
-            recipe = pkgRoot.existsFile(NativePath("dub.sdl")) ? "dub.sdl" : null;
-        if (recipe is null)
-            recipe = pkgRoot.existsFile(NativePath("package.json")) ? "package.json" : null;
+        string recipe;
+        foreach (faf; packageInfoFiles) {
+            if (pkgRoot.existsFile(NativePath(faf.filename))) {
+                recipe = faf.filename;
+                break;
+            }
+        }
+
         // Note: If you want to provide an invalid package, override
         // [Mock]PackageSupplier. Most tests will expect a well-behaving
         // registry so this assert is here to help with writing tests.


### PR DESCRIPTION
```
Currently calling 'dub convert --format=nope' will trigger an assertion failure.
```

Also include a small future-proof refactoring for the test framework.