### PR TITLE
Pin commit hashes of third-party actions on GHA

### DIFF
--- a/.github/workflows/pr_info_intro.yml
+++ b/.github/workflows/pr_info_intro.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Prepare sticky comment'
-      uses: marocchino/sticky-pull-request-comment@v2.9.0
+      uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
       with:
         message: |
           Thanks for your Pull Request and making D better!

--- a/.github/workflows/pr_info_post.yml
+++ b/.github/workflows/pr_info_post.yml
@@ -46,7 +46,7 @@ jobs:
         echo "PR_ID=$PR_ID" >> $GITHUB_ENV
 
     - name: Update GitHub comment
-      uses: marocchino/sticky-pull-request-comment@v2.9.0
+      uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31
       with:
         path: ./comment.txt
         number: ${{ env.PR_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           echo "artifacts_directory=$HOME/artifacts" >> $GITHUB_OUTPUT
 
       - name: Update release artifacts
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This prevents potential supply chain attacks where an attacker swaps out the commit that a tag points to.