### PR TITLE
ninja: add module doc comment

### DIFF
--- a/source/dub/generators/ninja.d
+++ b/source/dub/generators/ninja.d
@@ -1,6 +1,8 @@
 /**
     Generator for Ninja build scripts
 
+    Copyright: © 2026 Hariprakash V
+
     License: Subject to the terms of the MIT license
     Authors: Hariprakash V
 */


### PR DESCRIPTION
Adds a module-level doc comment to ninja.d, matching the existing convention in cmake.d/visuald.d/sublimetext.d.