### PR TITLE
Fix Alpine CI

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -43,4 +43,4 @@ jobs:
           -f docker/Dockerfile.alpine $(pwd)
 
     - name: Test
-      run: docker run alpine-dub-image
+      run: docker run --init alpine-dub-image

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         include:
 # Disabled as we rely on DIP1000 `foreach (scope)` which GDC < 12 doesn't support
-#          - { dc: gdc, dcpkg: gcc-gdc, dcbin: gdc  }
-          - { dc: ldc, dcpkg: ldc,     dcbin: ldc2 }
-          - { dc: dmd, dcpkg: dmd,     dcbin: dmd  }
+#         - { dc: gdc, dcpkg: gcc-gdc,           dcbin: gdc  }
+          - { dc: ldc, dcpkg: "ldc ldc-runtime", dcbin: ldc2 }
+          - { dc: dmd, dcpkg: dmd,               dcbin: dmd  }
 
     # OS doesn't matter, we just need Docker
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -20,4 +20,4 @@ ENV DC=$DCBIN
 
 # Finally, just run the test-suite
 WORKDIR /root/build/test/
-ENTRYPOINT [ "/root/build/test/run-unittest.sh" ]
+CMD [ "/root/build/test/run-unittest.sh" ]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:edge AS Builder
+FROM alpine:edge AS builder
 
 # DCPKG is the name of the package, DCBIN the name of the binary
 # We need this because of the ldc / ldc2 disparity


### PR DESCRIPTION
- Fix “WARN: StageNameCasing: Stage name 'Builder' should be lowercase”
- Fix entrypoint of container image
- Fix package installation for Alpine’s split-up of LDC