### PR TITLE
feat(dub): Deprecate using 'package.json' for projects

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -543,6 +543,10 @@ class Dub {
 	{
 		auto selections = Project.loadSelections(pack.path, m_packageManager);
 		m_project = new Project(m_packageManager, pack, selections);
+		if (pack.recipePath().head == "package.json") {
+			logWarn("Using `package.json` is deprecated as it may conflict with other package managers");
+			logWarn("Rename 'package.json' to 'dub.json'. Loading dependencies using 'package.json' will still work.");
+		}
 	}
 
 	/** Loads a single file package.


### PR DESCRIPTION
The 'package.json' name is also used by NPM, which can cause conflicts if a repository holds both NPM and Dub projects.
However, we only display this warning on project loads, as dependencies might use it but there is less chance of a conflict.