### PR TITLE
chore(configy): Use JSON, not YAML, in the unittest

### DIFF
--- a/source/dub/internal/configy/dub_test.d
+++ b/source/dub/internal/configy/dub_test.d
@@ -26,7 +26,7 @@ unittest
         string[][string] names_;
     }
 
-    auto c = parseConfigString!Config("names-x86:\n  - John\n  - Luca\nnames:\n  - Marie", "/dev/null");
+    auto c = parseConfigString!Config(`{ "names-x86": [ "John", "Luca" ], "names": [ "Marie" ] }`, "/dev/null");
     assert(c.names_[null] == [ "Marie" ]);
     assert(c.names_["x86"] == [ "John", "Luca" ]);
 }


### PR DESCRIPTION
Dub does not yet support YAML, so using JSON here is slightly better if we were to change the underlying parser.