### PR TITLE
fix: Improve and fix printing ConfigException

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -528,6 +528,8 @@ int runDubCommandLine(string[] args)
 		return 1;
 	}
 
+	import dub.internal.configy.exceptions : ConfigException;
+
 	try {
 		// initialize the root package
 		Dub dub = cmd.prepareDub(handler.options);
@@ -539,10 +541,15 @@ int runDubCommandLine(string[] args)
 		// usage exceptions get thrown before any logging, so we are
 		// making the errors more narrow to better fit on small screens.
 		tagWidth.push(5);
-		logError("%s", e.msg);
+		logError("%s", e.message);
 		logDebug("Full exception: %s", e.toString().sanitize);
 		logInfo(`Run "%s" for more information about the "%s" command.`,
 			text("dub ", cmd.name, " -h").color(Mode.bold), cmd.name.color(Mode.bold));
+		return 1;
+	}
+	catch (ConfigException exc) {
+		logError("%S", exc);
+		logDiagnostic("%s", exc.stackTraceToString());
 		return 1;
 	}
 	catch (Exception e) {
@@ -550,7 +557,7 @@ int runDubCommandLine(string[] args)
 		// above. However this might be subject to change if it results in
 		// weird behavior anywhere.
 		tagWidth.push(5);
-		logError("%s", e.msg);
+		logError("%s", e.message);
 		logDebug("Full exception: %s", e.toString().sanitize);
 		return 2;
 	}

--- a/source/dub/internal/configy/exceptions.d
+++ b/source/dub/internal/configy/exceptions.d
@@ -116,27 +116,34 @@ public abstract class ConfigException : Exception
         this.formatMessage(sink, spec);
 
         debug (ConfigFillerDebug)
-        {
-            sink("\n\tError originated from: ");
-            Location(this.file, this.line).toString(sink);
+            this.stackTraceToString(sink);
+    }
 
-            if (!this.info)
-                return;
+    /// Print the regular D stack-trace for debugging purpose
+    public void stackTraceToString (scope SinkType sink) const scope @safe {
+        sink("\n\tError originated from: ");
+        Location(this.file, this.line).toString(sink);
 
-            () @trusted nothrow
-            {
-                try
-                {
-                    sink("\n----------------");
-                    foreach (t; info)
-                    {
-                        sink("\n"); sink(t);
-                    }
+        if (!this.info)
+            return;
+
+        () @trusted nothrow {
+            try {
+                sink("\n----------------");
+                foreach (t; info) {
+                    sink("\n"); sink(t);
                 }
-                // ignore more errors
-                catch (Throwable) {}
-            }();
-        }
+            }
+            // ignore more errors
+            catch (Throwable) {}
+        }();
+    }
+
+    /// Ditto
+    public final string stackTraceToString () const scope @safe {
+        string buffer;
+        this.stackTraceToString((in char[] data) { buffer ~= data; });
+        return buffer;
     }
 
     /// Hook called by `toString` to simplify coloring


### PR DESCRIPTION
Since we removed the fallback to the JSON parser,
we also removed the printing logic using '%S',
so it needs to be re-added. Additionally, change
msg to message for future-proofness, and make it
possible to print the stack trace with ConfigException for better bug reports in the future.