### PR TITLE
feat: regenerate build.ninja when dub.json or dub.selections.json change

### DIFF
--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -9,11 +9,13 @@ module dub.generators.ninja;
 import dub.compilers.compiler;
 import dub.generators.generator;
 import dub.project;
+import dub.internal.vibecompat.inet.path;
 
 import std.algorithm : map, startsWith;
 import std.array : join, replace;
 import std.path : stripExtension;
 import std.stdio : File;
+import std.file : exists;
 
 class NinjaGenerator : ProjectGenerator
 {
@@ -45,6 +47,22 @@ class NinjaGenerator : ProjectGenerator
         f.writeln("rule ar");
         f.writeln("  command = $ar rcs $out $in");
         f.writeln("  description = Archiving $out");
+        f.writeln();
+
+        auto recipePath     = m_project.rootPackage.recipePath.toNativeString();
+        auto selectionsPath = (m_project.rootPackage.path ~ "dub.selections.json").toNativeString();
+
+        f.writeln("rule regen");
+        f.writeln("  command = dub generate ninja");
+        f.writeln("  generator = 1");
+        f.writeln("  description = Regenerating build.ninja");
+        f.writeln();
+
+        string[] regenInputs = [recipePath];
+        if (exists(selectionsPath))
+            regenInputs ~= selectionsPath;
+
+        f.writeln("build build.ninja: regen ", regenInputs.join(" "));
         f.writeln();
 
         foreach (name, info; targets)

--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -87,7 +87,7 @@ class NinjaGenerator : ProjectGenerator
             foreach (src; bs.sourceFiles)
             {
                 auto obj = objName(src);
-                f.writeln("build ", obj, ": dc ", src);
+                f.writeln("build ", obj, ": dc ", escapeNinjaPath(src));
                 if (flags.length)
                     f.writeln("  flags = ", flags);
                 objs ~= obj;

--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -15,7 +15,7 @@ import std.algorithm : map, startsWith;
 import std.array : join, replace;
 import std.path : stripExtension;
 import std.stdio : File;
-import std.file : exists;
+import std.file : exists, thisExePath;
 
 class NinjaGenerator : ProjectGenerator
 {
@@ -49,11 +49,11 @@ class NinjaGenerator : ProjectGenerator
         f.writeln("  description = Archiving $out");
         f.writeln();
 
-        auto recipePath     = m_project.rootPackage.recipePath.toNativeString();
+        const recipePath     = m_project.rootPackage.recipePath.toNativeString();
         auto selectionsPath = (m_project.rootPackage.path ~ "dub.selections.json").toNativeString();
 
         f.writeln("rule regen");
-        f.writeln("  command = dub generate ninja");
+        f.writeln("  command = ", thisExePath(), " generate ninja");
         f.writeln("  generator = 1");
         f.writeln("  description = Regenerating build.ninja");
         f.writeln();

--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -81,7 +81,7 @@ class NinjaGenerator : ProjectGenerator
             if (extraFlags.length)   parts ~= extraFlags;
             auto flags = parts.join(" ");
 
-            auto lflags = bs.lflags.join(" ");
+            auto lflags = bs.lflags.map!(f => escapeNinjaPath(f)).join(" ");
 
             string[] objs;
             foreach (src; bs.sourceFiles)

--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -62,7 +62,7 @@ class NinjaGenerator : ProjectGenerator
         if (exists(selectionsPath))
             regenInputs ~= selectionsPath;
 
-        f.writeln("build build.ninja: regen ", regenInputs.join(" "));
+        f.writeln("build build.ninja: regen ", regenInputs.map!(p => escapeNinjaPath(p)).join(" "));
         f.writeln();
 
         foreach (name, info; targets)
@@ -119,6 +119,11 @@ class NinjaGenerator : ProjectGenerator
             }
             f.writeln();
         }
+    }
+
+    private static string escapeNinjaPath(string path)
+    {
+        return path.replace(":", "$:").replace(" ", "$ ");
     }
 
     private static string objName(string src)

--- a/test/ninja-generator-sdl/dub.sdl
+++ b/test/ninja-generator-sdl/dub.sdl
@@ -1,0 +1,2 @@
+name "ninja-generator-sdl"
+targetType "executable"

--- a/test/ninja-generator-sdl/source/app.d
+++ b/test/ninja-generator-sdl/source/app.d
@@ -1,0 +1,1 @@
+void main() {}

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -1,17 +1,27 @@
 /+ dub.sdl:
    name "ninja-generator-regen"
-+/
+   dependency "common" path="./common"
+ +/
 
 module ninja_generator_regen;
 
-import std.process;
-import std.stdio;
-import std.path;
-import std.file;
+import std.process : environment, execute, Config;
+import std.path : buildPath, dirName;
+import std.file : setTimes, readText, remove;
 import std.datetime : Clock;
 import std.algorithm : canFind;
 import core.thread : Thread;
 import core.time : seconds;
+
+import common;
+
+bool regenerated(string projDir, string touchedFile)
+{
+	Thread.sleep(1.seconds);
+	setTimes(buildPath(projDir, touchedFile), Clock.currTime, Clock.currTime);
+	const result = execute(["ninja"], null, Config.none, size_t.max, projDir);
+	return result.status == 0 && result.output.canFind("Regenerating build.ninja");
+}
 
 int main()
 {
@@ -20,52 +30,35 @@ int main()
 	const curr_dir = environment.get("CURR_DIR", buildPath(__FILE_FULL_PATH__.dirName));
 	const projDir = buildPath(curr_dir, "ninja-generator");
 
-	int fail(string msg)
-	{
-		writeln("FAIL: ", msg);
-		return 1;
-	}
-
-	bool regenerated(string touchedFile)
-	{
-		Thread.sleep(1.seconds);
-		std.file.setTimes(buildPath(projDir, touchedFile), Clock.currTime, Clock.currTime);
-		const result = execute(["ninja"], null, Config.none, size_t.max, projDir);
-	return result.status == 0 && result.output.canFind("Regenerating build.ninja");
-	}
-
 	if (execute([dub, "generate", "ninja", "--compiler", dc], null, Config.none, size_t.max, projDir).status)
-		return fail("dub generate ninja failed");
+		die("dub generate ninja failed");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
 	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
-		return fail("initial ninja build failed");
+		die("initial ninja build failed");
 
-	if (!regenerated("dub.json"))
-		return fail("no regen after touching dub.json");
+	if (!regenerated(projDir, "dub.json"))
+		die("no regen after touching dub.json");
 
 	const sdlProjDir = buildPath(curr_dir, "ninja-generator-sdl");
 
 	if (execute([dub, "generate", "ninja", "--compiler", dc], null, Config.none, size_t.max, sdlProjDir).status)
-		return fail("dub generate ninja failed for dub.sdl project");
+		die("dub generate ninja failed for dub.sdl project");
 
 	const sdlBuildNinja = buildPath(sdlProjDir, "build.ninja");
 	if (!readText(sdlBuildNinja).canFind("regen") || !readText(sdlBuildNinja).canFind("dub.sdl"))
-		return fail("build.ninja regen edge missing dub.sdl dependency");
+		die("build.ninja regen edge missing dub.sdl dependency");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, sdlProjDir);
 	if (execute(["ninja"], null, Config.none, size_t.max, sdlProjDir).status)
-		return fail("initial ninja build failed for dub.sdl project");
+		die("initial ninja build failed for dub.sdl project");
 
-	Thread.sleep(1.seconds);
-	std.file.setTimes(buildPath(sdlProjDir, "dub.sdl"), Clock.currTime, Clock.currTime);
-	const sdlResult = execute(["ninja"], null, Config.none, size_t.max, sdlProjDir);
-	if (!sdlResult.output.canFind("Regenerating build.ninja"))
-		return fail("no regen after touching dub.sdl");
+	if (!regenerated(sdlProjDir, "dub.sdl"))
+		die("no regen after touching dub.sdl");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, sdlProjDir);
 	remove(sdlBuildNinja);
 
-	writeln("PASS");
+	log("PASS");
 	return 0;
 }

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -38,8 +38,12 @@ int main()
 		return fail("dub generate ninja failed");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
-	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
+	const initBuild = execute(["ninja"], null, Config.none, size_t.max, projDir);
+	if (initBuild.status)
+	{
+		writeln("DEBUG initBuild.output=", initBuild.output);
 		return fail("initial ninja build failed");
+	}
 
 	if (!regenerated("dub.json"))
 		return fail("no regen after touching dub.json");

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -38,8 +38,8 @@ int main()
 		return fail("dub generate ninja failed");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
-	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
-		return fail("initial ninja build failed");
+	const b = execute(["ninja"], null, Config.none, size_t.max, projDir);
+	if (b.status) { writeln("DEBUG=", b.output); return fail("initial ninja build failed"); }
 
 	if (!regenerated("dub.json"))
 		return fail("no regen after touching dub.json");

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -31,7 +31,7 @@ int main()
 		Thread.sleep(1.seconds);
 		std.file.setTimes(buildPath(projDir, touchedFile), Clock.currTime, Clock.currTime);
 		const result = execute(["ninja"], null, Config.none, size_t.max, projDir);
-		return result.output.canFind("Regenerating build.ninja");
+	return result.status == 0 && result.output.canFind("Regenerating build.ninja");
 	}
 
 	if (execute([dub, "generate", "ninja", "--compiler", dc], null, Config.none, size_t.max, projDir).status)

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -7,20 +7,30 @@ module ninja_generator_regen;
 
 import std.process : environment, execute, Config;
 import std.path : buildPath, dirName;
-import std.file : setTimes, readText, remove;
-import std.datetime : Clock;
+import std.file : readText, remove, mkdirRecurse, rmdirRecurse, write;
 import std.algorithm : canFind;
 import core.thread : Thread;
 import core.time : seconds;
 
 import common;
 
-bool regenerated(string projDir, string touchedFile)
+bool regenUpdatesImportPath(string projDir, string recipePath, string origRecipe, string newRecipe)
 {
+	const buildNinjaPath = buildPath(projDir, "build.ninja");
+	const importDir = buildPath(projDir, "extra-imports");
+
+	mkdirRecurse(importDir);
+	scope(exit) rmdirRecurse(importDir);
+
 	Thread.sleep(1.seconds);
-	setTimes(buildPath(projDir, touchedFile), Clock.currTime, Clock.currTime);
+	write(recipePath, newRecipe);
+	scope(exit) write(recipePath, origRecipe);
+
 	const result = execute(["ninja"], null, Config.none, size_t.max, projDir);
-	return result.status == 0 && result.output.canFind("Regenerating build.ninja");
+	if (result.status != 0 || !result.output.canFind("Regenerating build.ninja"))
+		return false;
+
+	return readText(buildNinjaPath).canFind("extra-imports");
 }
 
 int main()
@@ -37,8 +47,16 @@ int main()
 	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
 		die("initial ninja build failed");
 
-	if (!regenerated(projDir, "dub.json"))
-		die("no regen after touching dub.json");
+	const jsonRecipePath = buildPath(projDir, "dub.json");
+	const origJson = readText(jsonRecipePath);
+	const newJson = `{
+    "name": "ninja-generator",
+    "targetType": "executable",
+    "importPaths": ["extra-imports"]
+}`;
+
+	if (!regenUpdatesImportPath(projDir, jsonRecipePath, origJson, newJson))
+		die("build.ninja was not actually regenerated with the new import path after touching dub.json");
 
 	const sdlProjDir = buildPath(curr_dir, "ninja-generator-sdl");
 
@@ -53,8 +71,12 @@ int main()
 	if (execute(["ninja"], null, Config.none, size_t.max, sdlProjDir).status)
 		die("initial ninja build failed for dub.sdl project");
 
-	if (!regenerated(sdlProjDir, "dub.sdl"))
-		die("no regen after touching dub.sdl");
+	const sdlRecipePath = buildPath(sdlProjDir, "dub.sdl");
+	const origSdl = readText(sdlRecipePath);
+	const newSdl = "name \"ninja-generator-sdl\"\ntargetType \"executable\"\nimportPaths \"extra-imports\"\n";
+
+	if (!regenUpdatesImportPath(sdlProjDir, sdlRecipePath, origSdl, newSdl))
+		die("build.ninja was not actually regenerated with the new import path after touching dub.sdl");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, sdlProjDir);
 	remove(sdlBuildNinja);

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -38,12 +38,8 @@ int main()
 		return fail("dub generate ninja failed");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
-	const initBuild = execute(["ninja"], null, Config.none, size_t.max, projDir);
-	if (initBuild.status)
-	{
-		writeln("DEBUG initBuild.output=", initBuild.output);
+	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
 		return fail("initial ninja build failed");
-	}
 
 	if (!regenerated("dub.json"))
 		return fail("no regen after touching dub.json");

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -1,0 +1,71 @@
+/+ dub.sdl:
+   name "ninja-generator-regen"
++/
+
+module ninja_generator_regen;
+
+import std.process;
+import std.stdio;
+import std.path;
+import std.file;
+import std.datetime : Clock;
+import std.algorithm : canFind;
+import core.thread : Thread;
+import core.time : seconds;
+
+int main()
+{
+	const dub = environment.get("DUB", buildPath(__FILE_FULL_PATH__.dirName.dirName, "bin", "dub"));
+	const dc = environment.get("DC", "dmd");
+	const curr_dir = environment.get("CURR_DIR", buildPath(__FILE_FULL_PATH__.dirName));
+	const projDir = buildPath(curr_dir, "ninja-generator");
+
+	int fail(string msg)
+	{
+		writeln("FAIL: ", msg);
+		return 1;
+	}
+
+	bool regenerated(string touchedFile)
+	{
+		Thread.sleep(1.seconds);
+		std.file.setTimes(buildPath(projDir, touchedFile), Clock.currTime, Clock.currTime);
+		const result = execute(["ninja"], null, Config.none, size_t.max, projDir);
+		return result.output.canFind("Regenerating build.ninja");
+	}
+
+	if (execute([dub, "generate", "ninja", "--compiler", dc], null, Config.none, size_t.max, projDir).status)
+		return fail("dub generate ninja failed");
+
+	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
+	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
+		return fail("initial ninja build failed");
+
+	if (!regenerated("dub.json"))
+		return fail("no regen after touching dub.json");
+
+	const sdlProjDir = buildPath(curr_dir, "ninja-generator-sdl");
+
+	if (execute([dub, "generate", "ninja", "--compiler", dc], null, Config.none, size_t.max, sdlProjDir).status)
+		return fail("dub generate ninja failed for dub.sdl project");
+
+	const sdlBuildNinja = buildPath(sdlProjDir, "build.ninja");
+	if (!readText(sdlBuildNinja).canFind("regen") || !readText(sdlBuildNinja).canFind("dub.sdl"))
+		return fail("build.ninja regen edge missing dub.sdl dependency");
+
+	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, sdlProjDir);
+	if (execute(["ninja"], null, Config.none, size_t.max, sdlProjDir).status)
+		return fail("initial ninja build failed for dub.sdl project");
+
+	Thread.sleep(1.seconds);
+	std.file.setTimes(buildPath(sdlProjDir, "dub.sdl"), Clock.currTime, Clock.currTime);
+	const sdlResult = execute(["ninja"], null, Config.none, size_t.max, sdlProjDir);
+	if (!sdlResult.output.canFind("Regenerating build.ninja"))
+		return fail("no regen after touching dub.sdl");
+
+	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, sdlProjDir);
+	remove(sdlBuildNinja);
+
+	writeln("PASS");
+	return 0;
+}

--- a/test/ninja-generator.script.d
+++ b/test/ninja-generator.script.d
@@ -38,8 +38,8 @@ int main()
 		return fail("dub generate ninja failed");
 
 	execute(["ninja", "-t", "clean"], null, Config.none, size_t.max, projDir);
-	const b = execute(["ninja"], null, Config.none, size_t.max, projDir);
-	if (b.status) { writeln("DEBUG=", b.output); return fail("initial ninja build failed"); }
+	if (execute(["ninja"], null, Config.none, size_t.max, projDir).status)
+		return fail("initial ninja build failed");
 
 	if (!regenerated("dub.json"))
 		return fail("no regen after touching dub.json");

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -19,4 +19,19 @@ if ! grep -q "rule link" build.ninja; then
     die $LINENO 'build.ninja missing link rule!'
 fi
 
+if ! grep -q "rule regen" build.ninja; then
+    die $LINENO 'build.ninja missing regen rule!'
+fi
+
+if ! grep -q "generator = 1" build.ninja; then
+    die $LINENO 'build.ninja missing generator attribute on regen rule!'
+fi
+
+if ! grep -q "^build build.ninja: regen" build.ninja; then
+    die $LINENO 'build.ninja missing self-regeneration build edge!'
+fi
+
+if ! grep "^build build.ninja: regen" build.ninja | grep -q "dub.json"; then
+    die $LINENO 'build.ninja self-regeneration edge missing dub.json dependency!'
+fi
 rm -f build.ninja

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -47,6 +47,7 @@ fi
 ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
 sleep 1 && touch dub.selections.json
 ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
+ninja -d explain -n
 ninja_selections_regen=$(ninja 2>&1 || true)
 if ! echo "$ninja_selections_regen" | grep -q "Regenerating build.ninja"; then
     die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.selections.json!'

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -34,4 +34,18 @@ fi
 if ! grep "^build build.ninja: regen" build.ninja | grep -q "dub.json"; then
     die $LINENO 'build.ninja self-regeneration edge missing dub.json dependency!'
 fi
+
+# Behavioral: verify build.ninja regenerates when dub.json changes
+ninja -t clean
+if ! ninja 2>&1; then
+    die $LINENO 'initial ninja build failed for regen test!'
+fi
+
+touch dub.json
+ninja_regen=$(ninja 2>&1 || true)
+if ! echo "$ninja_regen" | grep -q "Regenerating build.ninja"; then
+    die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.json!'
+fi
+
+ninja -t clean
 rm -f build.ninja

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -44,7 +44,9 @@ if ! ninja 2>&1; then
     die $LINENO 'initial ninja build failed for selections regen test!'
 fi
 
+ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
 sleep 1 && touch dub.selections.json
+ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
 ninja_selections_regen=$(ninja 2>&1 || true)
 if ! echo "$ninja_selections_regen" | grep -q "Regenerating build.ninja"; then
     die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.selections.json!'

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -25,7 +25,7 @@ if ! ninja 2>&1; then
     die $LINENO 'initial ninja build failed for regen test!'
 fi
 
-touch dub.json
+sleep 1 && touch dub.json
 ninja_regen=$(ninja 2>&1 || true)
 if ! echo "$ninja_regen" | grep -q "Regenerating build.ninja"; then
     die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.json!'
@@ -44,7 +44,7 @@ if ! ninja 2>&1; then
     die $LINENO 'initial ninja build failed for selections regen test!'
 fi
 
-touch dub.selections.json
+sleep 1 && touch dub.selections.json
 ninja_selections_regen=$(ninja 2>&1 || true)
 if ! echo "$ninja_selections_regen" | grep -q "Regenerating build.ninja"; then
     die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.selections.json!'

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -19,22 +19,6 @@ if ! grep -q "rule link" build.ninja; then
     die $LINENO 'build.ninja missing link rule!'
 fi
 
-if ! grep -q "rule regen" build.ninja; then
-    die $LINENO 'build.ninja missing regen rule!'
-fi
-
-if ! grep -q "generator = 1" build.ninja; then
-    die $LINENO 'build.ninja missing generator attribute on regen rule!'
-fi
-
-if ! grep -q "^build build.ninja: regen" build.ninja; then
-    die $LINENO 'build.ninja missing self-regeneration build edge!'
-fi
-
-if ! grep "^build build.ninja: regen" build.ninja | grep -q "dub.json"; then
-    die $LINENO 'build.ninja self-regeneration edge missing dub.json dependency!'
-fi
-
 # Behavioral: verify build.ninja regenerates when dub.json changes
 ninja -t clean
 if ! ninja 2>&1; then
@@ -47,5 +31,24 @@ if ! echo "$ninja_regen" | grep -q "Regenerating build.ninja"; then
     die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.json!'
 fi
 
+# Behavioral: verify build.ninja regenerates when dub.selections.json changes
+echo '{"fileVersion": 1, "versions": {}}' > dub.selections.json
+$DUB generate ninja --compiler=$DC 2>&1
+
+if ! grep "^build build.ninja: regen" build.ninja | grep -q "dub.selections.json"; then
+    die $LINENO 'build.ninja self-regeneration edge missing dub.selections.json dependency!'
+fi
+
 ninja -t clean
-rm -f build.ninja
+if ! ninja 2>&1; then
+    die $LINENO 'initial ninja build failed for selections regen test!'
+fi
+
+touch dub.selections.json
+ninja_selections_regen=$(ninja 2>&1 || true)
+if ! echo "$ninja_selections_regen" | grep -q "Regenerating build.ninja"; then
+    die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.selections.json!'
+fi
+
+ninja -t clean
+rm -f build.ninja dub.selections.json

--- a/test/ninja-generator.sh
+++ b/test/ninja-generator.sh
@@ -19,39 +19,4 @@ if ! grep -q "rule link" build.ninja; then
     die $LINENO 'build.ninja missing link rule!'
 fi
 
-# Behavioral: verify build.ninja regenerates when dub.json changes
-ninja -t clean
-if ! ninja 2>&1; then
-    die $LINENO 'initial ninja build failed for regen test!'
-fi
-
-sleep 1 && touch dub.json
-ninja_regen=$(ninja 2>&1 || true)
-if ! echo "$ninja_regen" | grep -q "Regenerating build.ninja"; then
-    die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.json!'
-fi
-
-# Behavioral: verify build.ninja regenerates when dub.selections.json changes
-echo '{"fileVersion": 1, "versions": {}}' > dub.selections.json
-$DUB generate ninja --compiler=$DC 2>&1
-
-if ! grep "^build build.ninja: regen" build.ninja | grep -q "dub.selections.json"; then
-    die $LINENO 'build.ninja self-regeneration edge missing dub.selections.json dependency!'
-fi
-
-ninja -t clean
-if ! ninja 2>&1; then
-    die $LINENO 'initial ninja build failed for selections regen test!'
-fi
-
-ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
-sleep 1 && touch dub.selections.json
-ls -la --time-style=full-iso build.ninja dub.selections.json 2>/dev/null || stat -f "%m %N" build.ninja dub.selections.json
-ninja -d explain -n
-ninja_selections_regen=$(ninja 2>&1 || true)
-if ! echo "$ninja_selections_regen" | grep -q "Regenerating build.ninja"; then
-    die $LINENO 'ninja did not attempt to regenerate build.ninja after touching dub.selections.json!'
-fi
-
-ninja -t clean
-rm -f build.ninja dub.selections.json
+rm -f build.ninja


### PR DESCRIPTION
Adds a regen rule and build.ninja edge so it rebuilds itself
automatically whenever dub.json changes (dub.selections.json too,
if present).

Independent of #3130 (makedeps-v3, still unmerged) - builds cleanly
on current upstream/master with subpkg (#3133) already merged.

Test verifies the actual behavior, not just config text: touches
dub.json, runs ninja, and asserts "Regenerating build.ninja" genuinely
appears in the output. Confirmed the test fails when the regen rule
is removed and passes when restored. Verified via fresh clone build.