### PR TITLE
fix(parser): Accept short hand package syntax (:a) in subpackages too

### DIFF
--- a/source/dub/test/subpackages.d
+++ b/source/dub/test/subpackages.d
@@ -55,3 +55,18 @@ unittest
     assert(dub.project.hasAllDependencies(), "project has missing dependencies");
     assert(dub.project.getDependency("b:a", true), "Missing 'b:a' dependency");
 }
+
+// https://github.com/dlang/dub/issues/1615
+// https://github.com/dlang/dub/pull/2972
+unittest
+{
+    scope dub = new TestDub((scope Filesystem root) {
+        root.writeFile(TestDub.ProjectPath ~ "dub.json",
+            `{"name": "t9",
+"subPackages":[{"name": "a","dependencies": {":b": "*"}},{"name": "b"}],
+"dependencies": {":a": "*",":b": "*"}}`);
+    });
+    dub.loadPackage();
+
+    assert(dub.project.hasAllDependencies(), "project has missing dependencies");
+}


### PR DESCRIPTION
The hack that we had in place to accept this did not properly recurse in arrays and associative array, the former causing the issue shown on the linked pull request. Additionally, add a comprehensive unittest as found in an old issue (1615) as it covers both cases.