### PR TITLE
Replace SkipPackageSuppliers.default_ usage with Nullable

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -35,7 +35,7 @@ import std.process : environment, spawnProcess, wait;
 import std.stdio;
 import std.string;
 import std.traits : EnumMembers;
-import std.typecons : Tuple, tuple;
+import std.typecons : Nullable, nullable, Tuple, tuple;
 
 /** Retrieves a list of all available commands.
 
@@ -566,7 +566,7 @@ struct CommonOptions {
 	string root_path, recipeFile;
 	enum Color { automatic, on, off }
 	Color colorMode = Color.automatic;
-	SkipPackageSuppliers skipRegistry = SkipPackageSuppliers.default_;
+	Nullable!SkipPackageSuppliers skipRegistry;
 	PlacementLocation placementLocation = PlacementLocation.user;
 
 	private void parseColor(string option, string value) @safe
@@ -622,7 +622,8 @@ struct CommonOptions {
 			"  DUB: URL to DUB registry (default)",
 			"  Maven: URL to Maven repository + group id containing dub packages as artifacts. E.g. mvn+http://localhost:8040/maven/libs-release/dubpackages",
 			]);
-		args.getopt("skip-registry", &skipRegistry, &parseSkipRegistry, [
+		string skipRegistryValue;
+		args.getopt("skip-registry", &skipRegistryValue, &parseSkipRegistry, [
 			"Sets a mode for skipping the search on certain package registry types:",
 			"  none: Search all configured or default registries (default)",
 			"  standard: Don't search the main registry (e.g. "~defaultRegistryURLs[0]~")",

--- a/source/dub/data/settings.d
+++ b/source/dub/data/settings.d
@@ -17,7 +17,6 @@ public enum SkipPackageSuppliers {
     standard,   /// Does not use the default package suppliers (`defaultPackageSuppliers`).
     configured, /// Does not use default suppliers or suppliers configured in DUB's configuration file
     all,        /// Uses only manually specified package suppliers.
-    default_,   /// The value wasn't specified. It is provided in order to know when it is safe to ignore it
 }
 
 /**
@@ -40,22 +39,7 @@ package(dub) struct Settings {
     @Optional string[] registryUrls;
     @Optional NativePath[] customCachePaths;
 
-    private struct SkipRegistry {
-	    SkipPackageSuppliers skipRegistry;
-	    static SkipRegistry fromString (string value) {
-		    import std.conv : to;
-		    auto result = value.to!SkipPackageSuppliers;
-		    if (result == SkipPackageSuppliers.default_) {
-			    throw new Exception(
-				"skipRegistry value `default_` is only meant for interal use."
-				~ " Instead, use one of `none`, `standard`, `configured`, or `all`."
-						);
-		    }
-		    return SkipRegistry(result);
-	    }
-	    alias skipRegistry this;
-    }
-    SetInfo!(SkipRegistry) skipRegistry;
+    SetInfo!(SkipPackageSuppliers) skipRegistry;
     SetInfo!(string) defaultCompiler;
     SetInfo!(string) defaultArchitecture;
     SetInfo!(bool) defaultLowMemory;
@@ -186,16 +170,4 @@ unittest {
 
      auto m3 = Settings.init.merge(c1);
      assert(m3 == c1);
-}
-
-unittest {
-    // Test that SkipPackageRegistry.default_ is not allowed
-
-    import dub.internal.configy.easy;
-    import std.exception : assertThrown;
-
-    const str1 = `{
-  "skipRegistry": "default_"
-}`;
-    assertThrown!Exception(parseConfigString!Settings(str1, "/dev/null"));
 }

--- a/source/dub/test/base.d
+++ b/source/dub/test/base.d
@@ -55,6 +55,7 @@ import std.datetime.systime;
 import std.exception;
 import std.format;
 import std.string;
+import std.typecons : Nullable, nullable;
 
 import dub.data.settings;
 public import dub.dependency;
@@ -222,7 +223,7 @@ public class TestDub : Dub
     public this (scope void delegate(scope Filesystem root) dg = null,
         string root = ProjectPath.toNativeString(),
         PackageSupplier[] extras = null,
-        SkipPackageSuppliers skip = SkipPackageSuppliers.none)
+        Nullable!SkipPackageSuppliers skip = Nullable!SkipPackageSuppliers.init)
     {
         /// Create the fs & its base structure
         auto fs_ = new MockFS();
@@ -236,23 +237,41 @@ public class TestDub : Dub
         if (dg !is null) dg(fs_);
         super(fs_, root, extras, skip);
     }
+    public this (scope void delegate(scope Filesystem root) dg,
+        string root,
+        PackageSupplier[] extras,
+        SkipPackageSuppliers skip)
+    {
+        this(dg, root, extras, nullable(skip));
+    }
 
     /// Workaround https://issues.dlang.org/show_bug.cgi?id=24388 when called
     /// when called with (null, ...).
     public this (typeof(null) _,
         string root = ProjectPath.toNativeString(),
         PackageSupplier[] extras = null,
-        SkipPackageSuppliers skip = SkipPackageSuppliers.none)
+        Nullable!SkipPackageSuppliers skip = Nullable!SkipPackageSuppliers.init)
     {
         alias TType = void delegate(scope Filesystem);
         this(TType.init, root, extras, skip);
     }
+    public this (typeof(null) _,
+        string root,
+        PackageSupplier[] extras,
+        SkipPackageSuppliers skip) {
+        this(null, root, extras, nullable(skip));
+    }
 
     /// Internal constructor
     private this(Filesystem fs_, string root, PackageSupplier[] extras,
-        SkipPackageSuppliers skip)
+        Nullable!SkipPackageSuppliers skip)
     {
         super(fs_, root, extras, skip);
+    }
+    private this(Filesystem fs_, string root, PackageSupplier[] extras,
+        SkipPackageSuppliers skip)
+    {
+        this(fs_, root, extras, nullable(skip));
     }
 
     /***************************************************************************


### PR DESCRIPTION
Instead of having a different enum value for stating that the value is not specified and it should be taken from the configuration files, use a Nullable. This has been suggested in https://github.com/dlang/dub/pull/2903#discussion_r1582262457

The main reason for this change is going through the other places where the configuration files were not honored (e.g. dub lint) (which was the intent of the original PR). It would be a shorter change to modify the current code to use the .default_ enum value when it was appropriate but if I have to change the code I might as well go and implement the less error-prone solution with Nullable.