### PR TITLE
feat: handle sub-packages in ninja generator

### DIFF
--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -76,7 +76,14 @@ class NinjaGenerator : ProjectGenerator
             }
             f.writeln();
 
-            auto outBin = bs.targetName.length ? bs.targetName : name;
+            string[] depLibs;
+            foreach (dep; info.linkDependencies)
+            {
+                if (dep in targets)
+                    depLibs ~= libName(targets[dep].buildSettings.targetName, sanitizeName(dep));
+            }
+
+            auto outBin = bs.targetName.length ? bs.targetName : sanitizeName(name);
 
             if (bs.targetType == TargetType.staticLibrary ||
                 bs.targetType == TargetType.library)
@@ -85,7 +92,8 @@ class NinjaGenerator : ProjectGenerator
             }
             else
             {
-                f.writeln("build ", outBin, ": link ", objs.join(" "));
+                auto linkInputs = (objs ~ depLibs).join(" ");
+                f.writeln("build ", outBin, ": link ", linkInputs);
                 if (lflags.length)
                     f.writeln("  lflags = ", lflags);
                 f.writeln();
@@ -103,6 +111,12 @@ class NinjaGenerator : ProjectGenerator
             .replace(":", "_") ~ ".o";
     }
 
+    private static string libName(string targetName, string fallback)
+    {
+        auto base = targetName.length ? targetName : fallback;
+        return base ~ ".a";
+    }
+
     private static string versionFlag(string cname)
     {
         if (cname.startsWith("ldc")) return "--d-version=";
@@ -116,4 +130,9 @@ class NinjaGenerator : ProjectGenerator
         if (cname.startsWith("gdc")) return "-fdebug=";
         return "-debug=";
     }
+    private static string sanitizeName(string name)
+    {
+        return name.replace(":", "_").replace("/", "_");
+    }
+
 }

--- a/test/ninja-subpackage.sh
+++ b/test/ninja-subpackage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+. $(dirname "${BASH_SOURCE[0]}")/common.sh
+
+cd "$CURR_DIR"/ninja-subpackage
+
+if ! $DUB generate ninja --compiler=$DC 2>&1; then
+    die $LINENO 'dub generate ninja failed!'
+fi
+
+if ! grep -q "rule ar" build.ninja; then
+    die $LINENO 'build.ninja missing ar rule!'
+fi
+
+if ! grep -q "\.a" build.ninja; then
+    die $LINENO 'build.ninja missing static library build edge!'
+fi
+
+ninja -t clean
+if ! ninja 2>&1; then
+    die $LINENO 'ninja build failed!'
+fi
+
+if ! ./ninja-subpackage 2>&1; then
+    die $LINENO 'linked executable failed to run!'
+fi
+
+ninja -t clean
+rm -f build.ninja

--- a/test/ninja-subpackage/dub.json
+++ b/test/ninja-subpackage/dub.json
@@ -1,0 +1,14 @@
+{
+    "name": "ninja-subpackage",
+    "targetType": "executable",
+    "dependencies": {
+        "ninja-subpackage:mylib": "*"
+    },
+    "subPackages": [
+        {
+            "name": "mylib",
+            "targetType": "staticLibrary",
+            "sourcePaths": ["lib/source"]
+        }
+    ]
+}

--- a/test/ninja-subpackage/lib/source/lib.d
+++ b/test/ninja-subpackage/lib/source/lib.d
@@ -1,0 +1,1 @@
+extern(C) int add(int a, int b) { return a + b; }

--- a/test/ninja-subpackage/source/app.d
+++ b/test/ninja-subpackage/source/app.d
@@ -1,0 +1,2 @@
+extern(C) int add(int a, int b);
+void main() { assert(add(1, 2) == 3); }


### PR DESCRIPTION
Handles sub-packages in the ninja generator: sanitizes colon/slash
characters in target names, computes link dependencies for sub-package
.a archives, and links them into the parent executable.

Builds on the ar rule from #3132 (merged). Independent of #3130
(unmerged, not in this branch's history).

Test builds a sub-package as a static library, links it into an
executable via the ar rule, and runs the linked binary, asserting a
real computed result (add(1,2)==3) rather than just checking the
binary exists or exits 0. Verified to fail when the sub-package logic
is broken, and to pass on a fresh clone independent of local
working-tree state.