### PR TITLE
ci(workflows): update macOS runner versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         # Latest stable version, update at will
-        os: [ macos-15-intel, ubuntu-22.04, windows-2022 ]
+        # Note: macos-14 is ARM64. For Intel use macos-14-large (paid) or macos-15-intel
+        os: [ macos-14, ubuntu-22.04, windows-2022 ]
         dc:
           # Always test latest as that is what we use to compile on release
           - dmd-latest
@@ -72,14 +73,14 @@ jobs:
           - { dc: ldc-latest, do_test: true }
           - { dc: dmd-master, do_test: true }
           - { dc: ldc-master, do_test: true }
-          # Test on ARM64 (LDC only, DMD doesn't support ARM64)
-          - { os: macos-14, dc: ldc-latest, do_test: true }
         exclude:
-          # Error with those versions:
-          # ld: multiple errors: symbol count from symbol table and dynamic symbol table differ in [.../dub.o]; address=0x0 points to section(2) with no content in '[...]/osx/lib/libphobos2.a[3177](config_a68_4c3.o)'
-          - { os: macos-15-intel, dc: dmd-2.100.2 }
-          - { os: macos-15-intel, dc: dmd-2.103.1 }
-          - { os: macos-15-intel, dc: dmd-2.106.1 }
+          # TODO: DMD doesn't support ARM64 yet - remove these excludes when ARM support lands
+          - { os: macos-14, dc: dmd-latest }
+          - { os: macos-14, dc: dmd-master }
+          - { os: macos-14, dc: dmd-2.100.2 }
+          - { os: macos-14, dc: dmd-2.103.1 }
+          - { os: macos-14, dc: dmd-2.106.1 }
+          - { os: macos-14, dc: dmd-2.109.1 }
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-15-intel, ubuntu-22.04, windows-2019 ]
+        # Note: macos-14 is ARM64, but LDC cross-compiles to x86_64 via -mtriple
+        os: [ macos-14, ubuntu-22.04, windows-2019 ]
         arch: [ x86_64 ]
         include:
           - { os: windows-2019, arch: i686 }


### PR DESCRIPTION
- Update main workflow to use macos-14 instead of macOS-13
- Update release workflow to use macos-15-intel instead of macOS-13
- Normalize runner name casing to lowercase (macOS -> macos)