### PR TITLE
fix: Properly display error message for missing pkg-config

### DIFF
--- a/source/dub/compilers/utils.d
+++ b/source/dub/compilers/utils.d
@@ -148,15 +148,13 @@ void resolveLibs(ref BuildSettings settings, const scope ref BuildPlatform platf
 					} else if (f.startsWith("-Wl,")) settings.addLFlags(f[4 .. $].split(","));
 					else settings.addLFlags(f);
 				}
-			} else if (execute([pkgconfig_bin, "--exists", "thislibrarydoesnotexists"]).status == 127)
-				logWarn("'pkg-config' does not seem to be installed. 'dub' will " ~
-					"automatically fall back to directly using '-l' flags, but " ~
-					"this is error prone. Please install 'pkg-config', or use " ~
-					"'lflags' directly.");
+			}
 			if (settings.libs.length) logDiagnostic("Using direct -l... flags for %s.", settings.libs.array.join(", "));
 		} catch (Exception e) {
-			logDiagnostic("pkg-config failed: %s", e.msg);
-			logDiagnostic("Falling back to direct -l... flags.");
+			logWarn("'pkg-config' does not seem to be installed or functional as it failed with: %s", e.msg);
+			logWarn("'dub' will automatically fall back to directly using '-l' flags, " ~
+				"but this is error prone. Please install 'pkg-config', or use " ~
+				"'lflags' directly.");
 		}
 	}
 }


### PR DESCRIPTION
The code previously assumed the return code would be 127, when it was actually triggering an Exception in this case.

See #3041