### PR TITLE
Fix #2598: don't propagate build commands from root buildType to deps

### DIFF
--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -987,6 +987,22 @@ class Project {
 				// unit tests aren't run anyway and the additional code may
 				// cause linking to fail on Windows (issue #640)
 				btsettings.removeOptions(BuildOption.unittests);
+
+				// don't propagate commands from the root package's buildType
+				// to dependencies - they should only run for the root package
+				// (issue #2598)
+				btsettings.preBuildCommands = null;
+				btsettings.postBuildCommands = null;
+				btsettings.preGenerateCommands = null;
+				btsettings.postGenerateCommands = null;
+				btsettings.preRunCommands = null;
+				btsettings.postRunCommands = null;
+				btsettings.preBuildEnvironments = null;
+				btsettings.postBuildEnvironments = null;
+				btsettings.preGenerateEnvironments = null;
+				btsettings.postGenerateEnvironments = null;
+				btsettings.preRunEnvironments = null;
+				btsettings.postRunEnvironments = null;
 			}
 
 			processVars(dst, this, m_rootPackage, btsettings, gsettings);

--- a/source/dub/test/others.d
+++ b/source/dub/test/others.d
@@ -120,3 +120,70 @@ unittest
     dub.loadPackage();
     assert(dub.project.hasAllDependencies());
 }
+
+// https://github.com/dlang/dub/issues/2598
+// Verify that preBuildCommands/postBuildCommands from a custom buildType
+// in the root package are NOT propagated to dependencies.
+unittest
+{
+    import dub.compilers.buildsettings : BuildSettings;
+    import dub.generators.generator : GeneratorSettings;
+
+    scope dub = new TestDub((scope Filesystem fs) {
+        fs.writeFile(TestDub.ProjectPath ~ "dub.json",
+            `{
+                "name": "a",
+                "dependencies": {"b": "~>1.0"},
+                "buildTypes": {
+                    "custom": {
+                        "preBuildCommands": ["echo root-pre"],
+                        "postBuildCommands": ["echo root-post"],
+                        "preGenerateCommands": ["echo root-pregen"],
+                        "postGenerateCommands": ["echo root-postgen"],
+                        "preRunCommands": ["echo root-prerun"],
+                        "postRunCommands": ["echo root-postrun"]
+                    }
+                }
+            }`);
+        fs.writeFile(TestDub.ProjectPath ~ "dub.selections.json",
+            `{"fileVersion":1,"versions":{"b":"1.0.0"}}`);
+        fs.writePackageFile("b", "1.0.0", `{"name":"b","version":"1.0.0"}`);
+    });
+    dub.loadPackage();
+    assert(dub.project.hasAllDependencies());
+
+    GeneratorSettings gsettings;
+    gsettings.buildType = "custom";
+
+    // For root package: commands should be present
+    BuildSettings rootSettings;
+    dub.project.addBuildTypeSettings(rootSettings, gsettings, true);
+    assert(rootSettings.preBuildCommands.length > 0,
+        "Root package should have preBuildCommands from custom buildType");
+    assert(rootSettings.postBuildCommands.length > 0,
+        "Root package should have postBuildCommands from custom buildType");
+    assert(rootSettings.preGenerateCommands.length > 0,
+        "Root package should have preGenerateCommands from custom buildType");
+    assert(rootSettings.postGenerateCommands.length > 0,
+        "Root package should have postGenerateCommands from custom buildType");
+    assert(rootSettings.preRunCommands.length > 0,
+        "Root package should have preRunCommands from custom buildType");
+    assert(rootSettings.postRunCommands.length > 0,
+        "Root package should have postRunCommands from custom buildType");
+
+    // For dependency: commands should NOT be present
+    BuildSettings depSettings;
+    dub.project.addBuildTypeSettings(depSettings, gsettings, false);
+    assert(depSettings.preBuildCommands.length == 0,
+        "Dependency should NOT have preBuildCommands from root's custom buildType");
+    assert(depSettings.postBuildCommands.length == 0,
+        "Dependency should NOT have postBuildCommands from root's custom buildType");
+    assert(depSettings.preGenerateCommands.length == 0,
+        "Dependency should NOT have preGenerateCommands from root's custom buildType");
+    assert(depSettings.postGenerateCommands.length == 0,
+        "Dependency should NOT have postGenerateCommands from root's custom buildType");
+    assert(depSettings.preRunCommands.length == 0,
+        "Dependency should NOT have preRunCommands from root's custom buildType");
+    assert(depSettings.postRunCommands.length == 0,
+        "Dependency should NOT have postRunCommands from root's custom buildType");
+}


### PR DESCRIPTION
## Summary

- Fixes #2598: `preBuildCommands`/`postBuildCommands` (and all other command hooks) defined in a custom `buildType` in the root package were incorrectly executed for every dependency during the build.
- When `addBuildTypeSettings` is called for a non-root package, command fields and their associated environments are now cleared from the buildType settings before propagation, matching the existing pattern that already strips unittest options for dependencies.
- Added a unit test that verifies commands from a custom buildType are present for the root package but absent for dependencies.

## Root cause

In `Project.addBuildTypeSettings()` (`source/dub/project.d`), the root package's buildType settings (including all command hooks) were applied to every target via `processVars()`. The `for_root_package` flag was only used to strip unittest options, but commands were never filtered.

## Test plan

- [x] New unit test in `source/dub/test/others.d` that creates a project with a custom buildType containing all 6 command types, a dependency, and verifies commands appear only for the root package
- [x] Confirmed the test fails without the fix (1/56 modules FAILED) and passes with it (56 modules passed)
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)