### PR TITLE
feat: Remove hardlinking of files, only copy

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -184,7 +184,7 @@ class BuildGenerator : ProjectGenerator {
 			foreach (src; dynamicLibDepsFilesToCopy) {
 				logDiagnostic("Copying target from %s to %s",
 					src.toNativeString(), rootTargetPath.toNativeString());
-				hardLinkFile(src, rootTargetPath ~ src.head, true);
+				copyFile(src, rootTargetPath ~ src.head, true);
 			}
 		}
 
@@ -504,7 +504,7 @@ class BuildGenerator : ProjectGenerator {
 		{
 			auto src = build_path ~ filename;
 			logDiagnostic("Copying target from %s to %s", src.toNativeString(), buildsettings.targetPath);
-			hardLinkFile(src, NativePath(buildsettings.targetPath) ~ filename, true);
+			copyFile(src, NativePath(buildsettings.targetPath) ~ filename, true);
 		}
 	}
 

--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -1029,7 +1029,7 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 					if (de.isDirectory) {
 						copyFolderRec(folder ~ de.name, dstfolder ~ de.name);
 					} else {
-						try hardLinkFile(folder ~ de.name, dstfolder ~ de.name, true);
+						try copyFile(folder ~ de.name, dstfolder ~ de.name, true);
 						catch (Exception e) {
 							logWarn("Failed to copy file %s: %s", (folder ~ de.name).toNativeString(), e.msg);
 						}
@@ -1063,7 +1063,7 @@ private void finalizeGeneration(in Package pack, in Project proj, in GeneratorSe
 				}
 				logDiagnostic("  %s to %s", src.toNativeString(), dst.toNativeString());
 				try {
-					hardLinkFile(src, dst, true);
+					copyFile(src, dst, true);
 				} catch(Exception e) logWarn("Failed to copy %s to %s: %s", src.toNativeString(), dst.toNativeString(), e.msg);
 			}
 			logInfo("Copying files for %s...", pack.name);


### PR DESCRIPTION
Hard linking is a smart approach which can be confusing to users. The benefits are not quite clear, especially given how cheap storage is nowadays. As can be seen from the diff, having a simple copy makes the process a lot simpler.

Fixes #2127 and #2527