### PR TITLE
Rename PackageName.main to .base to making naming consistent

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1604,7 +1604,7 @@ class BuildCommand : GenerateCommand {
 		if (packageParts.name.startsWith(":"))
 			return 0;
 
-		const baseName = PackageName(packageParts.name).main;
+		const baseName = PackageName(packageParts.name).base;
 		// Found locally
 		if (dub.packageManager.getBestPackage(baseName, packageParts.range))
 			return 0;
@@ -2837,7 +2837,7 @@ class DustmiteCommand : PackageBuildCommand {
 			static void fixPathDependency(in PackageName name, ref Dependency dep) {
 				dep.visit!(
 					(NativePath path) {
-						dep = Dependency(NativePath("../") ~ name.main.toString());
+						dep = Dependency(NativePath("../") ~ name.base.toString());
 					},
 					(any) { /* Nothing to do */ },
 				);

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -19,15 +19,19 @@ import std.exception;
 import std.string;
 
 /// Represents a fully-qualified package name
-public struct PackageName
+struct PackageName
 {
-	/// The underlying full name of the package
-	private string fullName;
-	/// Where the separator lies, if any
-	private size_t separator;
+	private {
+		/// The underlying full name of the package
+		string fullName;
+		/// Where the separator lies, if any
+		size_t separator;
+	}
+
+ @safe pure:
 
 	/// Creates a new instance of this struct
-	public this(string fn) @safe pure
+	this(string fn)
 	{
 		this.fullName = fn;
 		if (auto idx = fn.indexOf(':'))
@@ -38,20 +42,20 @@ public struct PackageName
 	}
 
 	/// Private constructor to have nothrow / @nogc
-	private this(string fn, size_t sep) @safe pure nothrow @nogc
+	private this(string fn, size_t sep) nothrow @nogc
 	{
 		this.fullName = fn;
 		this.separator = sep;
 	}
 
 	/// The base package name in which the subpackages may live
-	public PackageName main () const return @safe pure nothrow @nogc
+	PackageName main() const return nothrow @nogc
 	{
 		return PackageName(this.fullName[0 .. this.separator], this.separator);
 	}
 
 	/// The subpackage name, or an empty string if there isn't
-	public string sub () const return @safe pure nothrow @nogc
+	string sub() const return nothrow @nogc
 	{
 		// Return `null` instead of an empty string so that
 		// it can be used in a boolean context, e.g.
@@ -62,20 +66,20 @@ public struct PackageName
 	}
 
 	/// Human readable representation
-	public string toString () const return scope @safe pure nothrow @nogc
+	string toString() const return scope nothrow @nogc
 	{
 		return this.fullName;
 	}
 
     ///
-    public int opCmp (in PackageName other) const scope @safe pure nothrow @nogc
+    int opCmp(in PackageName other) const scope nothrow @nogc
     {
         import core.internal.string : dstrcmp;
         return dstrcmp(this.toString(), other.toString());
     }
 
     ///
-    public bool opEquals (in PackageName other) const scope @safe pure nothrow @nogc
+    bool opEquals(in PackageName other) const scope nothrow @nogc
     {
         return this.toString() == other.toString();
     }

--- a/source/dub/dependency.d
+++ b/source/dub/dependency.d
@@ -49,10 +49,13 @@ struct PackageName
 	}
 
 	/// The base package name in which the subpackages may live
-	PackageName main() const return nothrow @nogc
+	PackageName base() const return nothrow @nogc
 	{
 		return PackageName(this.fullName[0 .. this.separator], this.separator);
 	}
+
+	deprecated("Use .base instead.")
+	alias main = base;
 
 	/// The subpackage name, or an empty string if there isn't
 	string sub() const return nothrow @nogc

--- a/source/dub/dependencyresolver.d
+++ b/source/dub/dependencyresolver.d
@@ -101,7 +101,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 	CONFIG[PackageName] resolve(TreeNode root, bool throw_on_failure = true)
 	{
-		auto rootbase = root.pack.main;
+		auto rootbase = root.pack.base;
 
 		// build up the dependency graph, eliminating as many configurations/
 		// versions as possible
@@ -180,7 +180,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 	*/
 	private void constrain(TreeNode n, ref ResolveContext context, ref ulong max_iterations)
 	{
-		auto base = n.pack.main;
+		auto base = n.pack.base;
 		assert(base in context.configs);
 		if (context.isVisited(n.pack)) return;
 		context.setVisited(n.pack);
@@ -189,7 +189,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 		foreach (dep; dependencies) {
 			// lazily load all dependency configurations
-			auto depbase = dep.pack.main;
+			auto depbase = dep.pack.base;
 			auto di = depbase in context.configs;
 			if (!di) {
 				context.configs[depbase] =
@@ -243,7 +243,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 			~ " recipe that reproduces this error.");
 
 		auto dep = &dependencies[depidx];
-		auto depbase = dep.pack.main;
+		auto depbase = dep.pack.base;
 		auto depconfigs = context.configs[depbase];
 
 		Exception first_err;
@@ -291,9 +291,9 @@ class DependencyResolver(CONFIGS, CONFIG) {
 		{
 			if (node.pack in visited) return;
 			visited[node.pack] = true;
-			required[node.pack.main] = true;
+			required[node.pack.base] = true;
 			foreach (dep; getChildren(node).filter!(dep => dep.depType != DependencyType.optional))
-				if (auto dp = dep.pack.main in configs)
+				if (auto dp = dep.pack.base in configs)
 					markRecursively(TreeNode(dep.pack, *dp));
 		}
 
@@ -314,12 +314,12 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 		this(TreeNode parent, TreeNodes dep, const scope ref ResolveContext context, string file = __FILE__, size_t line = __LINE__)
 		{
-			auto m = format("Unresolvable dependencies to package %s:", dep.pack.main);
+			auto m = format("Unresolvable dependencies to package %s:", dep.pack.base);
 			super(m, file, line);
 
 			this.failedNode = dep.pack;
 
-			auto failbase = failedNode.main;
+			auto failbase = failedNode.base;
 
 			// Get partial results
 			CONFIG[PackageName] partial_result;
@@ -332,10 +332,10 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 			// get the list of all dependencies to the failed package
 			auto deps = context.visited.byKey
-				.filter!(p => !!(p.main in partial_result))
-				.map!(p => TreeNode(p, partial_result[p.main]))
+				.filter!(p => !!(p.base in partial_result))
+				.map!(p => TreeNode(p, partial_result[p.base]))
 				.map!(n => getChildren(n)
-					.filter!(d => d.pack.main == failbase)
+					.filter!(d => d.pack.base == failbase)
 					.map!(d => tuple(n, d))
 				)
 				.join
@@ -343,7 +343,7 @@ class DependencyResolver(CONFIGS, CONFIG) {
 
 			foreach (d; deps) {
 				// filter out trivial self-dependencies
-				if (d[0].pack.main == failbase
+				if (d[0].pack.base == failbase
 					&& matches(d[1].configs, d[0].config))
 					continue;
 				msg ~= format("\n  %s %s depends on %s %s", d[0].pack, d[0].config, d[1].pack, d[1].configs);
@@ -395,7 +395,7 @@ unittest {
 			foreach (p_; m_children.byKey) {
 				// Note: We abuse subpackage notation to store configs
 				const p = PackageName(p_);
-				if (p.main != pack.main) continue;
+				if (p.base != pack.base) continue;
 				ret ~= ic(p.sub.to!uint);
 			}
 			ret.data.sort!"a>b"();

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -696,12 +696,12 @@ class Dub {
 
 		if (options & UpgradeOptions.dryRun) {
 			bool any = false;
-			string rootbasename = PackageName(m_project.rootPackage.name).main.toString();
+			string rootbasename = PackageName(m_project.rootPackage.name).base.toString();
 
 			foreach (p, ver; versions) {
 				if (!ver.path.empty || !ver.repository.empty) continue;
 
-				auto basename = p.main;
+				auto basename = p.base;
 				if (basename.toString() == rootbasename) continue;
 
 				if (!m_project.selections.hasSelectedVersion(basename)) {
@@ -1028,7 +1028,7 @@ class Dub {
 		PackageSupplier supplier;
 		foreach(ps; m_packageSuppliers){
 			try {
-				pinfo = ps.fetchPackageRecipe(name.main, range, (options & FetchOptions.usePrerelease) != 0);
+				pinfo = ps.fetchPackageRecipe(name.base, range, (options & FetchOptions.usePrerelease) != 0);
 				if (pinfo.type == Json.Type.null_)
 					continue;
 				supplier = ps;
@@ -1049,7 +1049,7 @@ class Dub {
 			if (existing && existing.version_ != ver)
 				logInfo("A new version for %s is available (%s -> %s). Run \"%s\" to switch.",
                     name.toString().color(Mode.bold), existing, ver,
-					text("dub upgrade ", name.main).color(Mode.bold));
+					text("dub upgrade ", name.base).color(Mode.bold));
 			return null;
 		}
 
@@ -1078,17 +1078,17 @@ class Dub {
 		{
 			import std.zip : ZipException;
 
-			auto data = supplier.fetchPackage(name.main, range, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
+			auto data = supplier.fetchPackage(name.base, range, (options & FetchOptions.usePrerelease) != 0); // Q: continue on fail?
 			if (tag !is IntegrityTag.init)
 				enforce(tag.matches(data), ("Hash of downloaded package does " ~
 					"not match integrity tag for %s@%s - This can happen if " ~
-					"the version has been re-tagged").format(name.main, range));
+					"the version has been re-tagged").format(name.base, range));
 			else
 				tag = IntegrityTag.make(data);
 			logDiagnostic("Placing to %s...", location.toString());
 
 			try {
-				return m_packageManager.store(data, location, name.main, ver);
+				return m_packageManager.store(data, location, name.base, ver);
 			} catch (ZipException e) {
 				logInfo("Failed to extract zip archive for %s@%s...", name, ver);
 				// re-throw the exception at the end of the loop
@@ -1138,9 +1138,9 @@ class Dub {
 	void remove(in PackageName name, PlacementLocation location,
 		scope size_t delegate(in Package[] packages) resolve_version)
 	{
-		enforce(name.main.toString().length);
+		enforce(name.base.toString().length);
 		enforce(!name.sub.length, "Cannot remove subpackage %s, remove %s instead"
-			.format(name, name.main));
+			.format(name, name.base));
 		if (location == PlacementLocation.local) {
 			logInfo("To remove a locally placed package, make sure you don't have any data"
 					~ "\nleft in it's directory and then simply remove the whole directory.");
@@ -1915,7 +1915,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		auto basepack = pack.basePackage;
 
 		foreach (d; pack.getAllDependenciesRange()) {
-			auto dbasename = d.name.main.toString();
+			auto dbasename = d.name.base.toString();
 
 			// detect dependencies to the root package (or sub packages thereof)
 			if (dbasename == basepack.name) {
@@ -1926,7 +1926,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 					auto desireddeppath = basepack.path;
 					desireddeppath.endsWithSlash = true;
 
-					auto altdeppath = d.name == d.name.main ? basepack.path : subpack.path;
+					auto altdeppath = d.name == d.name.base ? basepack.path : subpack.path;
 					altdeppath.endsWithSlash = true;
 
 					if (!d.spec.path.empty && absdeppath != desireddeppath)
@@ -1950,14 +1950,14 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 			Dependency dspec = d.spec.mapToPath(pack.path);
 
 			// if not upgrading, use the selected version
-			if (!(m_options & UpgradeOptions.upgrade) && m_selectedVersions.hasSelectedVersion(d.name.main))
-				dspec = m_selectedVersions.getSelectedVersion(d.name.main);
+			if (!(m_options & UpgradeOptions.upgrade) && m_selectedVersions.hasSelectedVersion(d.name.base))
+				dspec = m_selectedVersions.getSelectedVersion(d.name.base);
 
 			// keep selected optional dependencies and avoid non-selected optional-default dependencies by default
 			if (!m_selectedVersions.bare) {
-				if (dt == DependencyType.optionalDefault && !m_selectedVersions.hasSelectedVersion(d.name.main))
+				if (dt == DependencyType.optionalDefault && !m_selectedVersions.hasSelectedVersion(d.name.base))
 					dt = DependencyType.optional;
-				else if (dt == DependencyType.optional && m_selectedVersions.hasSelectedVersion(d.name.main))
+				else if (dt == DependencyType.optional && m_selectedVersions.hasSelectedVersion(d.name.base))
 					dt = DependencyType.optionalDefault;
 			}
 
@@ -1988,9 +1988,9 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 
 		// for sub packages, first try to get them from the base package
 		// FIXME: avoid this, PackageManager.getSubPackage() is costly
-		if (name.main != name) {
+		if (name.base != name) {
 			auto subname = name.sub;
-			auto basepack = getPackage(name.main, dep);
+			auto basepack = getPackage(name.base, dep);
 			if (!basepack) return null;
 			if (auto sp = m_dub.m_packageManager.getSubPackage(basepack, subname, true))
 				return sp;
@@ -1999,7 +1999,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		}
 
 		// shortcut if the referenced package is the root package
-		if (name.main.toString() == m_rootPackage.basePackage.name)
+		if (name.base.toString() == m_rootPackage.basePackage.name)
 			return m_rootPackage.basePackage;
 
 		if (!dep.repository.empty) {
@@ -2029,7 +2029,7 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 		auto prerelease = (m_options & UpgradeOptions.preRelease) != 0;
 
 		foreach (ps; m_dub.m_packageSuppliers) {
-			if (name.main == name) {
+			if (name.base == name) {
 				try {
 					auto desc = ps.fetchPackageRecipe(name, VersionRange(vers, vers), prerelease);
 					if (desc.type == Json.Type.null_)
@@ -2048,16 +2048,16 @@ private class DependencyVersionResolver : DependencyResolver!(Dependency, Depend
 				try {
 					FetchOptions fetchOpts;
 					fetchOpts |= prerelease ? FetchOptions.usePrerelease : FetchOptions.none;
-					m_dub.fetch(name.main, vers, fetchOpts, m_dub.defaultPlacementLocation, "need sub package description");
+					m_dub.fetch(name.base, vers, fetchOpts, m_dub.defaultPlacementLocation, "need sub package description");
 					auto ret = m_dub.m_packageManager.getBestPackage(name, vers);
 					if (!ret) {
-						logWarn("Package %s %s doesn't have a sub package %s", name.main, dep, name);
+						logWarn("Package %s %s doesn't have a sub package %s", name.base, dep, name);
 						return null;
 					}
 					m_remotePackages[key] = ret;
 					return ret;
 				} catch (Exception e) {
-					logDiagnostic("Package %s could not be downloaded from %s: %s", name.main, ps.description, e.msg);
+					logDiagnostic("Package %s could not be downloaded from %s: %s", name.base, ps.description, e.msg);
 					logDebug("Full error: %s", e.toString().sanitize);
 				}
 			}

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -406,7 +406,7 @@ class PackageManager {
 		if (!nameString.empty) {
 			nameToResolve = PackageName(nameString);
 			const loadedName = PackageName(pack.name);
-			enforce(loadedName == nameToResolve || loadedName == nameToResolve.main,
+			enforce(loadedName == nameToResolve || loadedName == nameToResolve.base,
 				"Package %s loaded from '%s' does not match expected name %s".format(
 					loadedName, path.toNativeString(), nameToResolve));
 		}
@@ -1353,7 +1353,7 @@ symlink_exit:
 	/// Returns null if the sub-package doesn't exist.
 	private Package addPackagesAndResolveSubPackage(ref Package[] dst_repos, Package pack,
 		in PackageName nameToResolve)
-	in(pack.name == nameToResolve.main.toString(),
+	in(pack.name == nameToResolve.base.toString(),
 		"nameToResolve must be the added package or one of its sub-packages")
 	{
 		this.addPackages(dst_repos, pack);
@@ -1784,12 +1784,12 @@ package struct Location {
 		if (!mgr.fs.existsDirectory(path))
 			return null;
 
-		logDiagnostic("Lazily loading package %s:%s from %s", name.main, vers, path);
+		logDiagnostic("Lazily loading package %s:%s from %s", name.base, vers, path);
 		auto p = mgr.load(path);
 		enforce(
 			p.version_ == vers,
 			format("Package %s located in %s has a different version than its path: Got %s, expected %s",
-				name.main, path, p.version_, vers));
+				name.base, path, p.version_, vers));
 		return mgr.addPackagesAndResolveSubPackage(this.fromPath, p, name);
 	}
 
@@ -1815,8 +1815,8 @@ package struct Location {
 	 */
 	NativePath getPackagePath (in PackageName name, string vers)
 	{
-		NativePath result = this.packagePath ~ name.main.toString() ~ vers ~
-			name.main.toString();
+		NativePath result = this.packagePath ~ name.base.toString() ~ vers ~
+			name.base.toString();
 		result.endsWithSlash = true;
 		return result;
 	}

--- a/source/dub/packagesuppliers/filesystem.d
+++ b/source/dub/packagesuppliers/filesystem.d
@@ -28,12 +28,12 @@ class FileSystemPackageSupplier : PackageSupplier {
 		import std.conv : to;
 		import dub.semver : isValidVersion;
 		Version[] ret;
-        const zipFileGlob = name.main.toString() ~ "?*.zip";
+        const zipFileGlob = name.base.toString() ~ "?*.zip";
 		foreach (DirEntry d; dirEntries(m_path.toNativeString(), zipFileGlob, SpanMode.shallow)) {
 			NativePath p = NativePath(d.name);
-			auto vers = p.head.name[name.main.toString().length+1..$-4];
+			auto vers = p.head.name[name.base.toString().length+1..$-4];
 			if (!isValidVersion(vers)) {
-				logDebug("Ignoring entry '%s' because it isn't a version of package '%s'", p, name.main);
+				logDebug("Ignoring entry '%s' because it isn't a version of package '%s'", p, name.base);
 				continue;
 			}
 			logDebug("Entry: %s", p);
@@ -48,7 +48,7 @@ class FileSystemPackageSupplier : PackageSupplier {
 		in VersionRange dep, bool pre_release)
 	{
 		import dub.internal.vibecompat.core.file : readFile, existsFile;
-		logInfo("Storing package '%s', version requirements: %s", name.main, dep);
+		logInfo("Storing package '%s', version requirements: %s", name.base, dep);
 		auto filename = bestPackageFile(name, dep, pre_release);
 		enforce(existsFile(filename));
 		return readFile(filename);
@@ -71,9 +71,9 @@ class FileSystemPackageSupplier : PackageSupplier {
 		Json json = toJson(recipe);
 		auto basename = filePath.head.name;
 		enforce(basename.endsWith(".zip"), "Malformed package filename: " ~ filePath.toNativeString);
-		enforce(basename.startsWith(name.main.toString()),
+		enforce(basename.startsWith(name.base.toString()),
 			"Malformed package filename: " ~ filePath.toNativeString);
-		json["version"] = basename[name.main.toString().length + 1 .. $-4];
+		json["version"] = basename[name.base.toString().length + 1 .. $-4];
 		return json;
 	}
 
@@ -90,10 +90,10 @@ class FileSystemPackageSupplier : PackageSupplier {
 		import std.array : array;
 		import std.format : format;
 		NativePath toPath(Version ver) {
-			return m_path ~ "%s-%s.zip".format(name.main, ver);
+			return m_path ~ "%s-%s.zip".format(name.base, ver);
 		}
 		auto versions = getVersions(name).filter!(v => dep.matches(v)).array;
-		enforce(versions.length > 0, format("No package %s found matching %s", name.main, dep));
+		enforce(versions.length > 0, format("No package %s found matching %s", name.base, dep));
 		foreach_reverse (ver; versions) {
 			if (pre_release || !ver.isPreRelease)
 				return toPath(ver);

--- a/source/dub/packagesuppliers/maven.d
+++ b/source/dub/packagesuppliers/maven.d
@@ -36,7 +36,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 	override Version[] getVersions(in PackageName name)
 	{
 		import std.algorithm.sorting : sort;
-		auto md = getMetadata(name.main);
+		auto md = getMetadata(name.base);
 		if (md.type == Json.Type.null_)
 			return null;
 		Version[] ret;
@@ -52,25 +52,25 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		in VersionRange dep, bool pre_release)
 	{
 		import std.format : format;
-		auto md = getMetadata(name.main);
-		Json best = getBestPackage(md, name.main, dep, pre_release);
+		auto md = getMetadata(name.base);
+		Json best = getBestPackage(md, name.base, dep, pre_release);
 		if (best.type == Json.Type.null_)
 			return null;
 		auto vers = best["version"].get!string;
 		auto url = m_mavenUrl ~ InetPath(
-			"%s/%s/%s-%s.zip".format(name.main, vers, name.main, vers));
+			"%s/%s/%s-%s.zip".format(name.base, vers, name.base, vers));
 
 		try {
 			return retryDownload(url, 3, httpTimeout);
 		}
 		catch(HTTPStatusException e) {
 			if (e.status == 404) throw e;
-			else logDebug("Failed to download package %s from %s", name.main, url);
+			else logDebug("Failed to download package %s from %s", name.base, url);
 		}
 		catch(Exception e) {
-			logDebug("Failed to download package %s from %s", name.main, url);
+			logDebug("Failed to download package %s from %s", name.base, url);
 		}
-		throw new Exception("Failed to download package %s from %s".format(name.main, url));
+		throw new Exception("Failed to download package %s from %s".format(name.base, url));
 	}
 
 	override Json fetchPackageRecipe(in PackageName name, in VersionRange dep,
@@ -85,29 +85,29 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		import dub.internal.undead.xml;
 
 		auto now = Clock.currTime(UTC());
-		if (auto pentry = name.main in m_metadataCache) {
+		if (auto pentry = name.base in m_metadataCache) {
 			if (pentry.cacheTime + m_maxCacheTime > now)
 				return pentry.data;
-			m_metadataCache.remove(name.main);
+			m_metadataCache.remove(name.base);
 		}
 
-		auto url = m_mavenUrl ~ InetPath(name.main.toString() ~ "/maven-metadata.xml");
+		auto url = m_mavenUrl ~ InetPath(name.base.toString() ~ "/maven-metadata.xml");
 
-		logDebug("Downloading maven metadata for %s", name.main);
+		logDebug("Downloading maven metadata for %s", name.base);
 		string xmlData;
 
 		try
 			xmlData = cast(string)retryDownload(url, 3, httpTimeout);
 		catch(HTTPStatusException e) {
 			if (e.status == 404) {
-				logDebug("Maven metadata %s not found at %s (404): %s", name.main, description, e.msg);
+				logDebug("Maven metadata %s not found at %s (404): %s", name.base, description, e.msg);
 				return Json(null);
 			}
 			else throw e;
 		}
 
 		auto json = Json([
-			"name": Json(name.main.toString()),
+			"name": Json(name.base.toString()),
 			"versions": Json.emptyArray
 		]);
 		auto xml = new DocumentParser(xmlData);
@@ -115,7 +115,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		xml.onStartTag["versions"] = (ElementParser xml) {
 			 xml.onEndTag["version"] = (in Element e) {
 				json["versions"] ~= serializeToJson([
-					"name": name.main.toString(),
+					"name": name.base.toString(),
 					"version": e.text,
 				]);
 			 };
@@ -123,7 +123,7 @@ class MavenRegistryPackageSupplier : PackageSupplier {
 		};
 		xml.parse();
 
-		m_metadataCache[name.main] = CacheEntry(json, now);
+		m_metadataCache[name.base] = CacheEntry(json, now);
 		return json;
 	}
 

--- a/source/dub/packagesuppliers/packagesupplier.d
+++ b/source/dub/packagesuppliers/packagesupplier.d
@@ -122,6 +122,6 @@ package Json getBestPackage(Json metadata, in PackageName name,
 		bestver = Version(cast(string)best["version"]);
 	}
 	enforce(best != null,
-		"No package candidate found for %s@%s".format(name.main, dep));
+		"No package candidate found for %s@%s".format(name.base, dep));
 	return best;
 }

--- a/source/dub/packagesuppliers/registry.d
+++ b/source/dub/packagesuppliers/registry.d
@@ -62,7 +62,7 @@ class RegistryPackageSupplier : PackageSupplier {
 		{
 			auto vers = best["version"].get!string;
 			ret = m_registryUrl ~ InetPath(
-				"%s/%s/%s.zip".format(PackagesPath, name.main, vers));
+				"%s/%s/%s.zip".format(PackagesPath, name.base, vers));
 		}
 		return ret;
 	}
@@ -79,12 +79,12 @@ class RegistryPackageSupplier : PackageSupplier {
 		}
 		catch(HTTPStatusException e) {
 			if (e.status == 404) throw e;
-			else logDebug("Failed to download package %s from %s", name.main, url);
+			else logDebug("Failed to download package %s from %s", name.base, url);
 		}
 		catch(Exception e) {
-			logDebug("Failed to download package %s from %s", name.main, url);
+			logDebug("Failed to download package %s from %s", name.base, url);
 		}
-		throw new Exception("Failed to download package %s from %s".format(name.main, url));
+		throw new Exception("Failed to download package %s from %s".format(name.base, url));
 	}
 
 	override Json fetchPackageRecipe(in PackageName name, in VersionRange dep,
@@ -97,19 +97,19 @@ class RegistryPackageSupplier : PackageSupplier {
 	private Json getMetadata(in PackageName name)
 	{
 		auto now = Clock.currTime(UTC());
-		if (auto pentry = name.main in m_metadataCache) {
+		if (auto pentry = name.base in m_metadataCache) {
 			if (pentry.cacheTime + m_maxCacheTime > now)
 				return pentry.data;
-			m_metadataCache.remove(name.main);
+			m_metadataCache.remove(name.base);
 		}
 
 		auto url = m_registryUrl ~ InetPath("api/packages/infos");
 
 		url.queryString = "packages=" ~
-			encodeComponent(`["` ~ name.main.toString() ~ `"]`) ~
+			encodeComponent(`["` ~ name.base.toString() ~ `"]`) ~
 			"&include_dependencies=true&minimize=true";
 
-		logDebug("Downloading metadata for %s", name.main);
+		logDebug("Downloading metadata for %s", name.base);
 		string jsonData;
 
 		jsonData = cast(string)retryDownload(url);
@@ -120,7 +120,7 @@ class RegistryPackageSupplier : PackageSupplier {
 			logDebug("adding %s to metadata cache", pkg);
 			m_metadataCache[PackageName(pkg)] = CacheEntry(info, now);
 		}
-		return json[name.main.toString()];
+		return json[name.base.toString()];
 	}
 
 	SearchResult[] searchPackages(string query) {

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -469,7 +469,7 @@ class Project {
 			pack.simpleLint();
 
 			foreach (d; pack.getAllDependencies()) {
-				auto basename = d.name.main;
+				auto basename = d.name.base;
 				d.spec.visit!(
 					(NativePath path) { /* Valid */ },
 					(Repository repo) { /* Valid */ },
@@ -530,7 +530,7 @@ class Project {
 			Dependency vspec = dep.spec;
 			Package p;
 
-			auto basename = dep.name.main;
+			auto basename = dep.name.base;
 			auto subname = dep.name.sub;
 
 			// non-optional and optional-default dependencies (if no selections file exists)
@@ -564,8 +564,8 @@ class Project {
 						return m_packageManager.getPackage(dep.name, vspec.version_);
 					},
 				);
-			} else if (m_dependencies.canFind!(d => PackageName(d.name).main == basename)) {
-				auto idx = m_dependencies.countUntil!(d => PackageName(d.name).main == basename);
+			} else if (m_dependencies.canFind!(d => PackageName(d.name).base == basename)) {
+				auto idx = m_dependencies.countUntil!(d => PackageName(d.name).base == basename);
 				auto bp = m_dependencies[idx].basePackage;
 				vspec = Dependency(bp.path);
 				p = resolveSubPackage(bp, subname, false);
@@ -1955,11 +1955,11 @@ public class SelectedVersions {
 	void selectVersion(in PackageName name, Version version_, in IntegrityTag tag = IntegrityTag.init)
 	{
 		auto dep = SelectedDependency(Dependency(version_), tag);
-		if (auto pdep = name.main.toString() in this.m_selections.versions) {
+		if (auto pdep = name.base.toString() in this.m_selections.versions) {
 			if (*pdep == dep)
 				return;
 		}
-		this.m_selections.versions[name.main.toString()] = dep;
+		this.m_selections.versions[name.base.toString()] = dep;
 		this.m_dirty = true;
 	}
 
@@ -1996,11 +1996,11 @@ public class SelectedVersions {
 	/// Internal implementation of selectVersion
 	private void selectVersionInternal(in PackageName name, in Dependency dep)
 	{
-		if (auto pdep = name.main.toString() in m_selections.versions) {
+		if (auto pdep = name.base.toString() in m_selections.versions) {
 			if (*pdep == dep)
 				return;
 		}
-		m_selections.versions[name.main.toString()] = dep;
+		m_selections.versions[name.base.toString()] = dep;
 		m_dirty = true;
 	}
 
@@ -2021,7 +2021,7 @@ public class SelectedVersions {
 	/// Ditto
 	void deselectVersion(in PackageName name)
 	{
-		m_selections.versions.remove(name.main.toString());
+		m_selections.versions.remove(name.base.toString());
 		m_dirty = true;
 	}
 
@@ -2035,7 +2035,7 @@ public class SelectedVersions {
 	/// Ditto
 	bool hasSelectedVersion(in PackageName name) const
 	{
-		return (name.main.toString() in m_selections.versions) !is null;
+		return (name.base.toString() in m_selections.versions) !is null;
 	}
 
 	/** Returns the selection for a particular package.
@@ -2056,13 +2056,13 @@ public class SelectedVersions {
 	Dependency getSelectedVersion(in PackageName name) const
 	{
 		enforce(hasSelectedVersion(name));
-		return m_selections.versions[name.main.toString()];
+		return m_selections.versions[name.base.toString()];
 	}
 
 	/// Returns: The `IntegrityTag` associated to the version, or `.init` if none
 	IntegrityTag getIntegrityTag(in PackageName name) const
 	{
-		if (auto ptr = name.main.toString() in this.m_selections.versions)
+		if (auto ptr = name.base.toString() in this.m_selections.versions)
 			return (*ptr).integrity;
 		return typeof(return).init;
 	}

--- a/source/dub/recipe/json.d
+++ b/source/dub/recipe/json.d
@@ -121,7 +121,7 @@ Json toJson(const scope ref PackageRecipe recipe)
 private void parseSubPackages(ref PackageRecipe recipe, in PackageName parent, Json[] subPackagesJson)
 {
 	enforce(!parent.sub, format("'subPackages' found in '%s'. This is only supported in the main package file for '%s'.",
-		parent, parent.main));
+		parent, parent.base));
 
 	recipe.subPackages = new SubPackage[subPackagesJson.length];
 	foreach (i, subPackageJson; subPackagesJson) {

--- a/source/dub/recipe/packagerecipe.d
+++ b/source/dub/recipe/packagerecipe.d
@@ -48,7 +48,7 @@ deprecated @safe unittest
 
 	In case of a top level package, the qualified name is returned unmodified.
 */
-deprecated("Use `dub.dependency : PackageName(arg).main` instead")
+deprecated("Use `dub.dependency : PackageName(arg).base` instead")
 string getBasePackageName(string package_name) @safe pure
 {
 	return package_name.findSplit(":")[0];


### PR DESCRIPTION
This is and has always been referred to "base package name" throughout the code base and should be named like this here, too, to avoid confusion.

Also reduces the amount of explicit attribute annotations a bit.