### PR TITLE
Update generated `.gitignore` during `init`

### DIFF
--- a/source/dub/init.d
+++ b/source/dub/init.d
@@ -190,6 +190,7 @@ docs/
 %1$s.so
 %1$s.dylib
 %1$s.dll
+lib%1$s.a
 %1$s.a
 %1$s.lib
 %1$s-test-*


### PR DESCRIPTION
I added a filter for the file with pattern `libname.a`, as that is what I get on my platform by default and it was missing.  
For context, debian 13 and latest ldc2 from github releases.