### PR TITLE
Fix redundant format prompt in dub init

### DIFF
--- a/changelog/init-format-prompt.dd
+++ b/changelog/init-format-prompt.dd
@@ -1,0 +1,4 @@
+Skip format selection when initializing with `--format`
+
+Interactive `dub init` no longer asks for a package recipe format when the
+format was already selected with `--format`.

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -998,7 +998,14 @@ class InitCommand : Command {
 	private{
 		string m_templateType = "minimal";
 		PackageFormat m_format = PackageFormat.json;
+		bool m_formatSpecified;
 		bool m_nonInteractive;
+	}
+
+	private void parseFormat(string, string value) @safe
+	{
+		m_format = value.to!PackageFormat;
+		m_formatSpecified = true;
 	}
 	this() @safe pure nothrow
 	{
@@ -1026,7 +1033,7 @@ class InitCommand : Command {
 			"deimos  - skeleton for C header bindings",
 			"custom  - custom project provided by dub package",
 		]);
-		args.getopt("f|format", &m_format, [
+		args.getopt("f|format", &m_format, &parseFormat, [
 			"Sets the format to use for the package description file. Possible values:",
 			"  " ~ [__traits(allMembers, PackageFormat)].map!(f => f == m_format.init.to!string ? f ~ " (default)" : f).join(", ")
 		]);
@@ -1228,7 +1235,8 @@ class InitCommand : Command {
 			if (m_nonInteractive) return;
 
 			enum free_choice = true;
-			fmt = select("a package recipe format", !free_choice, fmt.to!string, "sdl", "json").to!PackageFormat;
+			if (!m_formatSpecified)
+				fmt = select("a package recipe format", !free_choice, fmt.to!string, "sdl", "json").to!PackageFormat;
 			auto author = p.authors.join(", ");
 			while (true) {
 				// Tries getting the name until a valid one is given.

--- a/test/0-init-interactive.sh
+++ b/test/0-init-interactive.sh
@@ -10,8 +10,9 @@ function cleanup {
 function runTest {
     local inp=$1
     local comp=$2
+    shift 2
     local dub_ext=${comp##*.}
-    local outp=$(echo -e $inp | $DUB init $packname)
+    local outp=$(echo -e $inp | $DUB init "$@" $packname)
     if [ ! -e $packname/dub.$dub_ext ]; then # it failed
         cleanup
         die $LINENO "No dub.$dub_ext file has been generated for test $comp with input '$inp'. Output: $outp"
@@ -37,6 +38,9 @@ runTest '1\n\ndesc\nauthor\ngpl\ncopy\n\n' 0-init-interactive.default_name.dub.s
 runTest '2\ntest\ndesc\nauthor\ngpl\ncopy\n\n' 0-init-interactive.dub.json
 # default package format
 runTest '\ntest\ndesc\nauthor\ngpl\ncopy\n\n' 0-init-interactive.dub.json
+# explicit package format skips format selection
+runTest 'test\ndesc\nauthor\ngpl\ncopy\n\n' 0-init-interactive.dub.sdl --format=sdl
+runTest 'test\ndesc\nauthor\ngpl\ncopy\n\n' 0-init-interactive.dub.json --format=json
 # select license
 runTest '1\ntest\ndesc\nauthor\n6\n3\ncopy\n\n' 0-init-interactive.license_gpl3.dub.sdl
 # select license (with description)


### PR DESCRIPTION
Fixes #830.

Track whether `--format` was supplied and skip the duplicate format question during interactive `dub init`. Other prompts remain unchanged. Includes SDL and JSON regression cases plus a changelog entry.

Validated with LDC 1.43.0:
- interactive init suite
- 59 D unit-test modules
- `git diff --check`

Developed with OpenAI Codex; reviewed and tested by the author.
