### PR TITLE
commandline: add ninja to generate help text

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1453,6 +1453,7 @@ class GenerateCommand : PackageBuildCommand {
 			"visuald - VisualD project files",
 			"sublimetext - SublimeText project file",
 			"cmake - CMake build scripts",
+			"ninja - Ninja build files",
 			"build - Builds the package directly",
 			"",
 			"An optional package name can be given to generate a different package than the root/CWD package."


### PR DESCRIPTION
The ninja generator is registered in generator.d but was missing from the --help text and generated man page for dub generate. Follow-up to #3124-#3141.