### PR TITLE
fix: Don't add single package files to sourceFiles

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -599,7 +599,7 @@ class Dub {
 		enforce(recipe.buildSettings.cSourcePaths.length == 0, "Single-file packages are not allowed to specify C source paths.");
 		enforce(recipe.buildSettings.importPaths.length == 0, "Single-file packages are not allowed to specify import paths.");
 		enforce(recipe.buildSettings.cImportPaths.length == 0, "Single-file packages are not allowed to specify C import paths.");
-		recipe.buildSettings.sourceFiles[""] = [path.toNativeString()];
+		recipe.buildSettings.sourceFiles[""] = [];
 		recipe.buildSettings.sourcePaths[""] = [];
 		recipe.buildSettings.cSourcePaths[""] = [];
 		recipe.buildSettings.importPaths[""] = [];


### PR DESCRIPTION
They get added automatically via the mainSourceFile path, so rely on this. This work around a bug in Windows + git bash where the file gets mentioned twice on the command line.

This should fix #3030 but the underlying bug can still be triggered with a package and `mainSourceFile`, but fixing that requires a deeper refactoring.