### PR TITLE
compilers/dmd: Determine the backend version for gdmd

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -132,7 +132,7 @@ interface Compiler {
 	string[] lflagsToDFlags(const string[] lflags) const;
 
 	/// Determines compiler version
-	string determineVersion(string compiler_binary, string verboseOutput);
+	string determineVersion(in BuildPlatform platform, string verboseOutput);
 
 	/** Runs a tool and provides common boilerplate code.
 
@@ -193,8 +193,8 @@ interface Compiler {
 				format("Failed to invoke the compiler %s to determine the build platform: %s",
 				compiler_binary, result.output));
 		BuildPlatform build_platform = readPlatformSDLProbe(result.output);
-		string ver = determineVersion(compiler_binary, result.output).strip;
 		build_platform.compilerBinary = compiler_binary;
+		string ver = determineVersion(build_platform, result.output).strip;
 
 		if (ver.empty) {
 			logWarn(`Could not probe the compiler version for "%s". ` ~

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -54,10 +54,10 @@ class GDCCompiler : Compiler {
 
 	@property string name() const { return "gdc"; }
 
-	string determineVersion(string compiler_binary, string verboseOutput)
+	string determineVersion(in BuildPlatform platform, string verboseOutput)
 	{
 		const result = execute([
-			compiler_binary,
+			platform.compilerBinary,
 			"-dumpfullversion",
 			"-dumpversion"
 		]);

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -69,7 +69,7 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 		assert(c && c.length > 1 && c[1] == "1.11.0");
 	}
 
-	string determineVersion(string compiler_binary, string verboseOutput)
+	string determineVersion(in BuildPlatform platform, string verboseOutput)
 	{
 		import std.regex : matchFirst, regex;
 		auto ver = matchFirst(verboseOutput, regex(ldcVersionRe, "m"));


### PR DESCRIPTION
This changes makes the compiler version for gdmd match the gdc version instead of the dmd FE version that gdc had been using. This matches what happens for ldmd2 which mirrors the ldc2 version.

Specifically, now the versions look like:
- ldmd2-1.40 :: 1.40.X
- ldc2-1.40 :: 1.40.X
- gdc-14 :: 14.X.Y
- gdmd-14 :: 14.X.Y

When, previously, gdmd-14 would result in a version like 2.108.X