### PR TITLE
dub.compilers.utils: Add pkg-config C preprocessor flags support

### DIFF
--- a/test/issue782-gtkd-pkg-config.sh
+++ b/test/issue782-gtkd-pkg-config.sh
@@ -22,6 +22,25 @@ else
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:}$PWD/../fake-gtkd
     # pkg-config needs to find our .pc file which is in $PWD/../fake-gtkd/pkgconfig, so set PKG_CONFIG_PATH accordingly
     export PKG_CONFIG_PATH=$PWD/../fake-gtkd/pkgconfig
+
+    # Verify that pkg-config --cflags is being extracted properly
+    # The .pc file includes -DFAKE_GTKD_VERSION=100 which should appear as -P-DFAKE_GTKD_VERSION=100
+    VERBOSE_OUTPUT=$(${DUB} build --force --compiler=${DC} -v 2>&1)
+    if ! echo "$VERBOSE_OUTPUT" | grep -q "\-P-DFAKE_GTKD_VERSION=100"; then
+        echo "FAIL: pkg-config --cflags extraction not working: -P-DFAKE_GTKD_VERSION=100 not found in compiler flags"
+        echo "Verbose output:"
+        echo "$VERBOSE_OUTPUT"
+        exit 1
+    fi
+    echo "PASS: pkg-config --cflags extraction working (-P-DFAKE_GTKD_VERSION=100 found)"
+
+    # Also verify -P-I flag for cImportPaths is present
+    if ! echo "$VERBOSE_OUTPUT" | grep -q "\-P-I.*fake-gtkd"; then
+        echo "FAIL: pkg-config --cflags extraction not working: -P-I path not found in compiler flags"
+        exit 1
+    fi
+    echo "PASS: pkg-config --cflags include path extraction working"
+
     ${DUB} run --force --compiler=${DC}
     cd ..
     rm -rf fake-gtkd/.dub

--- a/test/issue782-gtkd-pkg-config/fake-gtkd/pkgconfig/fake-gtkd.pc
+++ b/test/issue782-gtkd-pkg-config/fake-gtkd/pkgconfig/fake-gtkd.pc
@@ -9,4 +9,6 @@ Version: 1.0.0
 # The "-L-defaultlib=libphobos2.so" and "-defaultlib=libphobos2.so" should both end up on the compiler (at link stage) invocation as "-defaultlib=libphobos2.so"
 # For this test, it doesn't hurt that they appear twice on the cmd line...
 Libs: -L-L${libdir} -L-l:libfake-gtkd.so -L-l:libdl.so.2 -pthread -L-defaultlib=libphobos2.so -defaultlib=libphobos2.so
-Cflags: -I${includedir}
+# Cflags should be extracted and passed to the C preprocessor via -P flags
+# -I goes to cImportPaths, -D goes to dflags with -P prefix
+Cflags: -I${includedir} -DFAKE_GTKD_VERSION=100


### PR DESCRIPTION
Query pkg-config for any C preprocessor flags as well (notably include paths and defines), and pass them to the D compiler so that they can be included when preprocessing C code and library headers.

----

Context:

Following a major release of one of my D projects, I got [a report](https://github.com/CyberShadow/btdu/issues/52#issuecomment-3705147880) that the program fails to build / work correctly on OpenSUSE due to mismatching ncurses bindings. This was unexpected, since I verified that the program builds on Debian and NixOS, and I've made [a pass](https://github.com/D-Programming-Deimos/ncurses/pull/45) over the D bindings in Deimos a while ago to ensure they were accurate.

As it turns out, and much to my horror, the C ncurses headers that the D bindings are based on are actually templates - the true source is in `.h.in` files, and the headers are configured by the ncurses autotools `configure` script and then rendered into C header files. I used the Debian header files when creating the D bindings, whereas I should have used the source `.h.in` files instead; SuSE's ncurses package configures the library with different options, which result in different header files, different shared library, and a different ABI, causing link failures at best and segmentation faults at worst.

So, there's two paths forward for fixing this:

1. Double down on trying to provide an accurate D bindings package for the C headers. This would mean throwing away the bundled Debian-specific header files, replacing them with the true source `.h.in` files, then either fixing the D bindings based on the diff (i.e. added `@@`-macros) or redoing them from scratch. This would also require adding a pre-build step to generate a configuration D file, which would detect the configuration that the system ncurses library/headers were built with and configure the D bindings to ensure they reflect the same ABI - similar to how the OpenSSL bindings package detects the OpenSSL version (OpenSSL's ABI is similarly unstable, except at the C header level).

2. Try this new-fangled ImportC feature, which will hopefully save us from the insanity above.

Well, not exactly. One form of insanity leaves, another enters. Now we have to actually make sure that ImportC is parsing the headers in the same way a C compiler would, which is tricky for quite a lot of reasons. However, as far as Dub's concerned, one reason I've discovered is that distros may put libraries' include files somewhere else other than `/usr/include`! Or rather, their pkg-config descriptions do.

In OpenSuSE Tumbleweed specifically, the ncurses pkg-config definition pulls in a variant of the ncurses library with wide-character support. Although this version is the default one on some distributions, such as Debian, OpenSuSE keeps the narrow version in `/usr/include` but the wide version in `/usr/include/ncursesw`. So, if you don't use pkg-config at all, you'll link to the "vanilla" version, include the headers from `/usr/include`, and get the narrow version straight and narrow; but if you do use it, your expected experience as a C developer is going to be that the better wide-character-supporting version is going to just work.

So, how is Dub affected? Well, Dub does have some pkg-config support. However, currently, it only handles the linking part! This essentially means Dub supports half of it for projects that want to use ImportC. For the ncurses / OpenSuSE case, you get the wide library but narrow headers - a split-brain situation.

How do we cure the split-brain? With DMD's `-P` switch! `-P` allows us to ask DMD to add arbitrary flags to the preprocessor command line. This is perfect for pkg-config integration: we just take the `--cflags` output, prepend a `-P`, and get (in theory) perfectly matching auto-detected preprocessor configuration to go with our auto-detected linker configuration.

To illustrate, here's the `ncursesw.pc` from OpenSuSE Tumbleweed:

```make
# pkg-config file generated by gen-pkgconfig
# vile:makemode

prefix=/usr
exec_prefix=/usr
libdir=/usr/lib64
includedir=/usr/include/ncursesw
abi_version=6
major_version=6
version=6.5.20251213

Name: ncursesw
Description: ncurses 6.5 library
Version: ${version}
URL: https://invisible-island.net/ncurses
Requires.private:
Libs:  -lncursesw -Wl,--push-state,--as-needed -ltinfo -Wl,--pop-state
Libs.private:  -lpthread -ldl
Cflags:  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I${includedir}
```

We already understand `Libs`; this adds `Cflags` to match, too.

Technically, this is a breaking change. However, 

1. ImportC is a relatively new, and still rather bleeding-edge feature;
2. User-specified flags are inserted after any pkg-config-derived flags, so the user is still in control, and even if this introduces redundancy, it should be a no-op.
