### PR TITLE
Error out on invalid dub.json file

### DIFF
--- a/source/dub/recipe/io.d
+++ b/source/dub/recipe/io.d
@@ -83,8 +83,6 @@ PackageRecipe parsePackageRecipe(string contents, string filename,
 {
 	import std.algorithm : endsWith;
 	import dub.compilers.buildsettings : TargetType;
-	import dub.internal.vibecompat.data.json;
-	import dub.recipe.json : parseJson;
 	import dub.recipe.sdl : parseSDL;
 
 	PackageRecipe ret;
@@ -93,43 +91,8 @@ PackageRecipe parsePackageRecipe(string contents, string filename,
 
 	if (filename.endsWith(".json"))
 	{
-		try {
-			ret = parseConfigString!PackageRecipe(contents, filename, mode);
-			fixDependenciesNames(ret.name, ret);
-		} catch (ConfigException exc) {
-			logWarn("Your `dub.json` file use non-conventional features that are deprecated");
-			logWarn("Please adjust your `dub.json` file as those warnings will turn into errors in dub v1.40.0");
-			logWarn("Error was: %s", exc);
-			// Fallback to JSON parser
-			ret = PackageRecipe.init;
-			parseJson(ret, parseJsonString(contents, filename), parent);
-		} catch (Exception exc) {
-			logWarn("Your `dub.json` file use non-conventional features that are deprecated");
-			logWarn("This is most likely due to duplicated keys.");
-			logWarn("Please adjust your `dub.json` file as those warnings will turn into errors in dub v1.40.0");
-			logWarn("Error was: %s", exc);
-			// Fallback to JSON parser
-			ret = PackageRecipe.init;
-			parseJson(ret, parseJsonString(contents, filename), parent);
-		}
-		// `debug = ConfigFillerDebug` also enables verbose parser output
-		debug (ConfigFillerDebug)
-		{
-			import std.stdio;
-
-			PackageRecipe jsonret;
-			parseJson(jsonret, parseJsonString(contents, filename), parent_name);
-			if (ret != jsonret)
-			{
-				writeln("Content of JSON and YAML parsing differ for file: ", filename);
-				writeln("-------------------------------------------------------------------");
-				writeln("JSON (excepted): ", jsonret);
-				writeln("-------------------------------------------------------------------");
-				writeln("YAML (actual  ): ", ret);
-				writeln("========================================");
-				ret = jsonret;
-			}
-		}
+		ret = parseConfigString!PackageRecipe(contents, filename, mode);
+		fixDependenciesNames(ret.name, ret);
 	}
 	else if (filename.endsWith(".sdl")) parseSDL(ret, contents, parent, filename);
 	else assert(false, "readPackageRecipe called with filename with unknown extension: "~filename);


### PR DESCRIPTION
This warning was introduced in a8aa2341be8434b16630aba03958f70565ff3ad6.

It's been 10 releases and we should not longer be concerned about mismatches. In addition, this introduced a surprising error message when using single package files. Because `dub --single myfile.d` will *still* try to load the package in the current directory (in the event it is referenced by `myfile.d`), if this was run from somewhere where the package was not expected to be loaded (e.g. the script is in a repository in which there is also an NPM `package.json`) it could lead to confusing error messages.