### PR TITLE
fix(main): Re-enable the default D GC

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -23,17 +23,6 @@ version (DigitalMars) version (D_Coverage)
 	}
 }
 
-/**
- * Workaround https://github.com/dlang/dub/issues/1812
- *
- * On Linux, a segmentation fault happens when dub is compiled with a recent
- * compiler. While not confirmed, the logs seem to point to parallel marking
- * done by the GC. Hence this disables it.
- *
- * https://dlang.org/changelog/2.087.0.html#gc_parallel
- */
-extern(C) __gshared string[] rt_options = [ "gcopt=parallel:0" ];
-
 int main(string[] args)
 {
 	return runDubCommandLine(args);


### PR DESCRIPTION
This was disabled a few years ago as a workaround for a bug that was mostly affecting Dub running on Travis CI. At the time, the osthreads of DRuntime didn't take TLS into account, and due to how pthread works, the TLS was eating away at what we thought was available stack to the thread. Since this is long fixed and we don't support such old versions, we can remove this.