### PR TITLE
test/version-spec.sh: Disable pipefail to avoid SIGPIPE failures

### DIFF
--- a/test/version-spec.sh
+++ b/test/version-spec.sh
@@ -2,6 +2,18 @@
 
 . $(dirname "${BASH_SOURCE[0]}")/common.sh
 
+# When pipeing the dub output it is possible for head/tail to extract
+# the output line before dub finished printing leading to dub
+# receiving SIGPIPE. With pipefail this would fail the whole $()
+# invocation leading to a ERROR result but, since $() invokes a
+# subshell, the rest of the test still continue (and passes). The end
+# result are 2 log lines, one for success and one for failure, for
+# this single test file.
+#
+# The command that consistently fails for me is:
+# $DUB list foo@'>0.1.0' | head -n 2 | tail -n 1
+set +o pipefail
+
 DUBPKGPATH=${DPATH+"$DPATH/dub/packages/dub"}
 DUBPKGPATH=${DUBPKGPATH:-"$HOME/.dub/packages/dub"}
 


### PR DESCRIPTION
When dub output is piped into head/tail the latter may finish extracting the desired line before dub finishes printing, which would send dub SIGPIPE. With the pipefail option enabled this would lead to the $() invocation failing, which would add a ERROR result in the log, but would not stop the test from executing since the failure is in a different subshell. After the main test process finishes a INFO result would be appended to the logs, for the same test.

Below is the output when ran with pipefail enabled:
```
$ ./run-unittest.sh version-spec.sh
    Starting Performing "debug" build using dmd for x86_64.
  Up-to-date run-unittest ~master: target for configuration [application] is up to date.
    Finished To force a rebuild of up-to-date targets, run again with --force
     Running run-unittest version-spec.sh
[INFO] Running /home/happy/git/dub/test/version-spec.sh...
             Registered package: foo (version: 1.0.0)
             Registered package: foo (version: 0.1.0)
     Warning Excluding main source file source/app.d from test.
     Warning Excluding main source file source/app.d from test.
     Warning Excluding main source file source/app.d from test.
[ERROR] /home/happy/git/dub/test/version-spec.sh:56 command failed
             Deregistered package: foo (version: 1.0.0)
             Deregistered package: foo (version: 0.1.0)
    Fetching dub 1.9.0
     Fetched package dub@1.9.0 successfully
1 packages fetched, 0 already present, 0 failed
    Fetching dub 1.10.0
     Fetched package dub@1.10.0 successfully
1 packages fetched, 0 already present, 0 failed
    Removing dub (in /home/happy/.dub/packages/dub/1.9.0/dub/)
     Removed dub 1.9.0
    Removing dub (in /home/happy/.dub/packages/dub/1.10.0/dub/)
     Removed dub 1.10.0
[INFO] version-spec.sh status: Ok

Testing summary:
[INFO] Running /home/happy/git/dub/test/version-spec.sh...
[ERROR] /home/happy/git/dub/test/version-spec.sh:56 command failed
[INFO] version-spec.sh status: Ok
1/2 tests succeeded.
```