### PR TITLE
Fix -conf flag not being passed to linker

### DIFF
--- a/changelog/ldc-conf.dd
+++ b/changelog/ldc-conf.dd
@@ -1,0 +1,9 @@
+Fixed `--conf` options not being passed to LDC's linker step.
+
+Packages can now use `--conf` as a dflag to modify LDC's linker
+behavior for a package.
+
+Example:
+-------
+dflags "--conf=$KON_PACKAGE_DIR/55-wasm-wasi.conf" platform="wasm32"
+-------

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -360,7 +360,8 @@ config    /etc/ldc2.conf (x86_64-pc-linux-gnu)
 				    || arg.startsWith("-linker=")
 				    || arg.startsWith("-march=")
 				    || arg.startsWith("-mscrtlib=")
-				    || arg.startsWith("-mtriple=");
+				    || arg.startsWith("-mtriple=")
+				    || arg.startsWith("-conf=");
 		}
 	}
 


### PR DESCRIPTION
One of my libraries uses a custom ldc config file that overrides the original configuration of ldc, this also involves the linker step.
This PR simply makes sure the -conf option is passed along to ldc.